### PR TITLE
feat(frontend): persist queue page sorting preference

### DIFF
--- a/frontend/src/pages/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage.tsx
@@ -75,9 +75,16 @@ export function QueuePage() {
 	const [searchTerm, setSearchTerm] = useState("");
 	const [selectedItems, setSelectedItems] = useState<Set<number>>(new Set());
 	const [sortBy, setSortBy] = useState<"created_at" | "updated_at" | "status" | "nzb_path">(
-		"created_at",
+		() => {
+			const saved = localStorage.getItem("queue_sort_by");
+			const validColumns = ["created_at", "updated_at", "status", "nzb_path"];
+			return (validColumns.includes(saved || "") ? saved : "created_at") as "created_at" | "updated_at" | "status" | "nzb_path";
+		},
 	);
-	const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
+	const [sortOrder, setSortOrder] = useState<"asc" | "desc">(() => {
+		const saved = localStorage.getItem("queue_sort_order");
+		return (saved === "asc" || saved === "desc" ? saved : "desc");
+	});
 
 	const queryClient = useQueryClient();
 
@@ -381,18 +388,24 @@ export function QueuePage() {
 	}, []);
 
 	const handleSort = (column: "created_at" | "updated_at" | "status" | "nzb_path") => {
+		let newOrder: "asc" | "desc";
+		let newBy = sortBy;
 		if (sortBy === column) {
-			setSortOrder(sortOrder === "asc" ? "desc" : "asc");
+			newOrder = sortOrder === "asc" ? "desc" : "asc";
 		} else {
-			setSortBy(column);
+			newBy = column;
 			if (column === "created_at") {
-				setSortOrder("asc");
+				newOrder = "desc";
 			} else if (column === "updated_at") {
-				setSortOrder("desc");
+				newOrder = "desc";
 			} else {
-				setSortOrder("asc");
+				newOrder = "asc";
 			}
 		}
+		setSortBy(newBy);
+		setSortOrder(newOrder);
+		localStorage.setItem("queue_sort_by", newBy);
+		localStorage.setItem("queue_sort_order", newOrder);
 		setPage(0);
 		clearSelection();
 	};


### PR DESCRIPTION
Saves the column-based sorting selections (column and direction) on the Queue Page in local storage. This ensures the dashboard layout remains consistent and personalized across browser reloads.