### PR TITLE
fix(speedtest): match provider by name to avoid non-deterministic selection

### DIFF
--- a/internal/api/provider_speedtest_handler.go
+++ b/internal/api/provider_speedtest_handler.go
@@ -55,6 +55,15 @@ func (s *Server) handleTestProviderSpeed(c *fiber.Ctx) error {
 	testCtx, cancel := context.WithTimeout(c.Context(), 5*time.Minute)
 	defer cancel()
 
+	// Build the nntppool provider name the same way the production pool
+	// and coordinator do, so we can match the right per-provider stats
+	// entry in the result.
+	host := fmt.Sprintf("%s:%d", targetProvider.Host, targetProvider.Port)
+	providerName := host
+	if targetProvider.Username != "" {
+		providerName = host + "+" + targetProvider.Username
+	}
+
 	// Prefer the production pool when this provider is already part of
 	// it; otherwise fall back to the singleton coordinator so we never
 	// create a fresh nntppool.Client per request.
@@ -68,9 +77,12 @@ func (s *Server) handleTestProviderSpeed(c *fiber.Ctx) error {
 	// any concurrent stream or other provider's traffic during the test
 	// window inflates it. result.Providers carries the delta-based,
 	// per-provider speed for exactly the provider we targeted.
+	//
+	// Match by name to avoid picking a random provider when the result
+	// slice contains multiple entries (map iteration order is undefined).
 	wireBps := result.WireSpeedBps
 	for _, ps := range result.Providers {
-		if ps.AvgSpeed > 0 {
+		if ps.Name == providerName && ps.AvgSpeed > 0 {
 			wireBps = ps.AvgSpeed
 			break
 		}
@@ -154,7 +166,9 @@ func (s *Server) runProviderSpeedTest(ctx context.Context, p *config.ProviderCon
 		}
 	})
 	v, err := s.speedtest.run(ctx, p, func(client *nntppool.Client, providerName string) (any, error) {
-		return client.SpeedTest(ctx, nntppool.SpeedTestOptions{ProviderName: providerName})
+		return client.SpeedTest(ctx, nntppool.SpeedTestOptions{
+			ProviderName: providerName,
+		})
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

The speed test handler extracted provider-specific speed by taking the first provider entry with an average speed greater than zero from the results map. Because Go's map iteration order is randomized, this meant that in multi-provider environments, the speed test returned the performance of a random active provider instead of the one specifically targeted.

## Fixes

1. **Deterministic Provider Matching**: We now build the unique target provider name (e.g., `host:port+user`) and check for an exact match inside the speed test results list.

*Note: This PR retains testing against the full NZB to ensure maximum accuracy.*