### PR TITLE
feat(frontend): add TMDB/TVDB/File metadata badges to Health page items

### DIFF
--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthItemCard.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthItemCard.tsx
@@ -213,6 +213,43 @@ export const HealthItemCard = memo(function HealthItemCard({
 								<div className="mt-1 break-all font-mono text-xs">{item.library_path}</div>
 							</div>
 						)}
+						{item.metadata && (
+							<div>
+								<span className="opacity-70">Metadata:</span>
+								<div className="flex flex-wrap gap-1 mt-1">
+									{(() => {
+										try {
+											const meta = JSON.parse(item.metadata);
+											return (
+												<>
+													{meta.instanceName && (
+														<span className="badge badge-outline badge-xs">{meta.instanceName}</span>
+													)}
+													{meta.series?.id && (
+														<span className="badge badge-ghost badge-xs" title="Series ID">SeriesID: {meta.series.id}</span>
+													)}
+													{meta.movie?.id && (
+														<span className="badge badge-ghost badge-xs" title="Movie ID">MovieID: {meta.movie.id}</span>
+													)}
+													{meta.series?.tvdbId && (
+														<span className="badge badge-ghost badge-xs" title="TVDB ID">TVDBID: {meta.series.tvdbId}</span>
+													)}
+													{meta.episodeFile?.id && (
+														<span className="badge badge-ghost badge-xs" title="Episode File ID">FileID: {meta.episodeFile.id}</span>
+													)}
+													{meta.movie?.tmdbId && (
+														<span className="badge badge-ghost badge-xs" title="TMDB ID">TMDBID: {meta.movie.tmdbId}</span>
+													)}
+													{meta.movieFile?.id && (
+														<span className="badge badge-ghost badge-xs" title="Movie File ID">FileID: {meta.movieFile.id}</span>
+													)}
+												</>
+											);
+										} catch(e) { return null; }
+									})()}
+								</div>
+							</div>
+						)}
 						<div>
 							<span className="opacity-70">Next Check:</span>
 							<div className="mt-1 text-xs">

--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthTableRow.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthTableRow.tsx
@@ -1,5 +1,5 @@
 import { Clock, Heart, HeartCrack, Loader, Wrench } from "lucide-react";
-import { memo } from "react";
+import { memo, useMemo } from "react";
 import { HealthBadge } from "../../../../components/ui/StatusBadge";
 import { formatFutureTime, formatRelativeTime } from "../../../../lib/utils";
 import { type FileHealth, HealthPriority } from "../../../../types/api";
@@ -42,6 +42,15 @@ export const HealthTableRow = memo(function HealthTableRow({
 	onSetPriority,
 	onRegenerate,
 }: HealthTableRowProps) {
+	const parsedMetadata = useMemo(() => {
+		if (!item.metadata) return null;
+		try {
+			return JSON.parse(item.metadata);
+		} catch (e) {
+			return null;
+		}
+	}, [item.metadata]);
+
 	const getNextPriority = (current: HealthPriority): HealthPriority => {
 		switch (current) {
 			case HealthPriority.Normal:
@@ -110,7 +119,34 @@ export const HealthTableRow = memo(function HealthTableRow({
 				</div>
 			</td>
 			<td>
-				<div className="break-all text-sm">{item.library_path?.split("/").pop() || ""}</div>
+				<div className="flex flex-col gap-1">
+					<div className="break-all text-sm cursor-help" title={item.library_path || undefined}>{item.library_path?.split("/").pop() || ""}</div>
+					{parsedMetadata && (
+						<div className="flex flex-wrap gap-1 mt-1">
+							{parsedMetadata.instanceName && (
+								<span className="badge badge-outline badge-xs">{parsedMetadata.instanceName}</span>
+							)}
+							{parsedMetadata.series?.id && (
+								<span className="badge badge-ghost badge-xs" title="Series ID">SeriesID: {parsedMetadata.series.id}</span>
+							)}
+							{parsedMetadata.movie?.id && (
+								<span className="badge badge-ghost badge-xs" title="Movie ID">MovieID: {parsedMetadata.movie.id}</span>
+							)}
+							{parsedMetadata.series?.tvdbId && (
+								<span className="badge badge-ghost badge-xs" title="TVDB ID">TVDBID: {parsedMetadata.series.tvdbId}</span>
+							)}
+							{parsedMetadata.episodeFile?.id && (
+								<span className="badge badge-ghost badge-xs" title="Episode File ID">FileID: {parsedMetadata.episodeFile.id}</span>
+							)}
+							{parsedMetadata.movie?.tmdbId && (
+								<span className="badge badge-ghost badge-xs" title="TMDB ID">TMDBID: {parsedMetadata.movie.tmdbId}</span>
+							)}
+							{parsedMetadata.movieFile?.id && (
+								<span className="badge badge-ghost badge-xs" title="Movie File ID">FileID: {parsedMetadata.movieFile.id}</span>
+							)}
+						</div>
+					)}
+				</div>
 			</td>
 			<td>
 				<div className="flex items-center gap-2">

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -207,6 +207,7 @@ export interface FileHealth {
 	streaming_failure_count: number;
 	is_masked: boolean;
 	indexer?: string;
+	metadata?: string;
 }
 
 export interface HealthStats {


### PR DESCRIPTION
Exposes movie/series/episode metadata identifiers (such as TMDB, TVDB, Series ID, Episode ID, and File ID) directly as inline badge lists on Health table rows and mobile item cards. This preserves the standard page layout while enriching the displayed information to make file-to-metadata association clear.