### PR TITLE
feat(health): restore indexer tracking from webhook Grab and OnImport events

### DIFF
--- a/internal/api/arrs_handlers.go
+++ b/internal/api/arrs_handlers.go
@@ -60,9 +60,9 @@ type ArrsWebhookRequest struct {
 		Id int64 `json:"id"`
 	} `json:"bookFile"`
 
-	EventType string `json:"eventType"`
+	EventType    string `json:"eventType"`
 	InstanceName string `json:"instanceName,omitempty"`
-	FilePath  string `json:"filePath,omitempty"`
+	FilePath     string `json:"filePath,omitempty"`
 	// For upgrades/renames, the file path might be in other fields or need to be inferred
 	Movie struct {
 		Id         int64  `json:"id"`
@@ -85,6 +85,11 @@ type ArrsWebhookRequest struct {
 		Path      string `json:"path"`
 	} `json:"episodeFile"`
 	DeletedFiles ArrsDeletedFiles `json:"deletedFiles,omitempty"`
+	DownloadId   string           `json:"downloadId,omitempty"`
+	Release      *struct {
+		Indexer      string `json:"indexer,omitempty"`
+		ReleaseTitle string `json:"releaseTitle,omitempty"`
+	} `json:"release,omitempty"`
 }
 
 func (req ArrsWebhookRequest) ToMetadata() model.WebhookMetadata {
@@ -244,6 +249,22 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 	case "Test":
 		slog.InfoContext(c.Context(), "Received ARR test webhook")
 		return c.Status(200).JSON(fiber.Map{"success": true, "message": "Test successful"})
+	case "Grab":
+		if req.DownloadId != "" && req.Release != nil && req.Release.Indexer != "" {
+			indexerName := req.Release.Indexer
+			releaseTitle := req.Release.ReleaseTitle
+			s.importerService.StoreGrabbedIndexer(req.DownloadId, releaseTitle, indexerName)
+			slog.InfoContext(c.Context(), "Logged grabbed indexer from webhook", "download_id", req.DownloadId, "release_title", releaseTitle, "indexer", indexerName)
+			// Proactively update any existing queue item with this download ID
+			if err := s.queueRepo.UpdateQueueItemIndexerByDownloadID(c.Context(), req.DownloadId, indexerName); err != nil {
+				slog.WarnContext(c.Context(), "Failed to update indexer for existing queue item", "download_id", req.DownloadId, "indexer", indexerName, "error", err)
+			}
+			// In case the import already completed or failed (e.g. race condition), update history
+			if err := s.queueRepo.UpdateImportHistoryIndexerByDownloadID(c.Context(), req.DownloadId, indexerName); err != nil {
+				slog.DebugContext(c.Context(), "Failed to update indexer for import history (expected if not yet complete)", "download_id", req.DownloadId, "indexer", indexerName, "error", err)
+			}
+		}
+		return c.Status(200).JSON(fiber.Map{"success": true, "message": "Grab logged successfully"})
 	case "Download", "AlbumImport", "BookImport": // OnImport
 		isScanEvent = true
 		if req.EpisodeFile.Path != "" {
@@ -252,6 +273,22 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 			pathsToScan = append(pathsToScan, req.MovieFile.Path)
 		} else if req.FilePath != "" {
 			pathsToScan = append(pathsToScan, req.FilePath)
+		}
+
+		// Update indexer name in database tables if present in webhook
+		if req.DownloadId != "" && req.Release != nil && req.Release.Indexer != "" {
+			indexerName := req.Release.Indexer
+			slog.InfoContext(c.Context(), "Logged indexer from OnImport webhook", "download_id", req.DownloadId, "indexer", indexerName)
+
+			// 1. Update queue if it still exists
+			if err := s.queueRepo.UpdateQueueItemIndexerByDownloadID(c.Context(), req.DownloadId, indexerName); err != nil {
+				slog.DebugContext(c.Context(), "Failed to update indexer for queue item", "download_id", req.DownloadId, "indexer", indexerName, "error", err)
+			}
+
+			// 2. Update import history if it has already completed
+			if err := s.queueRepo.UpdateImportHistoryIndexerByDownloadID(c.Context(), req.DownloadId, indexerName); err != nil {
+				slog.DebugContext(c.Context(), "Failed to update indexer for import history", "download_id", req.DownloadId, "indexer", indexerName, "error", err)
+			}
 		}
 	case "Rename":
 		isScanEvent = true
@@ -615,9 +652,18 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 				metadataStr = &str
 			}
 
+			var indexer *string = nil
+			if req.Release != nil && req.Release.Indexer != "" {
+				indexer = &req.Release.Indexer
+			} else if req.DownloadId != "" {
+				if idxName, ok := s.importerService.GetGrabbedIndexer(req.DownloadId, ""); ok {
+					indexer = &idxName
+				}
+			}
+
 			// Add to health check (pending status) with high priority (Next) to ensure it's processed right away
 			cfg := s.configManager.GetConfigGetter()()
-			err = s.healthRepo.AddFileToHealthCheckWithMetadata(c.Context(), normalizedPath, &path, cfg.GetMaxRetries(), cfg.GetMaxRepairRetries(), sourceNzb, database.HealthPriorityNext, releaseDate, metadataStr, nil)
+			err = s.healthRepo.AddFileToHealthCheckWithMetadata(c.Context(), normalizedPath, &path, cfg.GetMaxRetries(), cfg.GetMaxRepairRetries(), sourceNzb, database.HealthPriorityNext, releaseDate, metadataStr, indexer)
 			if err != nil {
 				slog.ErrorContext(c.Context(), "Failed to add webhook file to health check", "path", normalizedPath, "error", err)
 			} else {

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -269,7 +269,7 @@ func (r *HealthRepository) GetUnhealthyFiles(ctx context.Context, limit int, str
 			&health.Priority,
 			&health.StreamingFailureCount,
 			&health.IsMasked,
-		&health.Metadata, &health.Indexer,
+			&health.Metadata, &health.Indexer,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan file health: %w", err)
@@ -836,7 +836,7 @@ func (r *HealthRepository) ListHealthItems(ctx context.Context, statusFilter *He
 			&health.SourceNzbPath, &health.ErrorDetails,
 			&health.CreatedAt, &health.UpdatedAt, &health.ScheduledCheckAt,
 			&health.LibraryPath, &health.StreamingFailureCount, &health.IsMasked,
-		&health.Metadata, &health.Indexer,
+			&health.Metadata, &health.Indexer,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan health item: %w", err)
@@ -1616,7 +1616,7 @@ func (r *HealthRepository) GetFilesWithoutLibraryPath(ctx context.Context) ([]*F
 			&health.RepairRetryCount, &health.MaxRepairRetries,
 			&health.SourceNzbPath, &health.ErrorDetails,
 			&health.CreatedAt, &health.UpdatedAt, &health.ReleaseDate, &health.Priority,
-		&health.Metadata,
+			&health.Metadata,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan file health: %w", err)
@@ -1790,7 +1790,7 @@ func (r *HealthRepository) GetFilesByPaths(ctx context.Context, filePaths []stri
 			&health.LastError, &health.RetryCount, &health.MaxRetries,
 			&health.RepairRetryCount, &health.MaxRepairRetries, &health.SourceNzbPath,
 			&health.ErrorDetails, &health.CreatedAt, &health.UpdatedAt, &health.ReleaseDate, &health.Priority,
-		&health.Metadata,
+			&health.Metadata,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan file health: %w", err)
@@ -1827,7 +1827,7 @@ func (r *HealthRepository) GetFilesForLibrarySync(ctx context.Context) ([]*FileH
 			&health.RepairRetryCount, &health.MaxRepairRetries,
 			&health.SourceNzbPath, &health.ErrorDetails,
 			&health.CreatedAt, &health.UpdatedAt, &health.ReleaseDate, &health.Priority,
-		&health.Metadata,
+			&health.Metadata,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan file health: %w", err)
@@ -1868,4 +1868,9 @@ func (r *HealthRepository) UpdateFileMetadata(ctx context.Context, id int64, met
 	`
 	_, err := r.db.ExecContext(ctx, query, metadata, id)
 	return err
+}
+
+// LogIndexerImport records a success or failure for an indexer persistently.
+func (r *HealthRepository) LogIndexerImport(ctx context.Context, indexer string, status string, errMsg string) error {
+	return logIndexerImport(ctx, r.db, indexer, status, errMsg)
 }

--- a/internal/database/indexer_repository.go
+++ b/internal/database/indexer_repository.go
@@ -25,16 +25,16 @@ type IndexerAggregatedHealth struct {
 
 // --- Consolidated Helper Functions ---
 
-func logIndexerImport(ctx context.Context, db DBQuerier, indexer string, status string, errMsg string, downloadID *string) error {
+func logIndexerImport(ctx context.Context, db DBQuerier, indexer string, status string, errMsg string) error {
 	var errDetails any = nil
 	if errMsg != "" {
 		errDetails = errMsg
 	}
 	query := `
-		INSERT INTO indexer_import_stats (indexer, status, error_message, download_id, created_at)
-		VALUES (?, ?, ?, ?, datetime('now'))
+		INSERT INTO indexer_import_stats (indexer, status, error_message, created_at)
+		VALUES (?, ?, ?, datetime('now'))
 	`
-	_, err := db.ExecContext(ctx, query, indexer, status, errDetails, downloadID)
+	_, err := db.ExecContext(ctx, query, indexer, status, errDetails)
 	return err
 }
 
@@ -100,9 +100,8 @@ func deleteIndexerStats(ctx context.Context, db DBQuerier, indexer string) (int6
 }
 
 func updateIndexerStatsByDownloadID(ctx context.Context, db DBQuerier, downloadID string, indexer string) error {
-	query := `UPDATE indexer_import_stats SET indexer = ? WHERE download_id = ? AND indexer = 'Unknown'`
-	_, err := db.ExecContext(ctx, query, indexer, downloadID)
-	return err
+	// No-op: we keep upstream schemas clean and already associate download_ids in queue/history tables
+	return nil
 }
 
 func updateImportHistoryIndexerByDownloadID(ctx context.Context, db DBQuerier, downloadID string, indexer string) error {
@@ -114,8 +113,8 @@ func updateImportHistoryIndexerByDownloadID(ctx context.Context, db DBQuerier, d
 // --- Repository Methods ---
 
 // LogIndexerImport records a success or failure for an indexer persistently.
-func (r *Repository) LogIndexerImport(ctx context.Context, indexer string, status string, errMsg string, downloadID *string) error {
-	return logIndexerImport(ctx, r.db, indexer, status, errMsg, downloadID)
+func (r *Repository) LogIndexerImport(ctx context.Context, indexer string, status string, errMsg string) error {
+	return logIndexerImport(ctx, r.db, indexer, status, errMsg)
 }
 
 // GetIndexerHealthStats aggregates all historical records to calculate success/failure rates.
@@ -136,8 +135,8 @@ func (r *Repository) DeleteIndexerStats(ctx context.Context, indexer string) (in
 // --- QueueRepository Methods ---
 
 // LogIndexerImport records a success or failure for an indexer persistently.
-func (r *QueueRepository) LogIndexerImport(ctx context.Context, indexer string, status string, errMsg string, downloadID *string) error {
-	return logIndexerImport(ctx, r.db, indexer, status, errMsg, downloadID)
+func (r *QueueRepository) LogIndexerImport(ctx context.Context, indexer string, status string, errMsg string) error {
+	return logIndexerImport(ctx, r.db, indexer, status, errMsg)
 }
 
 // GetIndexerHealthStats aggregates all historical records to calculate success/failure rates.

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -4,6 +4,8 @@ import (
 	"time"
 )
 
+const IndexerUnknown = "Unknown"
+
 // QueueStatus represents the status of a queued import
 type QueueStatus string
 
@@ -27,28 +29,28 @@ const (
 
 // ImportQueueItem represents a queued NZB file waiting for import
 type ImportQueueItem struct {
-	ID           int64         `db:"id"`
-	DownloadID   *string       `db:"download_id"` // GUID/String ID for external tracking (e.g. Sonarr/Radarr)
-	NzbPath      string        `db:"nzb_path"`
-	RelativePath *string       `db:"relative_path"`
-	StoragePath  *string       `db:"storage_path"`
-	Category     *string       `db:"category"` // SABnzbd-compatible category
-	Priority     QueuePriority `db:"priority"`
-	Status       QueueStatus   `db:"status"`
-	CreatedAt    time.Time     `db:"created_at"`
-	UpdatedAt    time.Time     `db:"updated_at"`
-	StartedAt    *time.Time    `db:"started_at"`
-	CompletedAt  *time.Time    `db:"completed_at"`
-	RetryCount   int           `db:"retry_count"`
-	MaxRetries   int           `db:"max_retries"`
-	ErrorMessage *string       `db:"error_message"`
-	BatchID      *string       `db:"batch_id"`
-	Metadata     *string       `db:"metadata"`    // JSON metadata
-	FileSize             *int64        `db:"file_size"`             // Total size in bytes calculated from segments
-	TargetPath           *string       `db:"target_path"`           // Optional forced symlink destination path
-	SkipArrNotification  bool          `db:"skip_arr_notification"`
-	SkipPostImportLinks  bool          `db:"skip_post_import_links"`
-	Indexer              *string       `db:"indexer"`
+	ID                  int64         `db:"id"`
+	DownloadID          *string       `db:"download_id"` // GUID/String ID for external tracking (e.g. Sonarr/Radarr)
+	NzbPath             string        `db:"nzb_path"`
+	RelativePath        *string       `db:"relative_path"`
+	StoragePath         *string       `db:"storage_path"`
+	Category            *string       `db:"category"` // SABnzbd-compatible category
+	Priority            QueuePriority `db:"priority"`
+	Status              QueueStatus   `db:"status"`
+	CreatedAt           time.Time     `db:"created_at"`
+	UpdatedAt           time.Time     `db:"updated_at"`
+	StartedAt           *time.Time    `db:"started_at"`
+	CompletedAt         *time.Time    `db:"completed_at"`
+	RetryCount          int           `db:"retry_count"`
+	MaxRetries          int           `db:"max_retries"`
+	ErrorMessage        *string       `db:"error_message"`
+	BatchID             *string       `db:"batch_id"`
+	Metadata            *string       `db:"metadata"`    // JSON metadata
+	FileSize            *int64        `db:"file_size"`   // Total size in bytes calculated from segments
+	TargetPath          *string       `db:"target_path"` // Optional forced symlink destination path
+	SkipArrNotification bool          `db:"skip_arr_notification"`
+	SkipPostImportLinks bool          `db:"skip_post_import_links"`
+	Indexer             *string       `db:"indexer"`
 }
 
 // BulkOperationResult represents the result of a bulk queue operation
@@ -114,9 +116,9 @@ type FileHealth struct {
 	ScheduledCheckAt *time.Time     `db:"scheduled_check_at"` // Next check time
 	Priority         HealthPriority `db:"priority"`           // Priority level for health checks
 	// Failure masking fields
-	StreamingFailureCount int  `db:"streaming_failure_count"`
-	IsMasked              bool `db:"is_masked"`
-	Indexer              *string `db:"indexer"`
+	StreamingFailureCount int     `db:"streaming_failure_count"`
+	IsMasked              bool    `db:"is_masked"`
+	Indexer               *string `db:"indexer"`
 }
 
 // User represents a user account in the system
@@ -224,5 +226,3 @@ type ProviderSpeedTestStat struct {
 	SpeedMbps  float64   `db:"speed_mbps"`
 	CreatedAt  time.Time `db:"created_at"`
 }
-
-

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -19,8 +19,8 @@ import (
 	"github.com/javi11/altmount/internal/importer"
 	"github.com/javi11/altmount/internal/metadata"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
-	"github.com/javi11/altmount/internal/utils"
 	"github.com/javi11/altmount/internal/progress"
+	"github.com/javi11/altmount/internal/utils"
 	"github.com/sourcegraph/conc/pool"
 )
 
@@ -474,6 +474,16 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 			update.Status = database.HealthStatusCorrupted
 			sideEffect = func() error {
 				slog.ErrorContext(ctx, "File permanently marked as corrupted after repair retries exhausted", "file_path", fh.FilePath)
+
+				// Log failure against the indexer if known
+				if fh.Indexer != nil && *fh.Indexer != "" && *fh.Indexer != database.IndexerUnknown {
+					errMsg := "Permanently corrupted"
+					if errorMsg != nil {
+						errMsg = *errorMsg
+					}
+					_ = hw.healthRepo.LogIndexerImport(ctx, *fh.Indexer, "failed", fmt.Sprintf("Health check permanently corrupted: %s", errMsg))
+				}
+
 				return nil
 			}
 		} else {
@@ -516,6 +526,16 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 
 			sideEffect = func() error {
 				slog.InfoContext(ctx, "Health check retries exhausted, triggering repair", "file_path", fh.FilePath)
+
+				// Log failure against the indexer if known
+				if fh.Indexer != nil && *fh.Indexer != "" && *fh.Indexer != database.IndexerUnknown {
+					errMsg := "Retries exhausted"
+					if errorMsg != nil {
+						errMsg = *errorMsg
+					}
+					_ = hw.healthRepo.LogIndexerImport(ctx, *fh.Indexer, "failed", fmt.Sprintf("Health check failed (repair triggered): %s", errMsg))
+				}
+
 				outcome, err := hw.triggerFileRepair(ctx, fh, errorMsg, event.Details)
 				applyRepairOutcome(update, outcome, err)
 				return nil

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -208,6 +208,7 @@ type Service struct {
 	// HandleFailure can clean them up without changing the ItemProcessor interface.
 	// Keys are item.ID (int64), values are []string.
 	writtenPathsCache sync.Map
+	grabbedIndexers   sync.Map
 }
 
 // NewService creates a new NZB import service with manual scanning and queue processing capabilities
@@ -337,6 +338,9 @@ func (s *Service) Start(ctx context.Context) error {
 
 	// Start background cleanup of stale failed queue items
 	go s.runFailedItemCleanup(ctx)
+
+	// Start background sweeper for grabbed indexers cache
+	go s.runGrabbedIndexerSweeper(s.ctx)
 
 	// Run one-time migration to compress legacy plain .nzb files
 	go s.runNzbCompressionMigration(s.ctx)
@@ -684,6 +688,14 @@ func (s *Service) AddToQueue(ctx context.Context, filePath string, relativePath 
 		itemPriority = *priority
 	}
 
+	// Lookup indexer from grabbedIndexers (Webhook-provided)
+	var indexerName *string = nil
+	if downloadID != nil && *downloadID != "" {
+		if name, ok := s.GetGrabbedIndexer(*downloadID, filepath.Base(filePath)); ok {
+			indexerName = &name
+		}
+	}
+
 	item := &database.ImportQueueItem{
 		DownloadID:   downloadID,
 		NzbPath:      filePath,
@@ -695,6 +707,7 @@ func (s *Service) AddToQueue(ctx context.Context, filePath string, relativePath 
 		MaxRetries:   3,
 		FileSize:     fileSize,
 		Metadata:     metadata,
+		Indexer:      indexerName,
 		CreatedAt:    time.Now(),
 	}
 
@@ -1022,6 +1035,22 @@ func (s *Service) resolveCategoryPath(category string) string {
 
 // handleProcessingSuccess handles all steps after successful NZB processing
 func (s *Service) handleProcessingSuccess(ctx context.Context, item *database.ImportQueueItem, resultingPath string) error {
+	// Log persistent indexer statistic
+	indexerName := database.IndexerUnknown
+	if item.Indexer != nil && *item.Indexer != "" {
+		indexerName = *item.Indexer
+	}
+	if (indexerName == database.IndexerUnknown || indexerName == "") && item.DownloadID != nil && *item.DownloadID != "" {
+		if latestItem, err := s.database.Repository.GetQueueItemByDownloadID(ctx, *item.DownloadID); err == nil && latestItem != nil && latestItem.Indexer != nil && *latestItem.Indexer != "" {
+			indexerName = *latestItem.Indexer
+		} else if name, ok := s.GetGrabbedIndexer(*item.DownloadID, filepath.Base(item.NzbPath)); ok {
+			indexerName = name
+		}
+	}
+	if err := s.database.Repository.LogIndexerImport(ctx, indexerName, "success", ""); err != nil {
+		s.log.WarnContext(ctx, "Failed to log indexer success statistic", "indexer", indexerName, "error", err)
+	}
+
 	// Add storage path to database
 	if err := s.database.Repository.AddStoragePath(ctx, item.ID, resultingPath); err != nil {
 		s.log.ErrorContext(ctx, "Failed to add storage path", "queue_id", item.ID, "error", err)
@@ -1128,6 +1157,25 @@ func (s *Service) cleanupWrittenPaths(ctx context.Context, itemID int64, paths [
 // handleProcessingFailure handles when processing fails
 func (s *Service) handleProcessingFailure(ctx context.Context, item *database.ImportQueueItem, processingErr error) {
 	errorMessage := processingErr.Error()
+
+	// Log persistent indexer statistic
+	indexerName := database.IndexerUnknown
+	if item.Indexer != nil && *item.Indexer != "" {
+		indexerName = *item.Indexer
+	}
+	if (indexerName == database.IndexerUnknown || indexerName == "") && item.DownloadID != nil && *item.DownloadID != "" {
+		if latestItem, err := s.database.Repository.GetQueueItemByDownloadID(ctx, *item.DownloadID); err == nil && latestItem != nil && latestItem.Indexer != nil && *latestItem.Indexer != "" {
+			indexerName = *latestItem.Indexer
+		} else if name, ok := s.GetGrabbedIndexer(*item.DownloadID, filepath.Base(item.NzbPath)); ok {
+			indexerName = name
+		}
+	}
+	// Don't log if it was just cancelled by the user
+	if !strings.Contains(errorMessage, "context canceled") && !strings.Contains(errorMessage, "processing cancelled") {
+		if err := s.database.Repository.LogIndexerImport(ctx, indexerName, "failed", errorMessage); err != nil {
+			s.log.WarnContext(ctx, "Failed to log indexer failure statistic", "indexer", indexerName, "error", err)
+		}
+	}
 
 	// Check if the error was due to cancellation
 	if strings.Contains(errorMessage, "context canceled") || strings.Contains(errorMessage, "processing cancelled") {
@@ -1503,4 +1551,93 @@ func (s *Service) RegenerateMetadata(ctx context.Context, mountRelativePath stri
 
 	s.log.InfoContext(ctx, "Successfully regenerated metadata", "path", mountRelativePath)
 	return nil
+}
+
+type grabbedIndexerInfo struct {
+	indexer   string
+	timestamp time.Time
+}
+
+// StoreGrabbedIndexer stores a downloadID to indexer mapping in-memory
+func (s *Service) StoreGrabbedIndexer(downloadID string, releaseTitle string, indexer string) {
+	info := grabbedIndexerInfo{
+		indexer:   indexer,
+		timestamp: time.Now(),
+	}
+
+	if downloadID != "" {
+		s.grabbedIndexers.Store(downloadID, info)
+	}
+	// Sanitize and use release title as an alternative fallback key
+	if releaseTitle != "" {
+		cleanTitle := strings.TrimSpace(strings.ToLower(releaseTitle))
+		cleanTitle = strings.TrimSuffix(cleanTitle, ".gz")
+		cleanTitle = strings.TrimSuffix(cleanTitle, ".nzb")
+		s.grabbedIndexers.Store(cleanTitle, info)
+	}
+}
+
+// GetGrabbedIndexer retrieves a grabbed indexer by download ID or release title
+// It only returns a match if it was stored within the last 24 hours.
+func (s *Service) GetGrabbedIndexer(downloadID string, releaseTitle string) (string, bool) {
+	now := time.Now()
+
+	check := func(key string) (string, bool) {
+		if val, ok := s.grabbedIndexers.Load(key); ok {
+			if info, isInfo := val.(grabbedIndexerInfo); isInfo {
+				if now.Sub(info.timestamp) < 24*time.Hour {
+					return info.indexer, true
+				}
+				// Cleanup expired entry
+				s.grabbedIndexers.Delete(key)
+			}
+		}
+		return "", false
+	}
+
+	if downloadID != "" {
+		if name, ok := check(downloadID); ok {
+			return name, true
+		}
+	}
+
+	if releaseTitle != "" {
+		cleanTitle := strings.TrimSpace(strings.ToLower(releaseTitle))
+		cleanTitle = strings.TrimSuffix(cleanTitle, ".gz")
+		cleanTitle = strings.TrimSuffix(cleanTitle, ".nzb")
+		if name, ok := check(cleanTitle); ok {
+			return name, true
+		}
+	}
+
+	return "", false
+}
+
+// runGrabbedIndexerSweeper runs in the background to clean up stale grabbed indexer mappings older than 24h
+func (s *Service) runGrabbedIndexerSweeper(ctx context.Context) {
+	ticker := time.NewTicker(1 * time.Hour)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.pruneGrabbedIndexers()
+		}
+	}
+}
+
+func (s *Service) pruneGrabbedIndexers() {
+	now := time.Now()
+	s.grabbedIndexers.Range(func(key, val any) bool {
+		if info, isInfo := val.(grabbedIndexerInfo); isInfo {
+			if now.Sub(info.timestamp) >= 24*time.Hour {
+				s.grabbedIndexers.Delete(key)
+			}
+		} else {
+			s.grabbedIndexers.Delete(key)
+		}
+		return true
+	})
 }


### PR DESCRIPTION
This pull request restores indexer tracking from webhook Grab and OnImport events. It logs persistent indexer failure when a file fails health checks and aligns the indexer stats query with the upstream schema. (Stacked on top of #623 dashboard overhaul).