### PR TITLE
feat(arrs): metadata deduplication, query optimization, and fallback blocklisting

### DIFF
--- a/internal/api/arrs_handlers_test.go
+++ b/internal/api/arrs_handlers_test.go
@@ -209,3 +209,40 @@ func TestArrsWebhookRequest_Unmarshal(t *testing.T) {
 		assert.Equal(t, "/path/to/movie/folder", req.Movie.FolderPath)
 	})
 }
+
+func TestHandleArrsWebhook_WithInstanceName(t *testing.T) {
+	app := fiber.New()
+
+	keyOverride := "12345678901234567890123456789012"
+	cfg := &config.Config{
+		API: config.APIConfig{
+			KeyOverride: keyOverride,
+		},
+	}
+
+	server := &Server{
+		configManager: &mockConfigManager{cfg: cfg},
+		arrsService:   &arrs.Service{}, // non-nil, empty s.data which validates the safe-check path
+	}
+
+	app.Post("/api/arrs/webhook", server.handleArrsWebhook)
+
+	payload := map[string]any{
+		"eventType":    "Test",
+		"instanceName": "Radarr-Test-Instance",
+	}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest("POST", "/api/arrs/webhook?apikey="+keyOverride, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]any
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	assert.NoError(t, err)
+	assert.Equal(t, true, result["success"])
+}
+

--- a/internal/arrs/data/manager_test.go
+++ b/internal/arrs/data/manager_test.go
@@ -1,0 +1,39 @@
+package data
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr/radarr"
+	"golift.io/starr/sonarr"
+)
+
+func TestManager_ClearCaches(t *testing.T) {
+	m := NewManager()
+
+	// Populate caches
+	m.movieCache["radarr1"] = []*radarr.Movie{{ID: 1}}
+	m.seriesCache["sonarr1"] = []*sonarr.Series{{ID: 2}}
+	m.episodeFilesCache["sonarr_episode_files_sonarr1_10"] = []*sonarr.EpisodeFile{{ID: 3}}
+	
+	m.cacheExpiry["radarr1"] = time.Now().Add(10 * time.Minute)
+	m.cacheExpiry["sonarr1"] = time.Now().Add(10 * time.Minute)
+	m.cacheExpiry["sonarr_episode_files_sonarr1_10"] = time.Now().Add(10 * time.Minute)
+
+	// Clear movies cache
+	m.ClearMoviesCache("radarr1")
+	assert.NotContains(t, m.movieCache, "radarr1")
+	assert.NotContains(t, m.cacheExpiry, "radarr1")
+
+	// Series and episode files should still be there
+	assert.Contains(t, m.seriesCache, "sonarr1")
+	assert.Contains(t, m.episodeFilesCache, "sonarr_episode_files_sonarr1_10")
+
+	// Clear series cache
+	m.ClearSeriesCache("sonarr1")
+	assert.NotContains(t, m.seriesCache, "sonarr1")
+	assert.NotContains(t, m.cacheExpiry, "sonarr1")
+	assert.NotContains(t, m.episodeFilesCache, "sonarr_episode_files_sonarr1_10")
+	assert.NotContains(t, m.cacheExpiry, "sonarr_episode_files_sonarr1_10")
+}

--- a/internal/arrs/model/metadata.go
+++ b/internal/arrs/model/metadata.go
@@ -44,6 +44,10 @@ type BookFileMetadata struct {
 	Id int64 `json:"id,omitempty"`
 }
 
+type EpisodeMetadata struct {
+	Id int64 `json:"id,omitempty"`
+}
+
 type WebhookMetadata struct {
 	EventType    string               `json:"eventType,omitempty"`
 	InstanceName string               `json:"instanceName,omitempty"`
@@ -51,6 +55,7 @@ type WebhookMetadata struct {
 	MovieFile    *MovieFileMetadata   `json:"movieFile,omitempty"`
 	Series       *SeriesMetadata      `json:"series,omitempty"`
 	EpisodeFile  *EpisodeFileMetadata `json:"episodeFile,omitempty"`
+	Episodes     []EpisodeMetadata    `json:"episodes,omitempty"`
 	Artist       *ArtistMetadata      `json:"artist,omitempty"`
 	Album        *AlbumMetadata       `json:"album,omitempty"`
 	TrackFile    *TrackFileMetadata   `json:"trackFile,omitempty"`
@@ -58,3 +63,4 @@ type WebhookMetadata struct {
 	Book         *BookMetadata        `json:"book,omitempty"`
 	BookFile     *BookFileMetadata    `json:"bookFile,omitempty"`
 }
+

--- a/internal/arrs/model/types.go
+++ b/internal/arrs/model/types.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	ErrPathMatchFailed         = fmt.Errorf("path match failed")
-	ErrEpisodeAlreadySatisfied = fmt.Errorf("episode already satisfied by another file")
+	ErrEpisodeAlreadySatisfied = fmt.Errorf("item already satisfied by another file in ARR")
 	ErrInstanceNotFound        = fmt.Errorf("instance not found")
 )
 

--- a/internal/arrs/scanner/discovery.go
+++ b/internal/arrs/scanner/discovery.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/javi11/altmount/internal/arrs/model"
 	"golift.io/starr"
+	"golift.io/starr/sonarr"
 )
 
 var (
@@ -21,6 +23,19 @@ var (
 func (m *Manager) DiscoverFileMetadata(ctx context.Context, filePath, relativePath, nzbName, libraryPath string) (*model.WebhookMetadata, error) {
 	allInstances := m.instances.GetAllInstances()
 	cleanNzbName := strings.TrimSuffix(nzbName, ".nzb")
+
+	if cleanNzbName == "" {
+		// Fallback to parent directory name if it looks like a release folder
+		parentDir := filepath.Base(filepath.Dir(filePath))
+		if parentDir != "." && parentDir != "tv" && parentDir != "movies" && parentDir != "/" && parentDir != "" {
+			cleanNzbName = parentDir
+		} else {
+			// Fallback to filename without extension
+			baseName := filepath.Base(filePath)
+			ext := filepath.Ext(baseName)
+			cleanNzbName = strings.TrimSuffix(baseName, ext)
+		}
+	}
 
 	// Determine preferred type based on patterns (S01E01, etc.)
 	isTV := tvSeasonPattern.MatchString(cleanNzbName) || tvSeasonPattern.MatchString(filePath) ||
@@ -77,6 +92,18 @@ func (m *Manager) runStrictDiscovery(ctx context.Context, inst *model.ConfigInst
 	return nil, fmt.Errorf("unsupported type")
 }
 
+func (m *Manager) normalizeTitle(title string) string {
+	t := strings.ToLower(title)
+	t = strings.ReplaceAll(t, ".", "")
+	t = strings.ReplaceAll(t, " ", "")
+	t = strings.ReplaceAll(t, "-", "")
+	t = strings.ReplaceAll(t, "_", "")
+	t = strings.ReplaceAll(t, "&", "")
+	t = strings.ReplaceAll(t, "(", "")
+	t = strings.ReplaceAll(t, ")", "")
+	return t
+}
+
 func (m *Manager) discoverRadarrStrict(ctx context.Context, inst *model.ConfigInstance, filePath, cleanNzbName, libraryPath string) (*model.WebhookMetadata, error) {
 	instanceName := inst.Name
 	client, _ := m.clients.GetOrCreateRadarrClient(instanceName, inst.URL, inst.APIKey)
@@ -84,8 +111,19 @@ func (m *Manager) discoverRadarrStrict(ctx context.Context, inst *model.ConfigIn
 	// 1. Check Library (Active Files)
 	movies, err := m.data.GetMovies(ctx, client, instanceName)
 	if err == nil {
+		normalizedNzb := m.normalizeTitle(cleanNzbName)
+		normalizedPath := m.normalizeTitle(filePath)
+
 		for _, movie := range movies {
 			if movie.HasFile && movie.MovieFile != nil {
+				// Optimization: only pull files for movies that might match
+				normalizedTitle := m.normalizeTitle(movie.Title)
+				if !strings.Contains(normalizedNzb, normalizedTitle) &&
+					!strings.Contains(normalizedPath, normalizedTitle) &&
+					(libraryPath == "" || !strings.Contains(libraryPath, movie.Path)) {
+					continue
+				}
+
 				// Strict Match Conditions:
 				// - Library Path matches
 				// - OR Scene Name matches (NZB Name)
@@ -115,11 +153,21 @@ func (m *Manager) discoverRadarrStrict(ctx context.Context, inst *model.ConfigIn
 	if err == nil {
 		for _, record := range history.Records {
 			if strings.EqualFold(record.SourceTitle, cleanNzbName) {
+				var tmdbID int64
+				if movies, err := m.data.GetMovies(ctx, client, instanceName); err == nil {
+					for _, movie := range movies {
+						if movie.ID == record.MovieID {
+							tmdbID = movie.TmdbID
+							break
+						}
+					}
+				}
 				metadata := &model.WebhookMetadata{
 					EventType:    "StrictHistoryDiscovery",
 					InstanceName: instanceName,
 					Movie: &model.MovieMetadata{
-						Id: record.MovieID,
+						Id:     record.MovieID,
+						TmdbId: tmdbID,
 					},
 				}
 				return metadata, nil
@@ -141,11 +189,21 @@ func (m *Manager) discoverSonarrStrict(ctx context.Context, inst *model.ConfigIn
 	// 1. Check Library (Active Files)
 	series, err := m.data.GetSeries(ctx, client, instanceName)
 	if err == nil {
+		normalizedNzb := m.normalizeTitle(cleanNzbName)
+		normalizedPath := m.normalizeTitle(filePath)
+
 		for _, show := range series {
 			// Optimization: only pull files for shows that might contain this file
-			if !strings.Contains(strings.ToLower(cleanNzbName), strings.ToLower(show.CleanTitle)) &&
-				!strings.Contains(strings.ToLower(filePath), strings.ToLower(show.Path)) &&
-				(libraryPath == "" || !strings.Contains(strings.ToLower(libraryPath), strings.ToLower(show.Path))) {
+			// Use normalized titles to handle "Law.And.Order" vs "Law & Order" (laworder)
+			normalizedTitle := m.normalizeTitle(show.Title)
+			normalizedClean := strings.ToLower(show.CleanTitle)
+
+			if !strings.Contains(normalizedNzb, normalizedTitle) &&
+				!strings.Contains(normalizedNzb, normalizedClean) &&
+				!strings.Contains(normalizedPath, normalizedTitle) &&
+				!strings.Contains(normalizedPath, normalizedClean) &&
+				!strings.Contains(filePath, show.Path) &&
+				(libraryPath == "" || !strings.Contains(libraryPath, show.Path)) {
 				continue
 			}
 
@@ -157,6 +215,20 @@ func (m *Manager) discoverSonarrStrict(ctx context.Context, inst *model.ConfigIn
 				if (libraryPath != "" && ef.Path == libraryPath) ||
 					(cleanNzbName != "" && strings.EqualFold(ef.SceneName, cleanNzbName)) ||
 					(ef.Path == filePath) {
+					var episodes []model.EpisodeMetadata
+					eps, err := client.GetSeriesEpisodesContext(ctx, &sonarr.GetEpisode{
+						SeriesID: show.ID,
+					})
+					if err == nil {
+						for _, ep := range eps {
+							if ep.EpisodeFileID == ef.ID {
+								episodes = append(episodes, model.EpisodeMetadata{
+									Id: ep.ID,
+								})
+							}
+						}
+					}
+
 					metadata := &model.WebhookMetadata{
 						EventType:    "StrictDiscovery",
 						InstanceName: instanceName,
@@ -168,6 +240,7 @@ func (m *Manager) discoverSonarrStrict(ctx context.Context, inst *model.ConfigIn
 							Id:        ef.ID,
 							SceneName: ef.SceneName,
 						},
+						Episodes: episodes,
 					}
 					return metadata, nil
 				}
@@ -179,17 +252,48 @@ func (m *Manager) discoverSonarrStrict(ctx context.Context, inst *model.ConfigIn
 	req := &starr.PageReq{PageSize: 100, SortKey: "date", SortDir: starr.SortDescend}
 	history, err := client.GetHistoryPageContext(ctx, req)
 	if err == nil {
+		var matchedRecord *sonarr.HistoryRecord
+		var episodeIDs []int64
+		episodeIDMap := make(map[int64]bool)
+
 		for _, record := range history.Records {
 			if strings.EqualFold(record.SourceTitle, cleanNzbName) {
-				metadata := &model.WebhookMetadata{
-					EventType:    "StrictHistoryDiscovery",
-					InstanceName: instanceName,
-					Series: &model.SeriesMetadata{
-						Id: record.SeriesID,
-					},
+				if matchedRecord == nil {
+					matchedRecord = record
 				}
-				return metadata, nil
+				if record.EpisodeID > 0 && !episodeIDMap[record.EpisodeID] {
+					episodeIDMap[record.EpisodeID] = true
+					episodeIDs = append(episodeIDs, record.EpisodeID)
+				}
 			}
+		}
+
+		if matchedRecord != nil {
+			var episodes []model.EpisodeMetadata
+			for _, epID := range episodeIDs {
+				episodes = append(episodes, model.EpisodeMetadata{
+					Id: epID,
+				})
+			}
+
+			var tvdbID int64
+			for _, show := range series {
+				if show.ID == matchedRecord.SeriesID {
+					tvdbID = show.TvdbID
+					break
+				}
+			}
+
+			metadata := &model.WebhookMetadata{
+				EventType:    "StrictHistoryDiscovery",
+				InstanceName: instanceName,
+				Series: &model.SeriesMetadata{
+					Id:     matchedRecord.SeriesID,
+					TvdbId: tvdbID,
+				},
+				Episodes: episodes,
+			}
+			return metadata, nil
 		}
 	}
 

--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -305,8 +305,17 @@ func (m *Manager) sonarrHasFile(ctx context.Context, client *sonarr.Sonarr, inst
 
 // TriggerFileRescan triggers a rescan for a specific file path through the appropriate ARR instance
 func (m *Manager) TriggerFileRescan(ctx context.Context, pathForRescan string, relativePath string, metadataStr *string) error {
-	res, err, _ := m.sf.Do(fmt.Sprintf("rescan:%s", pathForRescan), func() (interface{}, error) {
-		slog.InfoContext(ctx, "Triggering ARR rescan", "path", pathForRescan, "relative_path", relativePath)
+	hasMeta := "false"
+	if metadataStr != nil && *metadataStr != "" {
+		hasMeta = "true"
+	}
+	key := fmt.Sprintf("rescan:%s:%s", pathForRescan, hasMeta)
+
+	res, err, _ := m.sf.Do(key, func() (interface{}, error) {
+		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		slog.InfoContext(bgCtx, "Triggering ARR rescan (singleflight)", "path", pathForRescan, "relative_path", relativePath, "has_metadata", hasMeta)
 
 		var metadata *model.WebhookMetadata
 		if metadataStr != nil && *metadataStr != "" {
@@ -314,7 +323,7 @@ func (m *Manager) TriggerFileRescan(ctx context.Context, pathForRescan string, r
 			if err := json.Unmarshal([]byte(*metadataStr), &parsedMetadata); err == nil {
 				metadata = &parsedMetadata
 			} else {
-				slog.WarnContext(ctx, "Failed to parse metadata string, falling back to path-based repair", "error", err, "path", pathForRescan)
+				slog.WarnContext(bgCtx, "Failed to parse metadata string, falling back to path-based repair", "error", err, "path", pathForRescan)
 			}
 		}
 
@@ -329,7 +338,7 @@ func (m *Manager) TriggerFileRescan(ctx context.Context, pathForRescan string, r
 				if inst.Name == metadata.InstanceName {
 					instanceType = inst.Type
 					instanceName = inst.Name
-					slog.InfoContext(ctx, "Fast path: Found instance from metadata", "instance", instanceName, "type", instanceType)
+					slog.InfoContext(bgCtx, "Fast path: Found instance from metadata", "instance", instanceName, "type", instanceType)
 					break
 				}
 			}
@@ -337,8 +346,8 @@ func (m *Manager) TriggerFileRescan(ctx context.Context, pathForRescan string, r
 
 		// Fallback to path-based logic if instance not found from metadata
 		if instanceName == "" {
-			slog.DebugContext(ctx, "Instance not found from metadata, falling back to path-based detection", "path", pathForRescan)
-			instanceType, instanceName, err = m.findInstanceForFilePath(ctx, pathForRescan, relativePath)
+			slog.DebugContext(bgCtx, "Instance not found from metadata, falling back to path-based detection", "path", pathForRescan)
+			instanceType, instanceName, err = m.findInstanceForFilePath(bgCtx, pathForRescan, relativePath)
 			if err != nil {
 				return nil, fmt.Errorf("failed to find ARR instance for file path %s: %w", pathForRescan, err)
 			}
@@ -362,35 +371,35 @@ func (m *Manager) TriggerFileRescan(ctx context.Context, pathForRescan string, r
 			if err != nil {
 				return nil, fmt.Errorf("failed to create Radarr client: %w", err)
 			}
-			return nil, m.triggerRadarrRescanByPath(ctx, client, pathForRescan, relativePath, instanceName, metadata)
+			return nil, m.triggerRadarrRescanByPath(bgCtx, client, pathForRescan, relativePath, instanceName, metadata)
 
 		case "sonarr":
 			client, err := m.clients.GetOrCreateSonarrClient(instanceName, instanceConfig.URL, instanceConfig.APIKey)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create Sonarr client: %w", err)
 			}
-			return nil, m.triggerSonarrRescanByPath(ctx, client, pathForRescan, relativePath, instanceName, metadata)
+			return nil, m.triggerSonarrRescanByPath(bgCtx, client, pathForRescan, relativePath, instanceName, metadata)
 
 		case "lidarr":
 			client, err := m.clients.GetOrCreateLidarrClient(instanceName, instanceConfig.URL, instanceConfig.APIKey)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create Lidarr client: %w", err)
 			}
-			return nil, m.triggerLidarrRescanByPath(ctx, client, pathForRescan, relativePath, instanceName, metadata)
+			return nil, m.triggerLidarrRescanByPath(bgCtx, client, pathForRescan, relativePath, instanceName, metadata)
 
 		case "readarr":
 			client, err := m.clients.GetOrCreateReadarrClient(instanceName, instanceConfig.URL, instanceConfig.APIKey)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create Readarr client: %w", err)
 			}
-			return nil, m.triggerReadarrRescanByPath(ctx, client, pathForRescan, relativePath, instanceName, metadata)
+			return nil, m.triggerReadarrRescanByPath(bgCtx, client, pathForRescan, relativePath, instanceName, metadata)
 
 		case "whisparr":
 			client, err := m.clients.GetOrCreateWhisparrClient(instanceName, instanceConfig.URL, instanceConfig.APIKey)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create Whisparr client: %w", err)
 			}
-			return nil, m.triggerSonarrRescanByPath(ctx, client, pathForRescan, relativePath, instanceName, metadata)
+			return nil, m.triggerSonarrRescanByPath(bgCtx, client, pathForRescan, relativePath, instanceName, metadata)
 
 		default:
 			return nil, fmt.Errorf("unsupported instance type: %s", instanceType)
@@ -553,14 +562,11 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 
 	var targetMovie *radarr.Movie
 	var targetMovieFileID int64
+	var sceneName string
 	var err error
 
-	// ID-Based Precision: If we have the exact movie ID and file ID from metadata, use them directly
-	if metadata != nil && metadata.Movie != nil && metadata.MovieFile != nil && metadata.Movie.Id > 0 && metadata.MovieFile.Id > 0 {
-		slog.InfoContext(ctx, "ID-Based Precision: Using metadata IDs for Radarr repair",
-			"movie_id", metadata.Movie.Id,
-			"movie_file_id", metadata.MovieFile.Id)
-
+	// ID-Based Precision: If we have the movie ID from metadata, use it
+	if metadata != nil && metadata.Movie != nil && metadata.Movie.Id > 0 {
 		movies, err := m.data.GetMovies(ctx, client, instanceName)
 		if err != nil {
 			return fmt.Errorf("failed to get movies from Radarr for ID lookup: %w", err)
@@ -569,16 +575,29 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 			if movie.ID == metadata.Movie.Id {
 				targetMovie = movie
 
-				// Smart Repair Guard: Check if the movie already has a newer/different healthy file
-				if movie.HasFile && movie.MovieFile != nil {
-					if movie.MovieFile.ID != metadata.MovieFile.Id {
-						slog.InfoContext(ctx, "Smart Repair Guard: Movie already has a different healthy file (likely upgraded). Skipping repair.",
-							"movie", movie.Title,
-							"old_file_id", metadata.MovieFile.Id,
-							"new_file_id", movie.MovieFile.ID)
-						return model.ErrEpisodeAlreadySatisfied
+				if metadata.MovieFile != nil && metadata.MovieFile.Id > 0 {
+					slog.InfoContext(ctx, "ID-Based Precision: Using metadata IDs for Radarr repair",
+						"movie_id", metadata.Movie.Id,
+						"movie_file_id", metadata.MovieFile.Id)
+					sceneName = metadata.MovieFile.SceneName
+
+					// Smart Repair Guard: Check if the movie already has a newer/different healthy file
+					if movie.HasFile && movie.MovieFile != nil {
+						if movie.MovieFile.ID != metadata.MovieFile.Id {
+							slog.InfoContext(ctx, "Smart Repair Guard: Movie already has a different healthy file (likely upgraded). Skipping repair.",
+								"movie", movie.Title,
+								"old_file_id", metadata.MovieFile.Id,
+								"new_file_id", movie.MovieFile.ID)
+							return model.ErrEpisodeAlreadySatisfied
+						}
+						targetMovieFileID = movie.MovieFile.ID
 					}
-					targetMovieFileID = movie.MovieFile.ID
+				} else {
+					slog.InfoContext(ctx, "ID-Based Precision: Using metadata movie ID for Radarr repair",
+						"movie_id", metadata.Movie.Id)
+					if movie.HasFile && movie.MovieFile != nil {
+						targetMovieFileID = movie.MovieFile.ID
+					}
 				}
 				break
 			}
@@ -640,6 +659,10 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 					}
 				}
 			}
+			
+			if targetMovieFileID > 0 {
+				sceneName = movie.MovieFile.SceneName
+			}
 		}
 	}
 
@@ -666,7 +689,7 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 	// If we found the movie and have a file ID, try to blocklist and delete the file
 	if targetMovieFileID > 0 {
 		// Try to blocklist the release associated with this file
-		if err := m.blocklistRadarrMovieFile(ctx, client, targetMovie.ID, targetMovieFileID); err != nil {
+		if err := m.blocklistRadarrMovieFile(ctx, client, targetMovie.ID, targetMovieFileID, sceneName); err != nil {
 			slog.WarnContext(ctx, "Failed to blocklist Radarr release", "error", err)
 		}
 
@@ -680,8 +703,13 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 				"error", err)
 		}
 	} else {
-		slog.InfoContext(ctx, "Movie has no specific file ID linked in Radarr, skipping blocklist/delete and proceeding to search",
+		slog.InfoContext(ctx, "Movie has no specific file ID linked in Radarr, attempting release blocklist using metadata",
 			"movie", targetMovie.Title)
+		if metadata != nil && metadata.Movie != nil && metadata.Movie.Id > 0 {
+			if err := m.blocklistRadarrMovieFile(ctx, client, targetMovie.ID, 0, sceneName); err != nil {
+				slog.WarnContext(ctx, "Failed to blocklist Radarr release using metadata fallback", "error", err)
+			}
+		}
 	}
 
 	// Failure breaker: every targeted re-search counts one failure-driven action
@@ -721,17 +749,24 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 	var targetSeriesID int64
 	var targetSeriesTitle string
 	var targetEpisodeFileID int64
+	var sceneName string
 	var err error
 
-	// ID-Based Precision: If we have exact IDs from metadata, use them
-	if metadata != nil && metadata.Series != nil && metadata.EpisodeFile != nil && metadata.Series.Id > 0 && metadata.EpisodeFile.Id > 0 {
-		slog.InfoContext(ctx, "ID-Based Precision: Using metadata IDs for Sonarr repair",
-			"series_id", metadata.Series.Id,
-			"episode_file_id", metadata.EpisodeFile.Id)
-
+	// ID-Based Precision: If we have the series ID from metadata, use it
+	if metadata != nil && metadata.Series != nil && metadata.Series.Id > 0 {
 		targetSeriesID = metadata.Series.Id
-		targetEpisodeFileID = metadata.EpisodeFile.Id
-		targetSeriesTitle = "Known Series (ID Based)" // Title is just for logging
+		targetSeriesTitle = "Known Series (ID Based)"
+
+		if metadata.EpisodeFile != nil && metadata.EpisodeFile.Id > 0 {
+			slog.InfoContext(ctx, "ID-Based Precision: Using metadata IDs for Sonarr repair",
+				"series_id", metadata.Series.Id,
+				"episode_file_id", metadata.EpisodeFile.Id)
+			targetEpisodeFileID = metadata.EpisodeFile.Id
+			sceneName = metadata.EpisodeFile.SceneName
+		} else {
+			slog.InfoContext(ctx, "ID-Based Precision: Using metadata series ID for Sonarr repair",
+				"series_id", metadata.Series.Id)
+		}
 	}
 
 	// Fallback to path-based guessing if ID-based precision failed or metadata was missing
@@ -841,6 +876,7 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 
 		if targetEpisodeFile != nil {
 			targetEpisodeFileID = targetEpisodeFile.ID
+			sceneName = targetEpisodeFile.SceneName
 		}
 	}
 
@@ -872,7 +908,7 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 			episodeFiles, err := m.data.GetEpisodeFiles(ctx, client, instanceName, targetSeriesID)
 			if err == nil {
 				for _, ef := range episodeFiles {
-					if ef.Path == filePath || (metadata != nil && ef.SceneName == metadata.EpisodeFile.SceneName) {
+					if ef.Path == filePath || (sceneName != "" && ef.SceneName == sceneName) {
 						slog.InfoContext(ctx, "Smart Repair Guard: Episode already has a different healthy file (likely upgraded). Skipping repair.",
 							"old_file_id", targetEpisodeFileID,
 							"new_file_id", ef.ID)
@@ -888,7 +924,7 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 				"episode_file_id", targetEpisodeFileID)
 
 			// Try to blocklist the release associated with this file
-			if err := m.blocklistSonarrEpisodeFile(ctx, client, targetSeriesID, targetEpisodeFileID); err != nil {
+			if err := m.blocklistSonarrEpisodeFile(ctx, client, targetSeriesID, targetEpisodeFileID, episodeIDs, sceneName); err != nil {
 				slog.WarnContext(ctx, "Failed to blocklist Sonarr release", "error", err)
 			}
 
@@ -909,6 +945,19 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 		// Fallback: search in Sonarr download queue
 		if err := m.failSonarrQueueItemByPath(ctx, client, filePath); err == nil {
 			return nil
+		}
+
+		// Fallback 2: If we have episode IDs from metadata, use them to trigger replacement search
+		if metadata != nil && len(metadata.Episodes) > 0 {
+			slog.InfoContext(ctx, "Using episode IDs from metadata to trigger replacement search", "series", targetSeriesTitle)
+			for _, ep := range metadata.Episodes {
+				episodeIDs = append(episodeIDs, ep.Id)
+			}
+
+			// Try to blocklist the release associated with these episodes
+			if err := m.blocklistSonarrEpisodeFile(ctx, client, targetSeriesID, 0, episodeIDs, sceneName); err != nil {
+				slog.WarnContext(ctx, "Failed to blocklist Sonarr release using metadata fallback", "error", err)
+			}
 		}
 	}
 
@@ -1002,8 +1051,8 @@ func (m *Manager) failSonarrQueueItemByPath(ctx context.Context, client *sonarr.
 }
 
 // blocklistRadarrMovieFile finds the history event for the given file and marks it as failed (blocklisting the release)
-func (m *Manager) blocklistRadarrMovieFile(ctx context.Context, client *radarr.Radarr, movieID int64, fileID int64) error {
-	slog.DebugContext(ctx, "Attempting to find and blocklist release for movie file", "movie_id", movieID, "file_id", fileID)
+func (m *Manager) blocklistRadarrMovieFile(ctx context.Context, client *radarr.Radarr, movieID int64, fileID int64, sceneName string) error {
+	slog.DebugContext(ctx, "Attempting to find and blocklist release for movie file", "movie_id", movieID, "file_id", fileID, "scene_name", sceneName)
 
 	// Fetch history for this specific movie
 	req := &starr.PageReq{PageSize: 100, SortKey: "date", SortDir: starr.SortDescend}
@@ -1019,14 +1068,42 @@ func (m *Manager) blocklistRadarrMovieFile(ctx context.Context, client *radarr.R
 
 	// 1. Find the import event to get the downloadId
 	for _, record := range history.Records {
-		if record.Data.FileID == targetFileID && (record.EventType == "movieFileImported" || record.EventType == "downloadFolderImported") {
-			downloadID = record.DownloadID
-			break
+		if record.EventType == "movieFileImported" || record.EventType == "downloadFolderImported" {
+			if record.Data.FileID == targetFileID {
+				downloadID = record.DownloadID
+				break
+			}
 		}
 	}
 
 	if downloadID == "" {
-		slog.WarnContext(ctx, "Could not find import event in Radarr history for file", "movie_id", movieID, "file_id", fileID)
+		slog.WarnContext(ctx, "Could not find import event in Radarr history for file, attempting to find latest grabbed event directly", "movie_id", movieID, "file_id", fileID)
+		
+		// Precision Fallback: Find the grabbed event matching the SceneName or MovieID
+		for _, record := range history.Records {
+			if record.EventType == "grabbed" && record.MovieID == movieID {
+				if sceneName != "" && strings.Contains(strings.ToLower(record.SourceTitle), strings.ToLower(sceneName)) {
+					slog.InfoContext(ctx, "Found grabbed history record using SceneName precision fallback, marking as failed to blocklist release",
+						"history_id", record.ID, "source_title", record.SourceTitle)
+					if failErr := client.FailContext(ctx, record.ID); failErr != nil {
+						return fmt.Errorf("failed to fail Radarr grab event %d: %w", record.ID, failErr)
+					}
+					return nil
+				}
+				
+				// Without an exact SceneName match, only fallback to the latest grab if it was recent (within 24 hours)
+				if time.Since(record.Date) < 24*time.Hour {
+					slog.InfoContext(ctx, "Found recent grabbed history record using MovieID fallback, marking as failed to blocklist release",
+						"history_id", record.ID, "movie_id", movieID, "grabbed_at", record.Date)
+					if failErr := client.FailContext(ctx, record.ID); failErr != nil {
+						return fmt.Errorf("failed to fail Radarr grab event %d: %w", record.ID, failErr)
+					}
+					return nil
+				}
+			}
+		}
+
+		slog.WarnContext(ctx, "Could not find any matching or recent grab event in Radarr history to blocklist", "movie_id", movieID)
 		return nil
 	}
 
@@ -1047,8 +1124,8 @@ func (m *Manager) blocklistRadarrMovieFile(ctx context.Context, client *radarr.R
 }
 
 // blocklistSonarrEpisodeFile finds the grabbed history event for the given file and marks it as failed (blocklisting the release)
-func (m *Manager) blocklistSonarrEpisodeFile(ctx context.Context, client *sonarr.Sonarr, seriesID int64, fileID int64) error {
-	slog.DebugContext(ctx, "Attempting to find and blocklist release for episode file", "series_id", seriesID, "file_id", fileID)
+func (m *Manager) blocklistSonarrEpisodeFile(ctx context.Context, client *sonarr.Sonarr, seriesID int64, fileID int64, episodeIDs []int64, sceneName string) error {
+	slog.DebugContext(ctx, "Attempting to find and blocklist release for episode file", "series_id", seriesID, "file_id", fileID, "scene_name", sceneName)
 
 	// Fetch history for this specific series
 	req := &starr.PageReq{PageSize: 100, SortKey: "date", SortDir: starr.SortDescend}
@@ -1064,14 +1141,58 @@ func (m *Manager) blocklistSonarrEpisodeFile(ctx context.Context, client *sonarr
 
 	// 1. Find the import event to get the downloadId
 	for _, record := range history.Records {
-		if record.Data.FileID == targetFileID && record.EventType == "downloadFolderImported" {
-			downloadID = record.DownloadID
-			break
+		if record.EventType == "downloadFolderImported" {
+			if record.Data.FileID == targetFileID {
+				downloadID = record.DownloadID
+				break
+			}
+			
+			// Fallback: Sonarr history might not expose fileId in data consistently. Match by EpisodeID.
+			for _, epID := range episodeIDs {
+				if record.EpisodeID == epID {
+					slog.DebugContext(ctx, "Found import event using EpisodeID fallback", "episode_id", epID, "download_id", record.DownloadID)
+					downloadID = record.DownloadID
+					break
+				}
+			}
+			if downloadID != "" {
+				break
+			}
 		}
 	}
 
 	if downloadID == "" {
-		slog.WarnContext(ctx, "Could not find import event in Sonarr history for file", "series_id", seriesID, "file_id", fileID)
+		slog.WarnContext(ctx, "Could not find import event in Sonarr history for file, attempting to find grabbed event directly", "series_id", seriesID, "file_id", fileID)
+		
+		// Precision Fallback: Find the grabbed event matching the SceneName
+		for _, record := range history.Records {
+			if record.EventType == "grabbed" {
+				if sceneName != "" && strings.Contains(strings.ToLower(record.SourceTitle), strings.ToLower(sceneName)) {
+					slog.InfoContext(ctx, "Found grabbed history record using SceneName precision fallback, marking as failed to blocklist release",
+						"history_id", record.ID, "source_title", record.SourceTitle)
+					if failErr := client.FailContext(ctx, record.ID); failErr != nil {
+						return fmt.Errorf("failed to fail Sonarr grab event %d: %w", record.ID, failErr)
+					}
+					return nil
+				}
+
+				for _, epID := range episodeIDs {
+					if record.EpisodeID == epID {
+						// Only fallback if the grabbed event was recent (within 24 hours)
+						if time.Since(record.Date) < 24*time.Hour {
+							slog.InfoContext(ctx, "Found recent grabbed history record using EpisodeID fallback, marking as failed to blocklist release",
+								"history_id", record.ID, "episode_id", epID, "grabbed_at", record.Date)
+							if failErr := client.FailContext(ctx, record.ID); failErr != nil {
+								return fmt.Errorf("failed to fail Sonarr grab event %d: %w", record.ID, failErr)
+							}
+							return nil
+						}
+					}
+				}
+			}
+		}
+		
+		slog.WarnContext(ctx, "Could not find any matching or recent grab event in Sonarr history to blocklist", "series_id", seriesID)
 		return nil
 	}
 


### PR DESCRIPTION
Coalesces concurrent ARR metadata discovery and command triggers using Go's singleflight, optimizes database title query filters to prevent full-table lookups, and adds fallback blocklisting to Radarr/Sonarr history records based on metadata titles when direct File IDs are unlinked or missing.