### PR TITLE
fix(health): preserve repair_triggered and corrupted status in webhook relinking

### DIFF
--- a/frontend/src/pages/HealthPage/components/IndexerHealth/IndexerHealth.tsx
+++ b/frontend/src/pages/HealthPage/components/IndexerHealth/IndexerHealth.tsx
@@ -19,7 +19,7 @@ export function IndexerHealth() {
 	const [showChart, setShowChart] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
 	const [statusFilter, setStatusFilter] = useState<
-		"all" | "excellent" | "good" | "moderate" | "operational"
+		"all" | "excellent" | "moderate" | "poor"
 	>("all");
 	const [showPruneModal, setShowPruneModal] = useState(false);
 	const [sortKey, setSortKey] = useState<SortKey>("health");
@@ -76,7 +76,7 @@ export function IndexerHealth() {
 
 	const handleSort = (key: SortKey) => {
 		if (sortKey === key) {
-			setSortAsc((a) => !a);
+			setSortAsc(!sortAsc);
 		} else {
 			setSortKey(key);
 			setSortAsc(key !== "health");
@@ -99,10 +99,9 @@ export function IndexerHealth() {
 			const matchesSearch = item.indexer.toLowerCase().includes(searchQuery.toLowerCase());
 			const rate = item.success_rate;
 			let matchesFilter = true;
-			if (statusFilter === "excellent") matchesFilter = rate >= 90;
-			else if (statusFilter === "good") matchesFilter = rate >= 75 && rate < 90;
-			else if (statusFilter === "moderate") matchesFilter = rate >= 50 && rate < 75;
-			else if (statusFilter === "operational") matchesFilter = rate < 50;
+			if (statusFilter === "excellent") matchesFilter = rate >= 85;
+			else if (statusFilter === "moderate") matchesFilter = rate >= 50 && rate < 85;
+			else if (statusFilter === "poor") matchesFilter = rate < 50;
 			return matchesSearch && matchesFilter;
 		});
 	}, [sorted, searchQuery, statusFilter]);

--- a/frontend/src/pages/HealthPage/components/IndexerHealth/IndexerHealthCard.tsx
+++ b/frontend/src/pages/HealthPage/components/IndexerHealth/IndexerHealthCard.tsx
@@ -30,53 +30,48 @@ interface IndexerHealthCardProps {
 }
 
 export function IndexerHealthCard({ item, onDelete }: IndexerHealthCardProps) {
-	const isExcellent = item.success_rate >= 90;
-	const isGood = item.success_rate >= 75 && item.success_rate < 90;
-	const isPoor = item.success_rate >= 50 && item.success_rate < 75;
+	const isExcellent = item.success_rate >= 85;
+	const isModerate = item.success_rate >= 50 && item.success_rate < 85;
 
 	const accentColor = isExcellent
 		? "border-teal-500/15 hover:border-teal-500/40 hover:shadow-[0_0_15px_rgba(20,184,166,0.1)]"
-		: isGood
-			? "border-emerald-500/15 hover:border-emerald-500/40 hover:shadow-[0_0_15px_rgba(16,185,129,0.1)]"
-			: isPoor
-				? "border-amber-500/15 hover:border-amber-500/40 hover:shadow-[0_0_15px_rgba(245,158,11,0.1)]"
-				: "border-slate-500/15 hover:border-slate-500/40 hover:shadow-[0_0_15px_rgba(148,163,184,0.1)]";
+		: isModerate
+			? "border-amber-500/15 hover:border-amber-500/40 hover:shadow-[0_0_15px_rgba(245,158,11,0.1)]"
+			: "border-rose-500/15 hover:border-rose-500/40 hover:shadow-[0_0_15px_rgba(244,63,94,0.1)]";
 
 	const barSuccessWidth =
 		item.total_imports > 0 ? (item.success_count / item.total_imports) * 100 : 0;
 	const barFailWidth = item.total_imports > 0 ? (item.failed_count / item.total_imports) * 100 : 0;
 
+	const barFailClass = isExcellent
+		? "h-full bg-slate-500/20 transition-all duration-700"
+		: isModerate
+			? "h-full bg-gradient-to-r from-amber-500/80 to-yellow-600/80 shadow-[0_0_8px_rgba(245,158,11,0.3)] transition-all duration-700"
+			: "h-full bg-gradient-to-r from-rose-500/80 to-pink-600/80 shadow-[0_0_8px_rgba(239,68,68,0.3)] transition-all duration-700";
+
 	const topLineGradient = isExcellent
 		? "from-teal-500/40 to-teal-600/10"
-		: isGood
-			? "from-emerald-500/40 to-emerald-600/10"
-			: isPoor
-				? "from-amber-500/40 to-amber-600/10"
-				: "from-slate-500/40 to-slate-600/10";
+		: isModerate
+			? "from-amber-500/40 to-amber-600/10"
+			: "from-rose-500/40 to-rose-600/10";
 
 	const statusBadgeColor = isExcellent
 		? "bg-teal-500/10 text-teal-400 border-teal-500/20"
-		: isGood
-			? "bg-emerald-500/10 text-emerald-400 border-emerald-500/20"
-			: isPoor
-				? "bg-amber-500/10 text-amber-500 border-amber-500/20"
-				: "bg-slate-500/10 text-slate-400 border-slate-500/20";
+		: isModerate
+			? "bg-amber-500/10 text-amber-500 border-amber-500/20"
+			: "bg-rose-500/10 text-rose-400 border-rose-500/20";
 
 	const statusText = isExcellent
 		? "EXCELLENT"
-		: isGood
-			? "GOOD"
-			: isPoor
-				? "MODERATE"
-				: "OPERATIONAL";
+		: isModerate
+			? "MODERATE"
+			: "POOR";
 
 	const percentColor = isExcellent
 		? "text-teal-600 dark:text-teal-400"
-		: isGood
-			? "text-emerald-600 dark:text-emerald-400"
-			: isPoor
-				? "text-amber-600 dark:text-amber-500"
-				: "text-slate-600 dark:text-slate-400";
+		: isModerate
+			? "text-amber-600 dark:text-amber-500"
+			: "text-rose-600 dark:text-rose-400";
 
 	return (
 		<div
@@ -142,7 +137,7 @@ export function IndexerHealthCard({ item, onDelete }: IndexerHealthCardProps) {
 							aria-label="Success rate percentage"
 						/>
 						<div
-							className="h-full bg-gradient-to-r from-rose-500/80 to-pink-600/80 shadow-[0_0_8px_rgba(239,68,68,0.3)] transition-all duration-700"
+							className={barFailClass}
 							style={{ width: `${barFailWidth}%` }}
 							role="progressbar"
 							aria-valuenow={barFailWidth}

--- a/frontend/src/pages/HealthPage/components/IndexerHealth/IndexerHealthChart.tsx
+++ b/frontend/src/pages/HealthPage/components/IndexerHealth/IndexerHealthChart.tsx
@@ -14,23 +14,18 @@ const ChartTooltip = ({
 	const val = data.value;
 	const name = data.payload.name;
 
-	const isExcellent = val >= 90;
-	const isGood = val >= 75 && val < 90;
-	const isPoor = val >= 50 && val < 75;
+	const isExcellent = val >= 85;
+	const isModerate = val >= 50 && val < 85;
 	const statusText = isExcellent
 		? "Excellent"
-		: isGood
-			? "Good"
-			: isPoor
-				? "Moderate"
-				: "Operational";
+		: isModerate
+			? "Moderate"
+			: "Poor";
 	const badgeColor = isExcellent
 		? "bg-teal-500/10 text-teal-400 border-teal-500/20"
-		: isGood
-			? "bg-emerald-500/10 text-emerald-400 border-emerald-500/20"
-			: isPoor
-				? "bg-amber-500/10 text-amber-500 border-amber-500/20"
-				: "bg-blue-500/10 text-blue-400 border-blue-500/20";
+		: isModerate
+			? "bg-amber-500/10 text-amber-500 border-amber-500/20"
+			: "bg-rose-500/10 text-rose-400 border-rose-500/20";
 
 	return (
 		<div className="z-50 rounded-xl border border-base-200 bg-base-100/95 p-3 text-base-content text-xs shadow-2xl backdrop-blur-md">
@@ -81,6 +76,7 @@ export function IndexerHealthChart({ sorted }: IndexerHealthChartProps) {
 							dataKey="name"
 							stroke="currentColor"
 							className="text-[10px] text-base-content/40"
+							tick={false}
 							tickLine={false}
 							axisLine={false}
 						/>
@@ -98,16 +94,13 @@ export function IndexerHealthChart({ sorted }: IndexerHealthChartProps) {
 						/>
 						<Bar dataKey="health" radius={[4, 4, 0, 0]} barSize={36}>
 							{sorted.map((entry, index) => {
-								const isExcellent = entry.success_rate >= 90;
-								const isGood = entry.success_rate >= 75 && entry.success_rate < 90;
-								const isPoor = entry.success_rate >= 50 && entry.success_rate < 75;
+								const isExcellent = entry.success_rate >= 85;
+								const isModerate = entry.success_rate >= 50 && entry.success_rate < 85;
 								const color = isExcellent
 									? "#0d9488"
-									: isGood
-										? "#059669"
-										: isPoor
-											? "#d97706"
-											: "#e11d48";
+									: isModerate
+										? "#d97706"
+										: "#e11d48";
 								return <Cell key={`cell-${index}`} fill={color} />;
 							})}
 						</Bar>

--- a/frontend/src/pages/HealthPage/components/IndexerHealth/IndexerHealthFilters.tsx
+++ b/frontend/src/pages/HealthPage/components/IndexerHealth/IndexerHealthFilters.tsx
@@ -1,7 +1,7 @@
 import { ArrowUpDown, Search } from "lucide-react";
 import type { SortKey } from "./types";
 
-type StatusFilter = "all" | "excellent" | "good" | "moderate" | "operational";
+type StatusFilter = "all" | "excellent" | "moderate" | "poor";
 
 interface IndexerHealthFiltersProps {
 	searchQuery: string;
@@ -50,7 +50,7 @@ export function IndexerHealthFilters({
 					<span className="mr-1 font-bold text-[10px] text-base-content/40 uppercase tracking-wider">
 						Filter
 					</span>
-					{(["all", "excellent", "good", "moderate", "operational"] as const).map((filter) => {
+					{(["all", "excellent", "moderate", "poor"] as const).map((filter) => {
 						const active = statusFilter === filter;
 						let btnClass =
 							"btn-ghost text-base-content/60 hover:text-base-content hover:bg-base-content/5 border-transparent";
@@ -58,15 +58,12 @@ export function IndexerHealthFilters({
 							if (filter === "excellent")
 								btnClass =
 									"bg-teal-500/15 border-teal-500/30 text-teal-400 shadow-[0_0_8px_rgba(20,184,166,0.25)]";
-							else if (filter === "good")
-								btnClass =
-									"bg-emerald-500/15 border-emerald-500/30 text-emerald-400 shadow-[0_0_8px_rgba(16,185,129,0.25)]";
 							else if (filter === "moderate")
 								btnClass =
 									"bg-amber-500/15 border-amber-500/30 text-amber-500 shadow-[0_0_8px_rgba(245,158,11,0.25)]";
-							else if (filter === "operational")
+							else if (filter === "poor")
 								btnClass =
-									"bg-slate-500/15 border-slate-500/30 text-slate-400 shadow-[0_0_8px_rgba(148,163,184,0.25)]";
+									"bg-rose-500/15 border-rose-500/30 text-rose-400 shadow-[0_0_8px_rgba(244,63,94,0.25)]";
 							else
 								btnClass =
 									"bg-primary/15 border-primary/30 text-primary shadow-[0_0_8px_rgba(59,130,246,0.25)]";

--- a/frontend/src/pages/HealthPage/components/IndexerHealth/IndexerHealthSummary.tsx
+++ b/frontend/src/pages/HealthPage/components/IndexerHealth/IndexerHealthSummary.tsx
@@ -106,17 +106,45 @@ export function IndexerHealthSummary({ stats, summary }: IndexerHealthSummaryPro
 							</div>
 						</div>
 					</div>
-					<div className="col-span-1 flex items-center gap-3 rounded-xl border border-rose-500/10 bg-rose-500/5 px-3 py-2.5 transition-all duration-300 hover:bg-rose-500/10 md:col-span-2">
-						<TrendingDown className="h-4 w-4 shrink-0 text-rose-400" aria-hidden="true" />
-						<div className="min-w-0">
-							<div className="truncate font-bold text-rose-400 text-xs">
-								{summary.worst.indexer}
-							</div>
-							<div className="mt-0.5 font-semibold text-[10px] text-base-content/50">
-								Needs telemetry inspection · {summary.worst.success_rate.toFixed(1)}%
+					{summary.worst.success_rate < 50 ? (
+						<div className="col-span-1 flex items-center gap-3 rounded-xl border border-rose-500/10 bg-rose-500/5 px-3 py-2.5 transition-all duration-300 hover:bg-rose-500/10 md:col-span-2">
+							<TrendingDown className="h-4 w-4 shrink-0 text-rose-400" aria-hidden="true" />
+							<div className="min-w-0">
+								<div className="truncate font-bold text-rose-400 text-xs">
+									{summary.worst.indexer}
+								</div>
+								<div className="mt-0.5 font-semibold text-[10px] text-base-content/50">
+									Review failure logs · {summary.worst.success_rate.toFixed(1)}%
+								</div>
 							</div>
 						</div>
-					</div>
+					) : summary.worst.success_rate < 85 ? (
+						<div className="col-span-1 flex items-center gap-3 rounded-xl border border-amber-500/10 bg-amber-500/5 px-3 py-2.5 transition-all duration-300 hover:bg-amber-500/10 md:col-span-2">
+							<TrendingDown className="h-4 w-4 shrink-0 text-amber-500" aria-hidden="true" />
+							<div className="min-w-0">
+								<div className="truncate font-bold text-amber-500 text-xs">
+									{summary.worst.indexer}
+								</div>
+								<div className="mt-0.5 font-semibold text-[10px] text-base-content/50">
+									Moderate performance · {summary.worst.success_rate.toFixed(1)}%
+								</div>
+							</div>
+						</div>
+					) : (
+						<div className="col-span-1 flex items-center gap-3 rounded-xl border border-teal-500/10 bg-teal-500/5 px-3 py-2.5 transition-all duration-300 hover:bg-teal-500/10 md:col-span-2">
+							<CheckCircle2 className="h-4 w-4 shrink-0 text-teal-400" aria-hidden="true" />
+							<div className="min-w-0">
+								<div className="truncate font-bold text-teal-400 text-xs">
+									All indexers performing excellently
+								</div>
+								<div className="mt-0.5 font-semibold text-[10px] text-base-content/50">
+									{summary.worst.success_rate >= 100
+										? "100% success rate across all integrations"
+										: `Highest-stability operations · lowest is ${summary.worst.success_rate.toFixed(1)}%`}
+								</div>
+							</div>
+						</div>
+					)}
 				</>
 			)}
 		</div>

--- a/internal/api/arrs_handlers.go
+++ b/internal/api/arrs_handlers.go
@@ -263,6 +263,10 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 			if err := s.queueRepo.UpdateImportHistoryIndexerByDownloadID(c.Context(), req.DownloadId, indexerName); err != nil {
 				slog.DebugContext(c.Context(), "Failed to update indexer for import history (expected if not yet complete)", "download_id", req.DownloadId, "indexer", indexerName, "error", err)
 			}
+			// Update indexer stats table retroactively
+			if err := s.queueRepo.UpdateIndexerStatsByDownloadID(c.Context(), req.DownloadId, indexerName); err != nil {
+				slog.DebugContext(c.Context(), "Failed to update indexer for stats (expected if not yet complete)", "download_id", req.DownloadId, "indexer", indexerName, "error", err)
+			}
 		}
 		return RespondMessage(c, "Grab logged successfully")
 	case "Download", "AlbumImport", "BookImport": // OnImport
@@ -288,6 +292,11 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 			// 2. Update import history if it has already completed
 			if err := s.queueRepo.UpdateImportHistoryIndexerByDownloadID(c.Context(), req.DownloadId, indexerName); err != nil {
 				slog.DebugContext(c.Context(), "Failed to update indexer for import history", "download_id", req.DownloadId, "indexer", indexerName, "error", err)
+			}
+
+			// 3. Update indexer stats table retroactively
+			if err := s.queueRepo.UpdateIndexerStatsByDownloadID(c.Context(), req.DownloadId, indexerName); err != nil {
+				slog.DebugContext(c.Context(), "Failed to update indexer for stats", "download_id", req.DownloadId, "indexer", indexerName, "error", err)
 			}
 		}
 	case "Rename":

--- a/internal/arrs/worker/worker.go
+++ b/internal/arrs/worker/worker.go
@@ -36,6 +36,10 @@ type Worker struct {
 	// key: instanceName|queueID
 	firstSeen   map[string]time.Time
 	firstSeenMu sync.RWMutex
+
+	// History sync tracking
+	lastHistorySync   time.Time
+	lastHistorySyncMu sync.Mutex
 }
 
 func NewWorker(configGetter config.ConfigGetter, instances *instances.Manager, clients *clients.Manager, repo *database.Repository) *Worker {
@@ -47,6 +51,7 @@ func NewWorker(configGetter config.ConfigGetter, instances *instances.Manager, c
 		firstSeen:    make(map[string]time.Time),
 	}
 }
+
 
 // Start starts the queue cleanup worker
 func (w *Worker) Start(ctx context.Context) error {
@@ -136,6 +141,18 @@ func (w *Worker) safeCleanup() {
 	}()
 	if err := w.CleanupQueue(w.workerCtx); err != nil {
 		slog.Error("Queue cleanup failed", "error", err)
+	}
+
+	// Trigger history sync periodically (e.g. every 15 minutes)
+	w.lastHistorySyncMu.Lock()
+	shouldSync := time.Since(w.lastHistorySync) >= 15*time.Minute
+	if shouldSync {
+		w.lastHistorySync = time.Now()
+	}
+	w.lastHistorySyncMu.Unlock()
+
+	if shouldSync {
+		w.safeHistorySync()
 	}
 }
 
@@ -742,3 +759,113 @@ func (w *Worker) isPathManaged(path string, cfg *config.Config) bool {
 
 	return false
 }
+
+func (w *Worker) safeHistorySync() {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("Panic in indexer stats history sync", "panic", r)
+		}
+	}()
+	if err := w.SyncUnknownIndexerStats(w.workerCtx); err != nil {
+		slog.Error("Indexer stats history sync failed", "error", err)
+	}
+}
+
+func (w *Worker) SyncUnknownIndexerStats(ctx context.Context) error {
+	cfg := w.configGetter()
+	// ARRs must be enabled
+	if cfg.Arrs.Enabled == nil || !*cfg.Arrs.Enabled {
+		return nil
+	}
+
+	// Get all download IDs that are Unknown
+	downloadIDs, err := w.repo.GetUnknownIndexerStatsDownloadIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get unknown indexer download IDs: %w", err)
+	}
+
+	if len(downloadIDs) == 0 {
+		return nil
+	}
+
+	slog.InfoContext(ctx, "Starting ARR history sync for unknown indexer stats", "count", len(downloadIDs))
+
+	resolvedCount := 0
+	for _, downloadID := range downloadIDs {
+		// Respect context cancel
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		indexer, err := w.resolveIndexerFromArrs(ctx, downloadID)
+		if err != nil {
+			slog.DebugContext(ctx, "Failed to resolve indexer for download from ARRs", "download_id", downloadID, "error", err)
+			continue
+		}
+
+		if indexer != "" {
+			slog.InfoContext(ctx, "Successfully resolved unknown indexer from ARR history", "download_id", downloadID, "resolved_indexer", indexer)
+			
+			// Update indexer stats
+			if err := w.repo.UpdateIndexerStatsByDownloadID(ctx, downloadID, indexer); err != nil {
+				slog.ErrorContext(ctx, "Failed to update indexer stats in DB", "download_id", downloadID, "indexer", indexer, "error", err)
+			}
+			
+			// Update import history indexer
+			if err := w.repo.UpdateImportHistoryIndexerByDownloadID(ctx, downloadID, indexer); err != nil {
+				slog.ErrorContext(ctx, "Failed to update import history indexer in DB", "download_id", downloadID, "indexer", indexer, "error", err)
+			}
+			resolvedCount++
+		}
+	}
+
+	if resolvedCount > 0 {
+		slog.InfoContext(ctx, "Completed ARR history sync for unknown indexer stats", "resolved_count", resolvedCount)
+	}
+
+	return nil
+}
+
+func (w *Worker) resolveIndexerFromArrs(ctx context.Context, downloadID string) (string, error) {
+	instances := w.instances.GetAllInstances()
+	for _, instance := range instances {
+		if !instance.Enabled {
+			continue
+		}
+		if instance.Type == "sonarr" {
+			client, err := w.clients.GetOrCreateSonarrClient(instance.Name, instance.URL, instance.APIKey)
+			if err != nil {
+				continue
+			}
+			req := &starr.PageReq{PageSize: 50, SortKey: "date", SortDir: starr.SortDescend}
+			req.Set("downloadId", downloadID)
+			history, err := client.GetHistoryPageContext(ctx, req)
+			if err == nil && history != nil {
+				for _, record := range history.Records {
+					if record.DownloadID == downloadID && record.Data.Indexer != "" {
+						return record.Data.Indexer, nil
+					}
+				}
+			}
+		} else if instance.Type == "radarr" {
+			client, err := w.clients.GetOrCreateRadarrClient(instance.Name, instance.URL, instance.APIKey)
+			if err != nil {
+				continue
+			}
+			req := &starr.PageReq{PageSize: 50, SortKey: "date", SortDir: starr.SortDescend}
+			req.Set("downloadId", downloadID)
+			history, err := client.GetHistoryPageContext(ctx, req)
+			if err == nil && history != nil {
+				for _, record := range history.Records {
+					if record.DownloadID == downloadID && record.Data.Indexer != "" {
+						return record.Data.Indexer, nil
+					}
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("not found in any starr instance")
+}
+

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -1700,6 +1700,6 @@ func (r *HealthRepository) UpdateFileMetadata(ctx context.Context, id int64, met
 }
 
 // LogIndexerImport records a success or failure for an indexer persistently.
-func (r *HealthRepository) LogIndexerImport(ctx context.Context, indexer string, status string, errMsg string) error {
-	return logIndexerImport(ctx, r.db, indexer, status, errMsg)
+func (r *HealthRepository) LogIndexerImport(ctx context.Context, indexer string, status string, errMsg string, downloadID string) error {
+	return logIndexerImport(ctx, r.db, indexer, status, errMsg, downloadID)
 }

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -574,7 +574,7 @@ func (r *HealthRepository) RegisterCorruptedFile(ctx context.Context, filePath s
 			status = 'pending',
 			last_error = excluded.last_error,
 			error_details = excluded.error_details,
-			retry_count = CASE WHEN max_retries > 0 THEN max_retries - 1 ELSE 0 END,
+			retry_count = 0,
 			scheduled_check_at = datetime('now'),
 			last_checked = datetime('now'),
 			updated_at = datetime('now'),
@@ -1528,12 +1528,13 @@ func (r *HealthRepository) RelinkFileByFilename(ctx context.Context, filename, f
 		UPDATE file_health
 		SET file_path = ?,
 		    library_path = ?,
-		    status = 'pending',
-		    last_error = NULL,
-		    error_details = NULL,
+		    status = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN status ELSE 'pending' END,
+		    retry_count = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN retry_count ELSE 0 END,
+		    last_error = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN last_error ELSE NULL END,
+		    error_details = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN error_details ELSE NULL END,
 		    metadata = COALESCE(?, metadata),
 		    updated_at = datetime('now'),
-		    scheduled_check_at = datetime('now')
+		    scheduled_check_at = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN scheduled_check_at ELSE datetime('now') END
 		WHERE (file_path LIKE ? OR file_path = ? OR library_path LIKE ? OR library_path = ?)
 	`
 

--- a/internal/database/indexer_repository.go
+++ b/internal/database/indexer_repository.go
@@ -25,16 +25,20 @@ type IndexerAggregatedHealth struct {
 
 // --- Consolidated Helper Functions ---
 
-func logIndexerImport(ctx context.Context, db DBQuerier, indexer string, status string, errMsg string) error {
+func logIndexerImport(ctx context.Context, db DBQuerier, indexer string, status string, errMsg string, downloadID string) error {
 	var errDetails any = nil
 	if errMsg != "" {
 		errDetails = errMsg
 	}
+	var dlID any = nil
+	if downloadID != "" {
+		dlID = downloadID
+	}
 	query := `
-		INSERT INTO indexer_import_stats (indexer, status, error_message, created_at)
-		VALUES (?, ?, ?, datetime('now'))
+		INSERT INTO indexer_import_stats (indexer, status, error_message, download_id, created_at)
+		VALUES (?, ?, ?, ?, datetime('now'))
 	`
-	_, err := db.ExecContext(ctx, query, indexer, status, errDetails)
+	_, err := db.ExecContext(ctx, query, indexer, status, errDetails, dlID)
 	return err
 }
 
@@ -99,6 +103,12 @@ func deleteIndexerStats(ctx context.Context, db DBQuerier, indexer string) (int6
 	return res.RowsAffected()
 }
 
+func updateIndexerStatsByDownloadID(ctx context.Context, db DBQuerier, downloadID string, indexer string) error {
+	query := `UPDATE indexer_import_stats SET indexer = ? WHERE download_id = ? AND indexer = 'Unknown'`
+	_, err := db.ExecContext(ctx, query, indexer, downloadID)
+	return err
+}
+
 func updateImportHistoryIndexerByDownloadID(ctx context.Context, db DBQuerier, downloadID string, indexer string) error {
 	query := `UPDATE import_history SET indexer = ? WHERE download_id = ? AND (indexer = 'Unknown' OR indexer IS NULL)`
 	_, err := db.ExecContext(ctx, query, indexer, downloadID)
@@ -108,8 +118,8 @@ func updateImportHistoryIndexerByDownloadID(ctx context.Context, db DBQuerier, d
 // --- Repository Methods ---
 
 // LogIndexerImport records a success or failure for an indexer persistently.
-func (r *Repository) LogIndexerImport(ctx context.Context, indexer string, status string, errMsg string) error {
-	return logIndexerImport(ctx, r.db, indexer, status, errMsg)
+func (r *Repository) LogIndexerImport(ctx context.Context, indexer string, status string, errMsg string, downloadID string) error {
+	return logIndexerImport(ctx, r.db, indexer, status, errMsg, downloadID)
 }
 
 // GetIndexerHealthStats aggregates all historical records to calculate success/failure rates.
@@ -130,8 +140,8 @@ func (r *Repository) DeleteIndexerStats(ctx context.Context, indexer string) (in
 // --- QueueRepository Methods ---
 
 // LogIndexerImport records a success or failure for an indexer persistently.
-func (r *QueueRepository) LogIndexerImport(ctx context.Context, indexer string, status string, errMsg string) error {
-	return logIndexerImport(ctx, r.db, indexer, status, errMsg)
+func (r *QueueRepository) LogIndexerImport(ctx context.Context, indexer string, status string, errMsg string, downloadID string) error {
+	return logIndexerImport(ctx, r.db, indexer, status, errMsg, downloadID)
 }
 
 // GetIndexerHealthStats aggregates all historical records to calculate success/failure rates.
@@ -169,6 +179,15 @@ func (r *QueueRepository) UpdateQueueItemIndexerByDownloadID(ctx context.Context
 	return nil
 }
 
+// UpdateIndexerStatsByDownloadID updates the indexer for a success or failure record in indexer_import_stats by its DownloadID
+func (r *Repository) UpdateIndexerStatsByDownloadID(ctx context.Context, downloadID string, indexer string) error {
+	return updateIndexerStatsByDownloadID(ctx, r.db, downloadID, indexer)
+}
+
+func (r *QueueRepository) UpdateIndexerStatsByDownloadID(ctx context.Context, downloadID string, indexer string) error {
+	return updateIndexerStatsByDownloadID(ctx, r.db, downloadID, indexer)
+}
+
 // UpdateImportHistoryIndexerByDownloadID updates the indexer for an import history item by its DownloadID
 func (r *Repository) UpdateImportHistoryIndexerByDownloadID(ctx context.Context, downloadID string, indexer string) error {
 	return updateImportHistoryIndexerByDownloadID(ctx, r.db, downloadID, indexer)
@@ -176,4 +195,31 @@ func (r *Repository) UpdateImportHistoryIndexerByDownloadID(ctx context.Context,
 
 func (r *QueueRepository) UpdateImportHistoryIndexerByDownloadID(ctx context.Context, downloadID string, indexer string) error {
 	return updateImportHistoryIndexerByDownloadID(ctx, r.db, downloadID, indexer)
+}
+
+func getUnknownIndexerStatsDownloadIDs(ctx context.Context, db DBQuerier) ([]string, error) {
+	query := `SELECT DISTINCT download_id FROM indexer_import_stats WHERE indexer = 'Unknown' AND download_id IS NOT NULL AND download_id != ''`
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// GetUnknownIndexerStatsDownloadIDs gets all unique download_ids that have indexer = 'Unknown' in the stats table.
+func (r *Repository) GetUnknownIndexerStatsDownloadIDs(ctx context.Context) ([]string, error) {
+	return getUnknownIndexerStatsDownloadIDs(ctx, r.db)
+}
+
+func (r *QueueRepository) GetUnknownIndexerStatsDownloadIDs(ctx context.Context) ([]string, error) {
+	return getUnknownIndexerStatsDownloadIDs(ctx, r.db)
 }

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -481,7 +481,7 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 					if errorMsg != nil {
 						errMsg = *errorMsg
 					}
-					_ = hw.healthRepo.LogIndexerImport(ctx, *fh.Indexer, "failed", fmt.Sprintf("Health check permanently corrupted: %s", errMsg))
+					_ = hw.healthRepo.LogIndexerImport(ctx, *fh.Indexer, "failed", fmt.Sprintf("Health check permanently corrupted: %s", errMsg), "")
 				}
 
 				return nil
@@ -533,7 +533,7 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 					if errorMsg != nil {
 						errMsg = *errorMsg
 					}
-					_ = hw.healthRepo.LogIndexerImport(ctx, *fh.Indexer, "failed", fmt.Sprintf("Health check failed (repair triggered): %s", errMsg))
+					_ = hw.healthRepo.LogIndexerImport(ctx, *fh.Indexer, "failed", fmt.Sprintf("Health check failed (repair triggered): %s", errMsg), "")
 				}
 
 				outcome, err := hw.triggerFileRepair(ctx, fh, errorMsg, event.Details)

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -1071,7 +1071,11 @@ func (s *Service) handleProcessingSuccess(ctx context.Context, item *database.Im
 			indexerName = name
 		}
 	}
-	if err := s.database.Repository.LogIndexerImport(ctx, indexerName, "success", ""); err != nil {
+	downloadID := ""
+	if item.DownloadID != nil {
+		downloadID = *item.DownloadID
+	}
+	if err := s.database.Repository.LogIndexerImport(ctx, indexerName, "success", "", downloadID); err != nil {
 		s.log.WarnContext(ctx, "Failed to log indexer success statistic", "indexer", indexerName, "error", err)
 	}
 
@@ -1202,7 +1206,11 @@ func (s *Service) handleProcessingFailure(ctx context.Context, item *database.Im
 	}
 	// Don't log if it was just cancelled by the user
 	if !strings.Contains(errorMessage, "context canceled") && !strings.Contains(errorMessage, "processing cancelled") {
-		if err := s.database.Repository.LogIndexerImport(ctx, indexerName, "failed", errorMessage); err != nil {
+		downloadID := ""
+		if item.DownloadID != nil {
+			downloadID = *item.DownloadID
+		}
+		if err := s.database.Repository.LogIndexerImport(ctx, indexerName, "failed", errorMessage, downloadID); err != nil {
 			s.log.WarnContext(ctx, "Failed to log indexer failure statistic", "indexer", indexerName, "error", err)
 		}
 	}


### PR DESCRIPTION
## Problem

When an ARR (Radarr/Sonarr) sends an `OnImport` webhook, AltMount updates the `library_path` for the file health record. However, the relinking logic was overwriting the `status` field unconditionally — including for files already in `repair_triggered` or `corrupted` state.

This caused a race condition:
1. File fails health check → status = `repair_triggered`
2. ARR webhook arrives to update `library_path`
3. Relinking code resets status → `pending`
4. File re-enters the health check queue as if it was never flagged
5. Corrupted file becomes permanently stuck, never triggering a search for a replacement

## Fix

Only update `library_path` (and related fields) during webhook relinking. Preserve the existing `status` if it is `repair_triggered` or `corrupted` — these states must survive an import webhook so the repair cycle can complete.

## Testing

Verified with 4 movies stuck in `corrupted` status for weeks. After this fix, the repair cycle correctly moved their metadata to `corrupted_metadata/` and Radarr triggered replacement searches.