### PR TITLE
feat(rclone): resolve startup mount timeouts via polling and request context propagation

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	_ "net/http/pprof"
@@ -289,8 +290,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// Start mount service after HTTP server is running
 	// This ensures the WebDAV server is ready to accept connections
 	go func() {
-		// Wait for HTTP server to be fully ready
-		time.Sleep(2 * time.Second)
+		// Wait for HTTP server to be fully ready by polling the liveness endpoint
+		if err := waitForHTTPServer(ctx, cfg.WebDAV.Port); err != nil {
+			logger.WarnContext(ctx, "HTTP server did not become ready, starting mount service anyway", "err", err)
+		} else {
+			logger.InfoContext(ctx, "HTTP server is ready, starting mount service")
+		}
 
 		if err := startMountService(ctx, cfg, mountService, logger); err != nil {
 			logger.WarnContext(ctx, "Mount service failed to start", "err", err)
@@ -399,3 +404,38 @@ func setupSPARoutes(app *fiber.App) {
 		return
 	}
 }
+
+func waitForHTTPServer(ctx context.Context, port int) error {
+	client := &http.Client{
+		Timeout: 500 * time.Millisecond,
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/live", port)
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	// Wait up to 30 seconds
+	timeout := time.After(30 * time.Second)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timeout:
+			return fmt.Errorf("timeout waiting for HTTP server on port %d to start", port)
+		case <-ticker.C:
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			if err != nil {
+				continue
+			}
+			resp, err := client.Do(req)
+			if err == nil {
+				resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					return nil
+				}
+			}
+		}
+	}
+}
+

--- a/pkg/rclonecli/client.go
+++ b/pkg/rclonecli/client.go
@@ -33,7 +33,7 @@ func (m *Manager) mountWithRetry(ctx context.Context, provider, mountPath, webda
 						"mountPoint": mountPath,
 					},
 				}
-				if _, err := m.makeRequest(req, true); err != nil {
+				if _, err := m.makeRequestWithContext(ctx, req, true); err != nil {
 					m.logger.DebugContext(ctx, "RC unmount before retry failed (may be expected)", "err", err, "provider", provider)
 				}
 			}
@@ -95,7 +95,7 @@ func (m *Manager) performMount(ctx context.Context, provider, mountPath, webdavU
 	}
 
 	// Create rclone config for this provider
-	if err := m.createConfig(provider, webdavURL, cfg.WebDAV.User, cfg.WebDAV.Password); err != nil {
+	if err := m.createConfig(ctx, provider, webdavURL, cfg.WebDAV.User, cfg.WebDAV.Password); err != nil {
 		return fmt.Errorf("failed to create rclone config: %w", err)
 	}
 
@@ -189,7 +189,7 @@ func (m *Manager) performMount(ctx context.Context, provider, mountPath, webdavU
 		Args:    mountArgs,
 	}
 
-	_, err := m.makeRequest(req, true)
+	_, err := m.makeRequestWithContext(ctx, req, true)
 	if err != nil {
 		// Clean up mount point on failure
 		m.forceUnmountPath(mountPath)
@@ -241,7 +241,7 @@ func (m *Manager) unmount(ctx context.Context, provider string) error {
 
 	var rcErr error
 	if m.IsReady() {
-		_, rcErr = m.makeRequest(req, true)
+		_, rcErr = m.makeRequestWithContext(ctx, req, true)
 	}
 
 	// If RC unmount fails or server is not ready, try force unmount
@@ -354,7 +354,7 @@ func (m *Manager) RefreshDir(ctx context.Context, provider string, dirs []string
 			Command: "vfs/forget",
 			Args:    forgetArgs,
 		}
-		_, err := m.makeRequest(req, true)
+		_, err := m.makeRequestWithContext(ctx, req, true)
 		if err != nil {
 			m.logger.ErrorContext(ctx, "Failed to forget directory", "err", err, "provider", provider, "dir", dir)
 			return fmt.Errorf("failed to forget directory %s for provider %s: %w", dir, provider, err)
@@ -376,7 +376,7 @@ func (m *Manager) RefreshDir(ctx context.Context, provider string, dirs []string
 			Command: "vfs/refresh",
 			Args:    refreshArgs,
 		}
-		_, err := m.makeRequest(req, true)
+		_, err := m.makeRequestWithContext(ctx, req, true)
 		if err != nil {
 			m.logger.ErrorContext(ctx, "Failed to refresh directory", "err", err, "provider", provider, "dir", dir)
 			return fmt.Errorf("failed to refresh directory %s for provider %s: %w", dir, provider, err)
@@ -386,7 +386,7 @@ func (m *Manager) RefreshDir(ctx context.Context, provider string, dirs []string
 }
 
 // createConfig creates an rclone config entry for the provider
-func (m *Manager) createConfig(configName, webdavURL string, user, pass string) error {
+func (m *Manager) createConfig(ctx context.Context, configName, webdavURL string, user, pass string) error {
 	req := RCRequest{
 		Command: "config/create",
 		Args: map[string]any{
@@ -402,7 +402,7 @@ func (m *Manager) createConfig(configName, webdavURL string, user, pass string) 
 		},
 	}
 
-	_, err := m.makeRequest(req, true)
+	_, err := m.makeRequestWithContext(ctx, req, true)
 	if err != nil {
 		return fmt.Errorf("failed to create config %s: %w", configName, err)
 	}

--- a/pkg/rclonecli/manager.go
+++ b/pkg/rclonecli/manager.go
@@ -80,7 +80,7 @@ func NewManager(cfm *config.Manager) *Manager {
 		logger:      logger,
 		ctx:         ctx,
 		cancel:      cancel,
-		httpClient:    httpclient.NewDefault(),
+		httpClient:    httpclient.New(httpclient.WithTimeout(0)),
 		serverReady:   make(chan struct{}),
 		processExited: make(chan struct{}),
 	}
@@ -368,14 +368,23 @@ func (m *Manager) pingServer() bool {
 	return err == nil
 }
 
-func (m *Manager) makeRequest(req RCRequest, close bool) (*http.Response, error) {
+func (m *Manager) makeRequestWithContext(ctx context.Context, req RCRequest, close bool) (*http.Response, error) {
 	reqBody, err := json.Marshal(req.Args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
+	var reqCtx context.Context
+	var cancel context.CancelFunc
+	if close {
+		reqCtx, cancel = context.WithTimeout(ctx, 2*time.Minute)
+		defer cancel()
+	} else {
+		reqCtx = ctx
+	}
+
 	url := fmt.Sprintf("http://localhost:%s/%s", m.rcPort, req.Command)
-	httpReq, err := http.NewRequestWithContext(m.ctx, "POST", url, bytes.NewBuffer(reqBody))
+	httpReq, err := http.NewRequestWithContext(reqCtx, "POST", url, bytes.NewBuffer(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -410,6 +419,10 @@ func (m *Manager) makeRequest(req RCRequest, close bool) (*http.Response, error)
 	}
 
 	return resp, nil
+}
+
+func (m *Manager) makeRequest(req RCRequest, close bool) (*http.Response, error) {
+	return m.makeRequestWithContext(m.ctx, req, close)
 }
 
 // IsReady returns true if the RC server is ready


### PR DESCRIPTION
Resolves AltMount startup hangs and crashes when rclone mounts take time to initialize. Implements robust polling, retry intervals, and proper context propagation so the server can safely await mount availability without failing startup.