### PR TITLE
feat: improve importer stability and manual queue prioritization

### DIFF
--- a/internal/api/arrs_handlers.go
+++ b/internal/api/arrs_handlers.go
@@ -286,26 +286,9 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 				filesToDelete = append(filesToDelete, deleted.Path)
 			}
 		}
-	case "MovieDelete", "ArtistDelete", "AuthorDelete":
-		if req.Movie.FolderPath != "" {
-			dirsToDelete = append(dirsToDelete, req.Movie.FolderPath)
-		} else if req.Artist.Path != "" {
-			dirsToDelete = append(dirsToDelete, req.Artist.Path)
-		} else if req.Author.Path != "" {
-			dirsToDelete = append(dirsToDelete, req.Author.Path)
-		}
-	case "SeriesDelete":
-		if req.Series.Path != "" {
-			dirsToDelete = append(dirsToDelete, req.Series.Path)
-		}
-	case "MovieFileDelete":
-		if req.MovieFile.Path != "" {
-			filesToDelete = append(filesToDelete, req.MovieFile.Path)
-		}
-	case "EpisodeFileDelete":
-		if req.EpisodeFile.Path != "" {
-			filesToDelete = append(filesToDelete, req.EpisodeFile.Path)
-		}
+	case "MovieDelete", "ArtistDelete", "AuthorDelete", "SeriesDelete", "MovieFileDelete", "EpisodeFileDelete", "BookFileDelete":
+		slog.InfoContext(c.Context(), "Ignoring ARR deletion webhook event", "event_type", req.EventType)
+		return c.Status(200).JSON(fiber.Map{"success": true, "message": "Ignored"})
 	default:
 		slog.DebugContext(c.Context(), "Ignoring unhandled webhook event", "event_type", req.EventType)
 		return c.Status(200).JSON(fiber.Map{"success": true, "message": "Ignored"})

--- a/internal/api/arrs_handlers_test.go
+++ b/internal/api/arrs_handlers_test.go
@@ -97,7 +97,7 @@ func TestHandleArrsWebhook_EpisodeFileDelete(t *testing.T) {
 	}
 
 	assert.Equal(t, true, result["success"])
-	assert.Equal(t, "No path to scan", result["message"])
+	assert.Equal(t, "Ignored", result["message"])
 }
 func TestHandleArrsWebhook_MovieFileDelete(t *testing.T) {
 	app := fiber.New()
@@ -137,7 +137,7 @@ func TestHandleArrsWebhook_MovieFileDelete(t *testing.T) {
 	}
 
 	assert.Equal(t, true, result["success"])
-	assert.Equal(t, "No path to scan", result["message"])
+	assert.Equal(t, "Ignored", result["message"])
 }
 
 func TestArrsWebhookRequest_Unmarshal(t *testing.T) {

--- a/internal/api/fuse_handlers.go
+++ b/internal/api/fuse_handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"os/exec"
 	"runtime"
 	"sync"
 	"time"
@@ -243,6 +244,10 @@ func (s *Server) handleStartFuseMount(c *fiber.Ctx) error {
 
 	// Ensure directory exists (skip on Windows: WinFSP requires the mount point to NOT exist)
 	if runtime.GOOS != "windows" {
+		// Attempt force unmount to prevent os.Stat (inside MkdirAll) from hanging on stale mounts
+		_ = exec.Command("fusermount", "-uz", req.Path).Run()
+		_ = exec.Command("umount", "-l", req.Path).Run()
+
 		if _, err := os.Stat(req.Path); os.IsNotExist(err) {
 			if err := os.MkdirAll(req.Path, 0755); err != nil {
 				s.fuseManager.mu.Lock()
@@ -433,6 +438,10 @@ func (s *Server) AutoStartFuse() {
 
 	// Skip on Windows: WinFSP requires the mount point to NOT exist
 	if runtime.GOOS != "windows" {
+		// Attempt force unmount to prevent os.Stat (inside MkdirAll) from hanging on stale mounts
+		_ = exec.Command("fusermount", "-uz", cfg.Fuse.MountPath).Run()
+		_ = exec.Command("umount", "-l", cfg.Fuse.MountPath).Run()
+
 		if _, err := os.Stat(cfg.Fuse.MountPath); os.IsNotExist(err) {
 			if err := os.MkdirAll(cfg.Fuse.MountPath, 0755); err != nil {
 				slog.ErrorContext(context.Background(), "Failed to create auto-mount directory", "path", cfg.Fuse.MountPath, "error", err)

--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -294,7 +294,7 @@ func (s *Server) handleRetryQueue(c *fiber.Ctx) error {
 	}
 
 	// Update status to pending for manual retry
-	err = s.queueRepo.UpdateQueueItemStatus(c.Context(), id, database.QueueStatusPending, nil)
+	err = s.importerService.ExecuteItem(c.Context(), id)
 	if err != nil {
 		return RespondInternalError(c, "Failed to retry queue item", err.Error())
 	}

--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"mime"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -417,6 +418,7 @@ func (s *Server) handleSABnzbdAddFile(c *fiber.Ctx) error {
 // handleSABnzbdAddUrl handles adding NZB from URL
 func (s *Server) handleSABnzbdAddUrl(c *fiber.Ctx) error {
 	nzbUrl := c.Query("name")
+	log.Printf("Received NZB download request for URL: %s", nzbUrl)
 
 	if nzbUrl == "" {
 		return s.writeSABnzbdErrorFiber(c, "URL parameter 'name' required")

--- a/internal/importer/postprocessor/coordinator.go
+++ b/internal/importer/postprocessor/coordinator.go
@@ -6,8 +6,6 @@ package postprocessor
 import (
 	"context"
 	"log/slog"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -93,40 +91,12 @@ func (c *Coordinator) HandleSuccess(ctx context.Context, item *database.ImportQu
 
 	// Small delay to allow FUSE mount propagation through kernel and into other containers
 	// This helps prevent race conditions where Sonarr tries to probe the file before it's visible.
-	ticker := time.NewTicker(500 * time.Millisecond)
-	refreshTicker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
-	defer refreshTicker.Stop()
-	timeout := time.After(10 * time.Second)
-
-	for {
-		select {
-		case <-ctx.Done():
-			return result, ctx.Err()
-		case <-timeout:
-			c.log.WarnContext(ctx, "Timed out waiting for file to appear on VFS mount", "path", resultingPath)
-			goto continue_processing
-		case <-refreshTicker.C:
-			// Aggressively refresh the directory
-			cfg := c.configGetter()
-			vfsName := cfg.RClone.VFSName
-			if vfsName == "" {
-				vfsName = config.MountProvider
-			}
-			parentDir := filepath.Dir(resultingPath)
-			if rcloneClient != nil {
-				if err := rcloneClient.RefreshDir(ctx, vfsName, []string{parentDir}); err != nil {
-					c.log.DebugContext(ctx, "Failed to refresh VFS directory during polling", "path", parentDir, "error", err)
-				}
-			}
-		case <-ticker.C:
-			if _, err := os.Stat(resultingPath); err == nil {
-				c.log.DebugContext(ctx, "File verified on VFS mount", "path", resultingPath)
-				goto continue_processing
-			}
-		}
+	select {
+	case <-ctx.Done():
+		return result, ctx.Err()
+	case <-time.After(1 * time.Second):
+		// Continue
 	}
-continue_processing:
 
 	// 2 & 3. Create symlinks and STRM files if configured
 	if shouldSkipPostImportLinks(item) {

--- a/internal/importer/queue/manager.go
+++ b/internal/importer/queue/manager.go
@@ -202,6 +202,49 @@ func (m *Manager) CancelProcessing(itemID int64) error {
 	return nil
 }
 
+// ExecuteItem manually triggers processing for a specific queue item, bypassing concurrency limits.
+func (m *Manager) ExecuteItem(ctx context.Context, itemID int64) error {
+	item, err := m.repository.GetQueueItem(ctx, itemID)
+	if err != nil {
+		return err
+	}
+	if item == nil {
+		return fmt.Errorf("queue item %d not found", itemID)
+	}
+
+	// Set status to processing before running
+	err = m.repository.UpdateQueueItemStatus(ctx, itemID, database.QueueStatusProcessing, nil)
+	if err != nil {
+		return err
+	}
+
+	m.log.InfoContext(ctx, "Manually triggering processing for queue item", "queue_id", itemID)
+
+	go func() {
+		// Use a separate context for the execution to avoid early termination
+		itemCtx, cancel := context.WithCancel(context.Background())
+		m.cancelMu.Lock()
+		m.cancelFuncs[item.ID] = cancel
+		m.cancelMu.Unlock()
+
+		defer func() {
+			m.cancelMu.Lock()
+			delete(m.cancelFuncs, item.ID)
+			m.cancelMu.Unlock()
+		}()
+
+		resultingPath, processingErr := m.processor.ProcessItem(itemCtx, item)
+
+		if processingErr != nil {
+			m.processor.HandleFailure(itemCtx, item, processingErr)
+		} else {
+			m.processor.HandleSuccess(itemCtx, item, resultingPath)
+		}
+	}()
+
+	return nil
+}
+
 // Resize dynamically adjusts the number of queue workers.
 // When scaling down, excess workers finish their current item before stopping.
 func (m *Manager) Resize(ctx context.Context, newCount int) error {

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -1256,6 +1256,12 @@ func (s *Service) CancelProcessing(itemID int64) error {
 	return s.queueManager.CancelProcessing(itemID)
 }
 
+// ExecuteItem manually triggers processing for a specific queue item, bypassing concurrency limits.
+func (s *Service) ExecuteItem(ctx context.Context, itemID int64) error {
+	s.ProcessItemInBackground(ctx, itemID)
+	return nil
+}
+
 // ProcessItemInBackground processes a specific queue item in the background.
 // NOTE: This intentionally runs outside the worker pool — it is used for manual retries
 // of specific items and should not compete with the normal import queue workers.


### PR DESCRIPTION
This PR introduces several stability and usability enhancements to the importer and queue system:

- **Manual Queue Prioritization:** Added a "Start Now" capability that allows manually triggered jobs to bypass worker limits and process immediately.
- **Robust FUSE Cleanup:** Enforced a more reliable cleanup process for FUSE mounts.
- **ARR Webhook Protection:** Added logic to ignore deletion webhooks from Sonarr/Radarr to prevent accidental data/mount loss during automated cleanup cycles.
- **VFS Stability:** Reverted propagation logic to a known stable version (May 15) to resolve recent intermittent issues.