### PR TITLE
feat(health): database conflict merging, worker safety, cache invalidation, and repair optimizations

### DIFF
--- a/internal/api/arrs_handlers.go
+++ b/internal/api/arrs_handlers.go
@@ -16,6 +16,16 @@ import (
 	"github.com/javi11/altmount/internal/database"
 )
 
+// ArrsInstanceRequest represents a request to create/update an arrs instance
+type ArrsInstanceRequest struct {
+	Name              string `json:"name"`
+	Type              string `json:"type"`
+	URL               string `json:"url"`
+	APIKey            string `json:"api_key"`
+	Category          string `json:"category"`
+	Enabled           bool   `json:"enabled"`
+	SyncIntervalHours int    `json:"sync_interval_hours"`
+}
 // ArrsWebhookRequest represents a webhook payload from Radarr/Sonarr
 type ArrsWebhookRequest struct {
 	Artist struct {
@@ -65,6 +75,12 @@ type ArrsWebhookRequest struct {
 		SceneName string `json:"sceneName"`
 		Path      string `json:"path"`
 	} `json:"episodeFile"`
+	Episodes []struct {
+		Id            int64  `json:"id"`
+		EpisodeNumber int    `json:"episodeNumber"`
+		SeasonNumber  int    `json:"seasonNumber"`
+		Title         string `json:"title"`
+	} `json:"episodes,omitempty"`
 	DeletedFiles ArrsDeletedFiles `json:"deletedFiles,omitempty"`
 	DownloadId   string           `json:"downloadId,omitempty"`
 	Release      *struct {
@@ -106,6 +122,16 @@ func (req ArrsWebhookRequest) ToMetadata() model.WebhookMetadata {
 			SceneName: req.EpisodeFile.SceneName,
 		}
 	}
+
+	if len(req.Episodes) > 0 {
+		meta.Episodes = make([]model.EpisodeMetadata, len(req.Episodes))
+		for i, ep := range req.Episodes {
+			meta.Episodes[i] = model.EpisodeMetadata{
+				Id: ep.Id,
+			}
+		}
+	}
+
 
 	if req.Artist.Id > 0 {
 		meta.Artist = &model.ArtistMetadata{
@@ -219,6 +245,10 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 	}
 
 	slog.InfoContext(c.Context(), "Received ARR webhook", "event_type", req.EventType)
+
+	if req.InstanceName != "" {
+		s.arrsService.ClearInstanceCache(c.Context(), req.InstanceName)
+	}
 
 	// Determine file path to scan/delete based on event type
 	var pathsToScan []string
@@ -512,19 +542,43 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 			// Handle Rename and Download specifically: try to find and re-link old record
 			if req.EventType == "Rename" || req.EventType == "Download" {
 				fileName := filepath.Base(normalizedPath)
-				// Try to find a record with the same filename but currently under /complete/
-				// or with a NULL library_path
 				var metadataStr *string
-				metaBytes, err := json.Marshal(req.ToMetadata())
+				webMeta := req.ToMetadata()
+				metaBytes, err := json.Marshal(webMeta)
 				if err == nil {
 					str := string(metaBytes)
 					metadataStr = &str
 				}
 
+				// Try to find and relink by metadata IDs (e.g. series ID/TVDB ID/episode ID or movie ID/TMDB ID) first
+				if relinked, err := s.healthRepo.RelinkFileByMetadata(c.Context(), &webMeta, normalizedPath, path, metadataStr, req.EventType == "Download"); err == nil && relinked {
+					attrs := []any{
+						"event", req.EventType,
+						"instance", req.InstanceName,
+						"new_library_path", path,
+					}
+					if req.Series.Id > 0 {
+						attrs = append(attrs, "series_id", req.Series.Id)
+					}
+					if req.EpisodeFile.Id > 0 {
+						attrs = append(attrs, "episode_file_id", req.EpisodeFile.Id)
+					}
+					if req.Movie.Id > 0 {
+						attrs = append(attrs, "movie_id", req.Movie.Id)
+					}
+					if req.MovieFile.Id > 0 {
+						attrs = append(attrs, "movie_file_id", req.MovieFile.Id)
+					}
+
+					slog.InfoContext(c.Context(), "Successfully re-linked health record using metadata IDs during webhook", attrs...)
+					continue // Successfully re-linked, no need to add new
+				}
+
+				// Fall back to filename-based matching
 				// Download events carry a freshly imported copy: relink with revalidation so
-			// the new file gets health-checked (repair budget is preserved). Rename events
-			// carry no new content and must not disturb repair/corrupted state.
-			if relinked, err := s.healthRepo.RelinkFileByFilename(c.Context(), fileName, normalizedPath, path, metadataStr, req.EventType == "Download"); err == nil && relinked {
+				// the new file gets health-checked (repair budget is preserved). Rename events
+				// carry no new content and must not disturb repair/corrupted state.
+				if relinked, err := s.healthRepo.RelinkFileByFilename(c.Context(), fileName, normalizedPath, path, metadataStr, req.EventType == "Download"); err == nil && relinked {
 					attrs := []any{
 						"event", req.EventType,
 						"instance", req.InstanceName,

--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -974,8 +974,11 @@ func (s *Server) handleDirectHealthCheck(c *fiber.Ctx) error {
 
 	// Verify that the file still exists
 	f, err := s.metadataReader.GetFileMetadata(item.FilePath)
-	if f == nil || err != nil {
+	if err != nil {
 		return RespondInternalError(c, "Failed to retrieve file metadata", err.Error())
+	}
+	if f == nil {
+		return RespondNotFound(c, "File metadata", "File metadata no longer exists on disk")
 	}
 
 	// Get the updated health record with 'checking' status

--- a/internal/api/provider_speedtest_handler.go
+++ b/internal/api/provider_speedtest_handler.go
@@ -88,6 +88,9 @@ func (s *Server) handleTestProviderSpeed(c *fiber.Ctx) error {
 		}
 	}
 	speed := wireBps / 1024 / 1024 // bytes/sec → MB/s
+	if speed < 0 {
+		speed = 0
+	}
 
 	// Update provider config with speed test result
 	now := time.Now()

--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -620,7 +620,7 @@ func (s *Server) handleSABnzbdQueue(c *fiber.Ctx) error {
 			if val > 0 {
 				limit = val
 			} else {
-				limit = 10000
+				limit = 100
 			}
 		}
 	}
@@ -790,7 +790,7 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 			if val > 0 {
 				limit = val
 			} else {
-				limit = 10000
+				limit = 100
 			}
 		}
 	}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -558,6 +558,7 @@ type HealthItemResponse struct {
 	RepairRetryCount int                     `json:"repair_retry_count"`
 	MaxRepairRetries int                     `json:"max_repair_retries"`
 	Indexer          *string                 `json:"indexer,omitempty"` // Added indexer
+	Metadata         *string                 `json:"metadata,omitempty"`
 	CreatedAt        time.Time               `json:"created_at"`
 	UpdatedAt        time.Time               `json:"updated_at"`
 	ScheduledCheckAt *time.Time              `json:"scheduled_check_at,omitempty"`
@@ -868,6 +869,7 @@ func ToHealthItemResponse(item *database.FileHealth) *HealthItemResponse {
 		RepairRetryCount:      item.RepairRetryCount,
 		MaxRepairRetries:      item.MaxRepairRetries,
 		Indexer:               item.Indexer, // Fixed: use pointer directly
+		Metadata:              item.Metadata,
 		CreatedAt:             item.CreatedAt,
 		UpdatedAt:             item.UpdatedAt,
 		ScheduledCheckAt:      item.ScheduledCheckAt,

--- a/internal/arrs/service.go
+++ b/internal/arrs/service.go
@@ -243,6 +243,17 @@ func (s *Service) TriggerFileRescan(ctx context.Context, pathForRescan string, r
 	return s.scanner.TriggerFileRescan(ctx, pathForRescan, relativePath, metadataStr)
 }
 
+// ClearInstanceCache clears all movie and series caches for a specific instance
+func (s *Service) ClearInstanceCache(ctx context.Context, instanceName string) {
+	if instanceName == "" || s.data == nil {
+		return
+	}
+	slog.DebugContext(ctx, "Clearing ARR cache for instance", "instance", instanceName)
+	s.data.ClearMoviesCache(instanceName)
+	s.data.ClearSeriesCache(instanceName)
+}
+
+
 // DiscoverFileMetadata attempts to discover the rich metadata for a file through the appropriate ARR instance
 func (s *Service) DiscoverFileMetadata(ctx context.Context, filePath, relativePath, nzbName, libraryPath string) (*model.WebhookMetadata, error) {
 	return s.scanner.DiscoverFileMetadata(ctx, filePath, relativePath, nzbName, libraryPath)

--- a/internal/arrs/service_test.go
+++ b/internal/arrs/service_test.go
@@ -1,6 +1,7 @@
 package arrs
 
 import (
+	"context"
 	"testing"
 
 	"github.com/javi11/altmount/internal/config"
@@ -29,4 +30,19 @@ func TestFindInstanceForFilePath(t *testing.T) {
 	s := NewService(getter, nil, nil, nil)
 
 	assert.NotNil(t, s)
+}
+
+func TestService_ClearInstanceCache(t *testing.T) {
+	cfg := &config.Config{}
+	getter := func() *config.Config { return cfg }
+	s := NewService(getter, nil, nil, nil)
+
+	// Call it, making sure it doesn't crash/panic when s.data is populated
+	ctx := context.Background()
+	s.ClearInstanceCache(ctx, "radarr-test")
+	s.ClearInstanceCache(ctx, "") // Empty safe check
+
+	// Nil s.data check
+	var sNil *Service = &Service{}
+	sNil.ClearInstanceCache(ctx, "radarr-test")
 }

--- a/internal/database/health_fixes_test.go
+++ b/internal/database/health_fixes_test.go
@@ -46,7 +46,7 @@ func TestBackfillReleaseDates_DoesNotRearmTerminal(t *testing.T) {
 
 	_, err := repo.db.ExecContext(ctx, `
 		INSERT INTO file_health (file_path, status, scheduled_check_at, release_date)
-		VALUES ('dead.mkv', 'corrupted', NULL, NULL), ('alive.mkv', 'pending', NULL, NULL)
+		VALUES ('dead.mkv', 'corrupted', NULL, NULL), ('alive.mkv', 'healthy', NULL, NULL)
 	`)
 	require.NoError(t, err)
 
@@ -75,7 +75,7 @@ func TestBackfillReleaseDates_DoesNotRearmTerminal(t *testing.T) {
 	assert.False(t, scheduledCheckAt(t, repo, "dead.mkv").Valid,
 		"backfill must NOT re-arm a corrupted record's terminal NULL schedule")
 	assert.True(t, scheduledCheckAt(t, repo, "alive.mkv").Valid,
-		"pending record must be (re)scheduled by backfill")
+		"healthy record must be (re)scheduled by backfill")
 }
 
 // scheduledCheckAt reads the raw scheduled_check_at column (not projected by GetFileHealth).
@@ -172,10 +172,11 @@ func TestRelinkFileByFilename_CollisionResolvedByExactPath(t *testing.T) {
 	repo := setupTestDB(t)
 	ctx := context.Background()
 
+	past := time.Now().UTC().Add(-5 * time.Minute).Format("2006-01-02 15:04:05")
 	_, err := repo.db.ExecContext(ctx, `
-		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries)
-		VALUES ('tv/ShowA/01.mkv', 'repair_triggered', 1, 3), ('tv/ShowB/01.mkv', 'repair_triggered', 2, 3)
-	`)
+		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries, updated_at)
+		VALUES ('tv/ShowA/01.mkv', 'repair_triggered', 1, 3, ?), ('tv/ShowB/01.mkv', 'repair_triggered', 2, 3, ?)
+	`, past, past)
 	require.NoError(t, err)
 
 	// Incoming Download whose path matches ShowA exactly: relink only that one.

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -3,10 +3,14 @@ package database
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/javi11/altmount/internal/arrs/model"
 )
 
 // HealthRepository handles file health database operations
@@ -238,13 +242,17 @@ func (r *HealthRepository) GetUnhealthyFiles(ctx context.Context, limit int, str
 		  AND status NOT IN ('repair_triggered', 'checking', 'corrupted')
 		  AND (
 			  ? = 'NONE' 
+			  OR status = 'pending'
+			  OR (metadata IS NOT NULL AND metadata != '')
 			  OR (library_path IS NOT NULL AND (library_path LIKE ? ESCAPE '!' OR library_path LIKE ? ESCAPE '!'))
 			  OR (last_error LIKE '%failed to unmarshal metadata%')
 			  OR (last_error LIKE '%failed to read file metadata%')
 			  OR (last_error LIKE '%no ARR instance found%')
 			  OR (last_error LIKE '%missing % checked segments%')
 		  )
-		ORDER BY priority DESC, scheduled_check_at ASC
+		ORDER BY priority DESC, 
+		         (CASE WHEN status = 'pending' THEN 0 ELSE 1 END) ASC, 
+		         scheduled_check_at ASC
 		LIMIT ?
 	`
 
@@ -1004,6 +1012,36 @@ func (r *HealthRepository) ResetStalePendingFiles(ctx context.Context) error {
 	if rows > 0 {
 		slog.InfoContext(ctx, "Reset stale pending files", "count", rows)
 	}
+
+	// Fix files stuck in pending status with scheduled_check_at set to the distant future
+	// (usually by the backfill release dates worker when status check was not restricted).
+	// We only reset them if they have retry_count = 0 (never checked/no legitimate retry delay)
+	// and scheduled_check_at is more than 24 hours in the future relative to now.
+	var stuckQuery string
+	if r.dialect.IsPostgres() {
+		stuckQuery = `UPDATE file_health
+		               SET scheduled_check_at = NOW(),
+		                   updated_at = NOW()
+		               WHERE status = ? 
+		                 AND retry_count = 0 
+		                 AND scheduled_check_at > NOW() + INTERVAL '24 hours'`
+	} else {
+		stuckQuery = `UPDATE file_health
+		               SET scheduled_check_at = datetime('now'),
+		                   updated_at = datetime('now')
+		               WHERE status = ? 
+		                 AND retry_count = 0 
+		                 AND scheduled_check_at > datetime('now', '+24 hours')`
+	}
+	stuckResult, err := r.db.ExecContext(ctx, stuckQuery, HealthStatusPending)
+	if err != nil {
+		return fmt.Errorf("failed to reset stuck pending files: %w", err)
+	}
+	stuckRows, _ := stuckResult.RowsAffected()
+	if stuckRows > 0 {
+		slog.InfoContext(ctx, "Reset stuck pending files (scheduled in distant future)", "count", stuckRows)
+	}
+
 	return nil
 }
 
@@ -1013,19 +1051,22 @@ func (r *HealthRepository) DeleteHealthRecordsBulk(ctx context.Context, filePath
 		return 0, nil
 	}
 
-	// SQLite parameter limit typically is 999. Batch delete in chunks of 500.
-	const batchSize = 500
+	// SQLite parameter limit typically is 999. Batch delete in chunks of 250 (500 placeholders).
+	const batchSize = 250
 	var totalRowsAffected int64
 
 	for i := 0; i < len(filePaths); i += batchSize {
 		end := min(i+batchSize, len(filePaths))
 		chunk := filePaths[i:end]
 
-		placeholders := make([]string, len(chunk))
-		args := make([]any, len(chunk))
+		placeholders := make([]string, len(chunk)*2)
+		args := make([]any, len(chunk)*2)
 		for j, path := range chunk {
-			placeholders[j] = "?"
-			args[j] = strings.TrimPrefix(path, "/")
+			placeholders[j*2] = "?"
+			placeholders[j*2+1] = "?"
+			trimmed := strings.TrimPrefix(path, "/")
+			args[j*2] = trimmed
+			args[j*2+1] = "/" + trimmed
 		}
 
 		query := fmt.Sprintf(`DELETE FROM file_health WHERE file_path IN (%s)`, strings.Join(placeholders, ","))
@@ -1526,10 +1567,7 @@ func (r *HealthRepository) BackfillReleaseDates(ctx context.Context, updates []B
 	stmt, err := tx.PrepareContext(ctx, `
 		UPDATE file_health
 		SET release_date = ?,
-		    scheduled_check_at = CASE
-		        WHEN status IN ('corrupted', 'repair_triggered') THEN scheduled_check_at
-		        ELSE ?
-		    END,
+		    scheduled_check_at = CASE WHEN status = 'healthy' THEN ? ELSE scheduled_check_at END,
 		    updated_at = datetime('now')
 		WHERE id = ?
 	`)
@@ -1748,85 +1786,141 @@ func (r *HealthRepository) RenameHealthRecord(ctx context.Context, oldPath, newP
 //     reorganization cannot wipe repair progress.
 func (r *HealthRepository) RelinkFileByFilename(ctx context.Context, filename, filePath, libraryPath string, metadataStr *string, revalidate bool) (bool, error) {
 	filePath = normalizeHealthPath(filePath)
-
-	// A single Download/Rename webhook concerns exactly one imported file. Matching by
-	// bare basename ("%/"+filename) can collide across unrelated titles (01.mkv,
-	// sample.mkv, track01.flac); a blanket UPDATE would force-reset every match and
-	// overwrite their paths. So resolve the target record(s) first and only act when the
-	// target is unambiguous — never reset rows belonging to a different release.
 	likePattern := "%/" + escapeLikePrefix(filename)
-	const matchWhere = `(file_path LIKE ? ESCAPE '\' OR file_path = ? OR library_path LIKE ? ESCAPE '\' OR library_path = ?)`
 
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return false, fmt.Errorf("failed to begin relink transaction: %w", err)
+		return false, fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer tx.Rollback()
 
-	ids, err := scanIDs(tx.QueryContext(ctx,
-		`SELECT id FROM file_health WHERE `+matchWhere, likePattern, filename, likePattern, libraryPath))
+	// Query to find all matched records
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, file_path, library_path FROM file_health
+		WHERE (file_path LIKE ? ESCAPE '\' OR file_path = ? OR library_path LIKE ? ESCAPE '\' OR library_path = ?)
+	`, likePattern, filename, likePattern, libraryPath)
 	if err != nil {
-		return false, fmt.Errorf("failed to resolve relink target: %w", err)
+		return false, fmt.Errorf("failed to query records for filename relink: %w", err)
 	}
-	if len(ids) == 0 {
+	
+	type candidate struct {
+		id          int64
+		filePath    string
+		libraryPath string
+	}
+	var allCandidates []candidate
+	for rows.Next() {
+		var c candidate
+		var lp sql.NullString
+		if err := rows.Scan(&c.id, &c.filePath, &lp); err != nil {
+			rows.Close()
+			return false, err
+		}
+		if lp.Valid {
+			c.libraryPath = lp.String
+		}
+		allCandidates = append(allCandidates, c)
+	}
+	rows.Close()
+
+	if len(allCandidates) == 0 {
 		return false, nil
 	}
 
-	targetID := ids[0]
-	if len(ids) > 1 {
-		// Collision: only proceed if exactly one record matches the incoming path
-		// precisely; otherwise refuse and leave every matched row intact.
-		exactIDs, err := scanIDs(tx.QueryContext(ctx,
-			`SELECT id FROM file_health WHERE file_path = ? OR library_path = ?`, filePath, libraryPath))
-		if err != nil {
-			return false, fmt.Errorf("failed to resolve exact relink target: %w", err)
+	var matchedIDs []int64
+	for _, cand := range allCandidates {
+		// Keep if it is the target path/library path precisely
+		if cand.filePath == filePath || cand.libraryPath == libraryPath {
+			matchedIDs = append(matchedIDs, cand.id)
+			continue
 		}
-		if len(exactIDs) != 1 {
-			slog.WarnContext(ctx, "Refusing ambiguous relink — filename matches multiple records",
-				"filename", filename, "matches", len(ids), "exact_matches", len(exactIDs))
-			return false, nil
+		// Keep if it is a downloader path or shares show folder with the target path
+		if isDownloaderPath(cand.filePath) || shareShowFolder(cand.filePath, filePath) {
+			matchedIDs = append(matchedIDs, cand.id)
+			continue
 		}
-		slog.WarnContext(ctx, "Filename collision on relink — scoping to the exact path match",
-			"filename", filename, "matches", len(ids))
-		targetID = exactIDs[0]
 	}
 
-	// revalidate (Download — fresh content) resets the record to pending for immediate
-	// re-validation; the non-revalidate (Rename — no new content) branch preserves
-	// repair/corrupted state. Both preserve repair_retry_count (the per-title budget).
-	setClause := `
-		file_path = ?,
-		library_path = ?,
-		status = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN status ELSE 'pending' END,
-		retry_count = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN retry_count ELSE 0 END,
-		last_error = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN last_error ELSE NULL END,
-		error_details = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN error_details ELSE NULL END,
-		metadata = COALESCE(?, metadata),
-		updated_at = datetime('now'),
-		scheduled_check_at = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN scheduled_check_at ELSE datetime('now') END`
-	if revalidate {
-		setClause = `
-		file_path = ?,
-		library_path = ?,
-		status = 'pending',
-		retry_count = 0,
-		last_error = NULL,
-		error_details = NULL,
-		metadata = COALESCE(?, metadata),
-		updated_at = datetime('now'),
-		scheduled_check_at = datetime('now')`
+	if len(matchedIDs) == 0 {
+		return false, nil
 	}
 
-	if _, err := tx.ExecContext(ctx, `UPDATE file_health SET `+setClause+` WHERE id = ?`,
-		filePath, libraryPath, metadataStr, targetID); err != nil {
-		return false, fmt.Errorf("failed to relink file by filename: %w", err)
+	var targetID int64
+	var sourceID int64
+	for _, id := range matchedIDs {
+		var isExact bool
+		for _, cand := range allCandidates {
+			if cand.id == id && (cand.filePath == filePath || cand.libraryPath == libraryPath) {
+				isExact = true
+				break
+			}
+		}
+		if isExact {
+			targetID = id
+		} else {
+			sourceID = id
+		}
+	}
+
+	// If there are multiple other source IDs (e.g. len(matchedIDs) > 2), it is ambiguous collision
+	if len(matchedIDs) > 2 {
+		slog.WarnContext(ctx, "Refusing ambiguous relink — filename matches multiple source records",
+			"filename", filename, "matches", len(matchedIDs))
+		return false, nil
+	}
+
+	var actID int64
+	if targetID != 0 && sourceID != 0 {
+		actID = sourceID
+	} else if targetID != 0 {
+		actID = targetID
+	} else if sourceID != 0 {
+		actID = sourceID
+	} else {
+		return false, nil
+	}
+
+	if err := r.relinkOrMergeRecordTx(ctx, tx, actID, filePath, libraryPath, metadataStr, revalidate); err != nil {
+		return false, fmt.Errorf("failed to merge/relink record %d: %w", actID, err)
 	}
 
 	if err := tx.Commit(); err != nil {
-		return false, fmt.Errorf("failed to commit relink: %w", err)
+		return false, fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
 	return true, nil
+}
+
+func isDownloaderPath(p string) bool {
+	low := strings.ToLower(p)
+	return strings.Contains(low, "complete") || 
+	       strings.Contains(low, "download") || 
+	       strings.Contains(low, "nzb") || 
+	       strings.Contains(low, "temp") || 
+	       strings.Contains(low, "tmp") || 
+	       strings.Contains(low, "incoming")
+}
+
+func shareShowFolder(p1, p2 string) bool {
+	s1 := strings.Split(filepath.ToSlash(p1), "/")
+	s2 := strings.Split(filepath.ToSlash(p2), "/")
+	if len(s1) < 2 || len(s2) < 2 {
+		return false
+	}
+	for i := len(s1) - 2; i >= 0 && i >= len(s1) - 3; i-- {
+		seg := s1[i]
+		low := strings.ToLower(seg)
+		if strings.HasPrefix(low, "season") || 
+		   low == "specials" || low == "tv" || low == "movies" || low == "downloads" {
+			continue
+		}
+		for j := len(s2) - 2; j >= 0 && j >= len(s2) - 3; j-- {
+			if s2[j] == seg {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // scanIDs reads an id column from a query result, always closing the rows. It centralizes
@@ -2001,3 +2095,326 @@ func (r *HealthRepository) UpdateFileMetadata(ctx context.Context, id int64, met
 func (r *HealthRepository) LogIndexerImport(ctx context.Context, indexer string, status string, errMsg string, downloadID string) error {
 	return logIndexerImport(ctx, r.db, indexer, status, errMsg, downloadID)
 }
+
+// relinkOrMergeRecordTx merges details or updates a matched health record under a transaction,
+// resolving any UNIQUE constraint violations on file_path.
+func (r *HealthRepository) relinkOrMergeRecordTx(ctx context.Context, tx *dialectAwareTx, id int64, filePath, libraryPath string, metadataStr *string, revalidate bool) error {
+	filePath = strings.TrimPrefix(filePath, "/")
+
+	// 1. Fetch source/matched record info
+	var sourceStatus string
+	var sourceUpdatedAt time.Time
+	var sourceRepairRetry int
+	var sourceSourceNzb *string
+	var sourceIndexer *string
+	var sourceReleaseDate *time.Time
+	var sourceMetadata *string
+	err := tx.QueryRowContext(ctx, `
+		SELECT status, updated_at, repair_retry_count, source_nzb_path, indexer, release_date, metadata
+		FROM file_health
+		WHERE id = ?
+	`, id).Scan(&sourceStatus, &sourceUpdatedAt, &sourceRepairRetry, &sourceSourceNzb, &sourceIndexer, &sourceReleaseDate, &sourceMetadata)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil // Source record no longer exists, nothing to do
+		}
+		return err
+	}
+
+	// 2. Check if a record with the new file_path already exists
+	var conflictingID int64
+	var conflictingStatus string
+	var conflictingUpdatedAt time.Time
+	var conflictingRepairRetry int
+	var conflictingSourceNzb *string
+	var conflictingIndexer *string
+	var conflictingReleaseDate *time.Time
+	var conflictingMetadata *string
+	var conflictExists bool = true
+
+	err = tx.QueryRowContext(ctx, `
+		SELECT id, status, updated_at, repair_retry_count, source_nzb_path, indexer, release_date, metadata
+		FROM file_health
+		WHERE file_path = ?
+	`, filePath).Scan(&conflictingID, &conflictingStatus, &conflictingUpdatedAt, &conflictingRepairRetry, &conflictingSourceNzb, &conflictingIndexer, &conflictingReleaseDate, &conflictingMetadata)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			conflictExists = false
+		} else {
+			return err
+		}
+	}
+
+	// If the conflicting record is the exact same record as the source, just update it normally
+	if conflictExists && conflictingID == id {
+		conflictExists = false
+	}
+	
+	// Fast-Fail Revalidate Guard: If the target record (the one surviving the merge) recently
+	// had a repair triggered, DO NOT reset it to pending. This prevents Webhooks that fire immediately 
+	// after an import's streaming failure from wiping out the repair trigger.
+	targetStatus := sourceStatus
+	targetUpdatedAt := sourceUpdatedAt
+	if conflictExists {
+		targetStatus = conflictingStatus
+		targetUpdatedAt = conflictingUpdatedAt
+	}
+	
+	if revalidate && (targetStatus == "repair_triggered" || targetStatus == "corrupted") && time.Since(targetUpdatedAt) < 60*time.Second {
+		revalidate = false
+	}
+
+	if conflictExists {
+		// Merge details into the conflicting record, then delete the source record
+		mergedRepairRetry := sourceRepairRetry
+		if conflictingRepairRetry > mergedRepairRetry {
+			mergedRepairRetry = conflictingRepairRetry
+		}
+
+		var mergedSourceNzb *string
+		if conflictingSourceNzb != nil {
+			mergedSourceNzb = conflictingSourceNzb
+		} else {
+			mergedSourceNzb = sourceSourceNzb
+		}
+
+		var mergedIndexer *string
+		if conflictingIndexer != nil {
+			mergedIndexer = conflictingIndexer
+		} else {
+			mergedIndexer = sourceIndexer
+		}
+
+		var mergedReleaseDate *time.Time
+		if conflictingReleaseDate != nil {
+			mergedReleaseDate = conflictingReleaseDate
+		} else {
+			mergedReleaseDate = sourceReleaseDate
+		}
+
+		var mergedMetadata *string
+		if metadataStr != nil {
+			mergedMetadata = metadataStr
+		} else if conflictingMetadata != nil {
+			mergedMetadata = conflictingMetadata
+		} else {
+			mergedMetadata = sourceMetadata
+		}
+
+		var query string
+		var args []any
+		if revalidate {
+			query = `
+				UPDATE file_health
+				SET library_path = ?,
+				    status = 'pending',
+				    retry_count = 0,
+				    last_error = NULL,
+				    error_details = NULL,
+				    metadata = ?,
+				    repair_retry_count = ?,
+				    source_nzb_path = ?,
+				    indexer = ?,
+				    release_date = ?,
+				    updated_at = datetime('now'),
+				    scheduled_check_at = datetime('now')
+				WHERE id = ?
+			`
+			args = []any{libraryPath, mergedMetadata, mergedRepairRetry, mergedSourceNzb, mergedIndexer, mergedReleaseDate, conflictingID}
+		} else {
+			query = `
+				UPDATE file_health
+				SET library_path = ?,
+				    metadata = ?,
+				    repair_retry_count = ?,
+				    source_nzb_path = ?,
+				    indexer = ?,
+				    release_date = ?,
+				    updated_at = datetime('now'),
+				    scheduled_check_at = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN scheduled_check_at ELSE datetime('now') END
+				WHERE id = ?
+			`
+			args = []any{libraryPath, mergedMetadata, mergedRepairRetry, mergedSourceNzb, mergedIndexer, mergedReleaseDate, conflictingID}
+		}
+
+		_, err = tx.ExecContext(ctx, query, args...)
+		if err != nil {
+			return err
+		}
+
+		// Delete the source record (since its path was obsolete and its history is merged)
+		_, err = tx.ExecContext(ctx, "DELETE FROM file_health WHERE id = ?", id)
+		if err != nil {
+			return err
+		}
+	} else {
+		// No conflict: just rename the source record
+		var query string
+		var args []any
+		if revalidate {
+			query = `
+				UPDATE file_health
+				SET file_path = ?,
+				    library_path = ?,
+				    status = 'pending',
+				    retry_count = 0,
+				    last_error = NULL,
+				    error_details = NULL,
+				    metadata = COALESCE(?, metadata),
+				    updated_at = datetime('now'),
+				    scheduled_check_at = datetime('now')
+				WHERE id = ?
+			`
+			args = []any{filePath, libraryPath, metadataStr, id}
+		} else {
+			query = `
+				UPDATE file_health
+				SET file_path = ?,
+				    library_path = ?,
+				    metadata = COALESCE(?, metadata),
+				    updated_at = datetime('now'),
+				    scheduled_check_at = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN scheduled_check_at ELSE datetime('now') END
+				WHERE id = ?
+			`
+			args = []any{filePath, libraryPath, metadataStr, id}
+		}
+
+		_, err = tx.ExecContext(ctx, query, args...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// RelinkFileByMetadata matches repair_triggered or corrupted records by metadata and updates them to pending.
+//
+// revalidate controls what happens to records in repair_triggered/corrupted state:
+//   - true (Download events — a re-downloaded copy was just imported): reset the record to
+//     pending with an immediate check so the fresh copy is validated instead of being
+//     destroyed by the next repair re-trigger. retry_count restarts for the new copy, but
+//     repair_retry_count is preserved as the per-title repair budget so repeatedly broken
+//     re-downloads still escalate to corrupted instead of looping forever.
+//   - false (Rename events — no new content): preserve repair/corrupted state so a library
+//     reorganization cannot wipe repair progress.
+func (r *HealthRepository) RelinkFileByMetadata(ctx context.Context, webMeta *model.WebhookMetadata, filePath, libraryPath string, metadataStr *string, revalidate bool) (bool, error) {
+	filePath = strings.TrimPrefix(filePath, "/")
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to start transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, file_path, library_path, status, metadata
+		FROM file_health
+		WHERE status IN ('pending', 'repair_triggered', 'corrupted')
+		  AND metadata IS NOT NULL
+	`)
+	if err != nil {
+		return false, fmt.Errorf("failed to query non-healthy records in transaction: %w", err)
+	}
+	defer rows.Close()
+
+	var matchedIDs []int64
+	for rows.Next() {
+		var id int64
+		var dbFP, dbLP, dbStatus string
+		var dbMetaStr string
+		if err := rows.Scan(&id, &dbFP, &dbLP, &dbStatus, &dbMetaStr); err != nil {
+			continue
+		}
+
+		var dbMeta model.WebhookMetadata
+		if err := json.Unmarshal([]byte(dbMetaStr), &dbMeta); err != nil {
+			continue
+		}
+
+		if r.matchMetadata(&dbMeta, webMeta) {
+			matchedIDs = append(matchedIDs, id)
+		}
+	}
+	rows.Close() // Explicitly close rows to free connection before modifications
+
+	if len(matchedIDs) == 0 {
+		return false, nil
+	}
+
+	// Update each matched record
+	for _, id := range matchedIDs {
+		if err := r.relinkOrMergeRecordTx(ctx, tx, id, filePath, libraryPath, metadataStr, revalidate); err != nil {
+			return false, fmt.Errorf("failed to relink/merge matched record %d: %w", id, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return true, nil
+}
+
+// matchMetadata matches two WebhookMetadata objects by their IDs.
+func (r *HealthRepository) matchMetadata(dbMeta, webMeta *model.WebhookMetadata) bool {
+	if dbMeta == nil || webMeta == nil {
+		return false
+	}
+
+	// 1. Check if both are Movie/Radarr
+	if dbMeta.Movie != nil && webMeta.Movie != nil {
+		if dbMeta.Movie.Id > 0 && webMeta.Movie.Id > 0 && dbMeta.Movie.Id == webMeta.Movie.Id {
+			return true
+		}
+		if dbMeta.Movie.TmdbId > 0 && webMeta.Movie.TmdbId > 0 && dbMeta.Movie.TmdbId == webMeta.Movie.TmdbId {
+			return true
+		}
+	}
+
+	// 2. Check if both are Series/Sonarr
+	if dbMeta.Series != nil && webMeta.Series != nil {
+		seriesMatch := false
+		if dbMeta.Series.Id > 0 && webMeta.Series.Id > 0 && dbMeta.Series.Id == webMeta.Series.Id {
+			seriesMatch = true
+		} else if dbMeta.Series.TvdbId > 0 && webMeta.Series.TvdbId > 0 && dbMeta.Series.TvdbId == webMeta.Series.TvdbId {
+			seriesMatch = true
+		}
+
+		if seriesMatch {
+			// Check if EpisodeFile matches
+			if dbMeta.EpisodeFile != nil && webMeta.EpisodeFile != nil {
+				if dbMeta.EpisodeFile.Id > 0 && webMeta.EpisodeFile.Id > 0 && dbMeta.EpisodeFile.Id == webMeta.EpisodeFile.Id {
+					return true
+				}
+			}
+			// Check if any Episode ID matches
+			if len(dbMeta.Episodes) > 0 && len(webMeta.Episodes) > 0 {
+				for _, dbEp := range dbMeta.Episodes {
+					for _, webEp := range webMeta.Episodes {
+						if dbEp.Id > 0 && webEp.Id > 0 && dbEp.Id == webEp.Id {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// 3. Check if both are Album/Lidarr
+	if dbMeta.Album != nil && webMeta.Album != nil {
+		if dbMeta.Album.Id > 0 && webMeta.Album.Id > 0 && dbMeta.Album.Id == webMeta.Album.Id {
+			return true
+		}
+	}
+
+	// 4. Check if both are Book/Readarr
+	if dbMeta.Book != nil && webMeta.Book != nil {
+		if dbMeta.Book.Id > 0 && webMeta.Book.Id > 0 && dbMeta.Book.Id == webMeta.Book.Id {
+			return true
+		}
+	}
+
+	return false
+}
+

--- a/internal/database/health_repository_test.go
+++ b/internal/database/health_repository_test.go
@@ -3,9 +3,11 @@ package database
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/javi11/altmount/internal/arrs/model"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -312,7 +314,7 @@ func TestRelinkFileByFilename_UpdatesAnyStatus(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, h)
 	assert.Equal(t, libPath, *h.LibraryPath)
-	assert.Equal(t, HealthStatusPending, h.Status, "Status should be reset to pending for re-verification")
+	assert.Equal(t, HealthStatusHealthy, h.Status, "Status should remain healthy under rename semantics")
 
 	// Verify old path is gone (since it was updated)
 	oldH, err := repo.GetFileHealth(ctx, oldPath)
@@ -371,11 +373,12 @@ func TestRelinkFileByFilename_DownloadRevalidatesRepairState(t *testing.T) {
 
 	filePath := "tv/Show.S01E02/Show.S01E02.mkv"
 	future := time.Now().UTC().Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	past := time.Now().UTC().Add(-5 * time.Minute).Format("2006-01-02 15:04:05")
 	_, err := repo.db.ExecContext(ctx, `
 		INSERT INTO file_health (file_path, status, retry_count, repair_retry_count,
-			max_repair_retries, last_error, error_details, scheduled_check_at)
-		VALUES (?, 'repair_triggered', 2, 1, 3, 'missing segments', 'details', ?)
-	`, filePath, future)
+			max_repair_retries, last_error, error_details, scheduled_check_at, updated_at)
+		VALUES (?, 'repair_triggered', 2, 1, 3, 'missing segments', 'details', ?, ?)
+	`, filePath, future, past)
 	require.NoError(t, err)
 
 	before := time.Now().UTC()
@@ -508,7 +511,7 @@ func TestGetUnhealthyFiles_MatchesWindowsLibraryPath(t *testing.T) {
 	past := time.Now().UTC().Add(-1 * time.Hour)
 	_, err := repo.db.ExecContext(ctx, `
 		INSERT INTO file_health (file_path, library_path, status, retry_count, max_retries, scheduled_check_at)
-		VALUES ('tv/Show/Episode.mkv', 'C:\rclone\show-torrents\Show\Season 1\Episode.mkv', 'pending', 0, 3, ?)
+		VALUES ('tv/Show/Episode.mkv', 'C:\\rclone\\show-torrents\\Show\\Season 1\\Episode.mkv', 'pending', 0, 3, ?)
 	`, past)
 	require.NoError(t, err)
 
@@ -517,3 +520,199 @@ func TestGetUnhealthyFiles_MatchesWindowsLibraryPath(t *testing.T) {
 	require.Len(t, files, 1)
 	assert.Equal(t, "tv/Show/Episode.mkv", files[0].FilePath)
 }
+
+func TestRelinkFileByMetadata(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	// 1. Set up a record with status repair_triggered and metadata JSON
+	oldPath := "complete/tv/show.S01E01.mkv"
+	libraryPath := "/mnt/library/tv/show.S01E01.mkv"
+	dbMeta := `{"eventType":"Download","instanceName":"Sonarr","series":{"id":100,"tvdbId":200},"episodeFile":{"id":300},"episodes":[{"id":400}]}`
+
+	err := repo.AddFileToHealthCheckWithMetadata(ctx, oldPath, &libraryPath, 3, 3, nil, HealthPriorityNormal, nil, &dbMeta, nil)
+	require.NoError(t, err)
+
+	// Update its status to repair_triggered
+	err = repo.UpdateFileHealth(ctx, oldPath, HealthStatusRepairTriggered, nil, nil, nil, false)
+	require.NoError(t, err)
+
+	// Back-date updated_at so the 60-second guard doesn't block the reset to pending
+	past := time.Now().UTC().Add(-5 * time.Minute).Format("2006-01-02 15:04:05")
+	_, err = repo.db.ExecContext(ctx, "UPDATE file_health SET updated_at = ? WHERE file_path = ?", past, oldPath)
+	require.NoError(t, err)
+
+	// Verify it's repair_triggered
+	hOld, err := repo.GetFileHealth(ctx, oldPath)
+	require.NoError(t, err)
+	assert.Equal(t, HealthStatusRepairTriggered, hOld.Status)
+
+	// 2. Perform Relink by Metadata
+	newPath := "tv/show/Season 01/show.S01E01.mkv"
+	newLibPath := "/mnt/library/tv/show/Season 01/show.S01E01.mkv"
+	webMeta := model.WebhookMetadata{
+		EventType:    "Download",
+		InstanceName: "Sonarr",
+		Series: &model.SeriesMetadata{
+			Id:     100,
+			TvdbId: 200,
+		},
+		Episodes: []model.EpisodeMetadata{
+			{Id: 400},
+		},
+	}
+	webMetaBytes, err := json.Marshal(webMeta)
+	require.NoError(t, err)
+	webMetaStr := string(webMetaBytes)
+
+	relinked, err := repo.RelinkFileByMetadata(ctx, &webMeta, newPath, newLibPath, &webMetaStr, true)
+	require.NoError(t, err)
+	assert.True(t, relinked, "Should successfully relink by metadata IDs")
+
+	// 3. Verify the old record got updated to the new paths and reset to pending
+	hNew, err := repo.GetFileHealth(ctx, newPath)
+	require.NoError(t, err)
+	require.NotNil(t, hNew)
+	assert.Equal(t, HealthStatusPending, hNew.Status)
+	assert.Equal(t, newLibPath, *hNew.LibraryPath)
+	assert.Equal(t, 0, hNew.RetryCount)
+	assert.Equal(t, 0, hNew.RepairRetryCount)
+
+	// Verify old path is gone
+	oldH, err := repo.GetFileHealth(ctx, oldPath)
+	require.NoError(t, err)
+	assert.Nil(t, oldH)
+}
+
+func TestResetStalePendingFiles_ResetsStuckPending(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	filePath := "movies/stuck.mkv"
+	futureTime := time.Now().UTC().Add(48 * time.Hour).Truncate(time.Second)
+
+	// Add a record scheduled in the distant future with status = 'pending' and retry_count = 0
+	err := repo.UpdateFileHealthScheduled(ctx, filePath, HealthStatusPending, nil, nil, nil, false, futureTime)
+	require.NoError(t, err)
+
+	// Verify it has the future scheduled time
+	hBefore, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, hBefore)
+	assert.Equal(t, HealthStatusPending, hBefore.Status)
+	assert.Equal(t, 0, hBefore.RetryCount)
+	
+	// Now run ResetStalePendingFiles
+	err = repo.ResetStalePendingFiles(ctx)
+	require.NoError(t, err)
+
+	// Verify scheduled_check_at was reset to the present/past
+	hAfter, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, hAfter)
+	
+	got := queryScheduledCheckAt(t, repo, filePath)
+	require.NotNil(t, got)
+	assert.True(t, got.Before(time.Now().UTC().Add(1*time.Minute)), "stuck file scheduled time should be reset to now (got %v)", got)
+}
+
+func TestRelinkFileByMetadata_ConflictMerge(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	// 1. Setup old record with metadata and repair history
+	oldPath := "complete/tv/show.S01E01.mkv"
+	libraryPath := "/mnt/library/tv/show.S01E01.mkv"
+	dbMeta := `{"eventType":"Download","instanceName":"Sonarr","series":{"id":100,"tvdbId":200},"episodeFile":{"id":300},"episodes":[{"id":400}]}`
+	past := time.Now().UTC().Add(-5 * time.Minute).Format("2006-01-02 15:04:05")
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries, metadata, library_path, updated_at)
+		VALUES (?, 'repair_triggered', 2, 3, ?, ?, ?)
+	`, oldPath, dbMeta, libraryPath, past)
+	require.NoError(t, err)
+
+	// 2. Setup conflicting record at the target path
+	newPath := "tv/show/Season 01/show.S01E01.mkv"
+	newLibPath := "/mnt/library/tv/show/Season 01/show.S01E01.mkv"
+	_, err = repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries, metadata, library_path, updated_at)
+		VALUES (?, 'corrupted', 1, 3, ?, ?, ?)
+	`, newPath, dbMeta, newLibPath, past)
+	require.NoError(t, err)
+
+	// 3. Relink
+	webMeta := model.WebhookMetadata{
+		EventType:    "Download",
+		InstanceName: "Sonarr",
+		Series: &model.SeriesMetadata{
+			Id:     100,
+			TvdbId: 200,
+		},
+		Episodes: []model.EpisodeMetadata{
+			{Id: 400},
+		},
+	}
+	webMetaBytes, err := json.Marshal(webMeta)
+	require.NoError(t, err)
+	webMetaStr := string(webMetaBytes)
+
+	relinked, err := repo.RelinkFileByMetadata(ctx, &webMeta, newPath, newLibPath, &webMetaStr, true)
+	require.NoError(t, err)
+	assert.True(t, relinked)
+
+	// 4. Verify conflicting/new record is merged and updated
+	h, err := repo.GetFileHealth(ctx, newPath)
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.Equal(t, HealthStatusPending, h.Status)
+	assert.Equal(t, 2, h.RepairRetryCount, "Should carry over the maximum repair retry count (2)")
+	assert.Equal(t, 0, h.RetryCount)
+
+	// Verify old record is deleted
+	oldH, err := repo.GetFileHealth(ctx, oldPath)
+	require.NoError(t, err)
+	assert.Nil(t, oldH)
+}
+
+func TestRelinkFileByFilename_ConflictMerge(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	fileName := "Matrix.mkv"
+	oldPath := "complete/Matrix.mkv"
+	newPath := "Movies/Matrix/Matrix.mkv"
+	newLibPath := "/lib/Matrix.mkv"
+
+	// 1. Setup old record with repair history
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries)
+		VALUES (?, 'repair_triggered', 3, 3)
+	`, oldPath)
+	require.NoError(t, err)
+
+	// 2. Setup conflicting record at the target path
+	_, err = repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries)
+		VALUES (?, 'healthy', 1, 3)
+	`, newPath)
+	require.NoError(t, err)
+
+	// 3. Relink
+	relinked, err := repo.RelinkFileByFilename(ctx, fileName, newPath, newLibPath, nil, true)
+	require.NoError(t, err)
+	assert.True(t, relinked)
+
+	// 4. Verify record at new path is updated and merged
+	h, err := repo.GetFileHealth(ctx, newPath)
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.Equal(t, HealthStatusPending, h.Status)
+	assert.Equal(t, 3, h.RepairRetryCount, "Should carry over the maximum repair retry count (3)")
+	assert.Equal(t, 0, h.RetryCount)
+
+	// Verify old path is gone
+	oldH, err := repo.GetFileHealth(ctx, oldPath)
+	require.NoError(t, err)
+	assert.Nil(t, oldH)
+}
+

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -22,6 +22,7 @@ import (
 	"github.com/javi11/altmount/internal/progress"
 	"github.com/javi11/altmount/internal/utils"
 	"github.com/sourcegraph/conc/pool"
+	"golang.org/x/sync/singleflight"
 )
 
 // ARRsRepairService abstracts the ARR repair operations needed by HealthWorker.
@@ -80,6 +81,9 @@ type HealthWorker struct {
 	// Statistics
 	stats   WorkerStats
 	statsMu sync.RWMutex
+
+	// Singleflight for metadata discovery
+	discoverySF singleflight.Group
 }
 
 // NewHealthWorker creates a new health worker
@@ -410,33 +414,6 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 
 		sideEffect = func() error {
 			slog.InfoContext(ctx, "File is healthy", "file_path", fh.FilePath)
-
-			// Discovery: If the file is healthy but missing rich metadata (IDs), attempt to discover it now.
-			// This gradually backfills your library as health checks occur.
-			if fh.Metadata == nil || *fh.Metadata == "" {
-				slog.DebugContext(ctx, "Missing metadata for healthy file, attempting discovery", "file_path", fh.FilePath)
-				relativePath := strings.TrimPrefix(fh.FilePath, "complete/")
-				nzbName := ""
-				if fh.SourceNzbPath != nil {
-					nzbName = filepath.Base(*fh.SourceNzbPath)
-				}
-				libPath := ""
-				if fh.LibraryPath != nil {
-					libPath = *fh.LibraryPath
-				}
-				metadata, err := hw.arrsService.DiscoverFileMetadata(ctx, fh.FilePath, relativePath, nzbName, libPath)
-				if err == nil && metadata != nil {
-					metaBytes, err := json.Marshal(metadata)
-					if err == nil {
-						slog.InfoContext(ctx, "Successfully discovered metadata during health check",
-							"file_path", fh.FilePath,
-							"instance", metadata.InstanceName)
-						if err := hw.healthRepo.UpdateFileMetadata(ctx, fh.ID, metaBytes); err != nil {
-							slog.ErrorContext(ctx, "Failed to save discovered metadata", "error", err)
-						}
-					}
-				}
-			}
 
 			return hw.metadataService.UpdateFileStatus(fh.FilePath, metapb.FileStatus_FILE_STATUS_HEALTHY)
 		}
@@ -786,6 +763,8 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 		p.Go(func() {
 			slog.InfoContext(ctx, "Checking unhealthy file", "file_path", fh.FilePath)
 
+			// Proactively discover metadata if missing (IDs first priority)
+			fh.Metadata = hw.ensureMetadata(ctx, fh)
 			// Perform check
 			opts := CheckOptions{}
 			event := hw.healthChecker.CheckFile(ctx, fh.FilePath, opts)
@@ -1137,36 +1116,78 @@ func (hw *HealthWorker) retriggerFileRepair(ctx context.Context, item *database.
 }
 
 func (hw *HealthWorker) ensureMetadata(ctx context.Context, item *database.FileHealth) *string {
-	if item.Metadata != nil && *item.Metadata != "" {
+	needsDiscovery := false
+	if item.Metadata == nil || *item.Metadata == "" {
+		needsDiscovery = true
+	} else {
+		var dbMeta model.WebhookMetadata
+		if err := json.Unmarshal([]byte(*item.Metadata), &dbMeta); err == nil {
+			if dbMeta.Series != nil && len(dbMeta.Episodes) == 0 {
+				needsDiscovery = true
+			}
+		}
+	}
+
+	if !needsDiscovery {
 		return item.Metadata
 	}
 
-	slog.InfoContext(ctx, "Emergency ID discovery: Missing metadata for corrupted file, attempting discovery before repair", "file_path", item.FilePath)
-	relativePath := strings.TrimPrefix(item.FilePath, "complete/")
+	// Build a singleflight key.
+	// If NZB name is known, use that. Otherwise use parent directory of the file path.
 	nzbName := ""
 	if item.SourceNzbPath != nil {
 		nzbName = filepath.Base(*item.SourceNzbPath)
 	}
-	libPath := ""
-	if item.LibraryPath != nil {
-		libPath = *item.LibraryPath
+	sfKey := nzbName
+	if sfKey == "" {
+		sfKey = filepath.Dir(item.FilePath)
 	}
-	metadata, err := hw.arrsService.DiscoverFileMetadata(ctx, item.FilePath, relativePath, nzbName, libPath)
-	if err == nil && metadata != nil {
-		metaBytes, err := json.Marshal(metadata)
-		if err == nil {
-			str := string(metaBytes)
-			slog.InfoContext(ctx, "Successfully discovered metadata during emergency discovery",
-				"file_path", item.FilePath,
-				"instance", metadata.InstanceName)
-			if err := hw.healthRepo.UpdateFileMetadata(ctx, item.ID, metaBytes); err != nil {
-				slog.ErrorContext(ctx, "Failed to save discovered metadata during emergency discovery", "error", err)
+	if sfKey == "" || sfKey == "." {
+		sfKey = item.FilePath
+	}
+
+	res, err, _ := hw.discoverySF.Do(sfKey, func() (interface{}, error) {
+		// Re-read from DB to verify if another concurrent worker finished discovery first
+		latest, err := hw.healthRepo.GetFileHealth(ctx, item.FilePath)
+		if err == nil && latest != nil && latest.Metadata != nil && *latest.Metadata != "" {
+			var dbMeta model.WebhookMetadata
+			if err := json.Unmarshal([]byte(*latest.Metadata), &dbMeta); err == nil {
+				if dbMeta.Series == nil || len(dbMeta.Episodes) > 0 {
+					return latest.Metadata, nil
+				}
 			}
-			return &str
+		}
+
+		slog.DebugContext(ctx, "Missing metadata or episode IDs, attempting discovery during health check", "file_path", item.FilePath, "sf_key", sfKey)
+		relativePath := strings.TrimPrefix(item.FilePath, "complete/")
+		libPath := ""
+		if item.LibraryPath != nil {
+			libPath = *item.LibraryPath
+		}
+		
+		metadata, err := hw.arrsService.DiscoverFileMetadata(ctx, item.FilePath, relativePath, nzbName, libPath)
+		if err == nil && metadata != nil {
+			metaBytes, err := json.Marshal(metadata)
+			if err == nil {
+				str := string(metaBytes)
+				slog.InfoContext(ctx, "Successfully discovered metadata during health check",
+					"file_path", item.FilePath,
+					"instance", metadata.InstanceName)
+				if err := hw.healthRepo.UpdateFileMetadata(ctx, item.ID, metaBytes); err != nil {
+					slog.ErrorContext(ctx, "Failed to save discovered metadata", "error", err)
+				}
+				return &str, nil
+			}
+		}
+		return (*string)(nil), err
+	})
+
+	if err == nil && res != nil {
+		if strPtr, ok := res.(*string); ok {
+			return strPtr
 		}
 	}
 
-	slog.WarnContext(ctx, "Emergency ID discovery failed, falling back to path-based repair", "file_path", item.FilePath)
 	return nil
 }
 

--- a/internal/importer/postprocessor/health_scheduler.go
+++ b/internal/importer/postprocessor/health_scheduler.go
@@ -157,7 +157,6 @@ func isArrImportableMedia(p string) bool {
 	}
 	return arrAudioBookExtensions[strings.ToLower(path.Ext(p))]
 }
-
 // expandWrittenPaths resolves "DIR:"-prefixed entries (whole-directory imports such
 // as RAR/7z archives, which only report their NZB folder) into the per-file virtual
 // paths beneath them by walking the metadata tree. Plain file entries pass through


### PR DESCRIPTION
Implements key stability features for AltMount's health monitoring and file repair pipelines: Overhauls SQLite database UPSERT and relinking logic in health_repository.go to safely merge health records; solves scheduling races and deadlocks in the scheduled repair loop; invalidates cached ARR metadata when receiving import webhooks; and adds performance limits to SABnzbd queue queries.