### PR TITLE
feat(health-queue): allow select all items matching filter and fix backend bulk operations limit

### DIFF
--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -1,3 +1,4 @@
+import { apiClient } from "../api/client";
 import { useQueryClient } from "@tanstack/react-query";
 import { FileCheck, RefreshCw, RotateCcw, Settings, ShieldCheck, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -471,6 +472,40 @@ export function HealthPage() {
 		}
 	};
 
+	const handleSelectAllPages = async () => {
+		if (!meta?.total) return;
+
+		const confirmed = await confirmAction(
+			"Select All Pages",
+			`Are you sure you want to select all ${meta.total} matching items across all pages? This might take a moment to fetch.`,
+			{
+				type: "info",
+				confirmText: "Select All",
+				confirmButtonClass: "btn-info",
+			},
+		);
+
+		if (confirmed) {
+			try {
+				const response = await apiClient.getHealth({
+					limit: meta.total,
+					search: searchTerm || undefined,
+					status: statusFilter || undefined,
+				});
+				if (response.data) {
+					setSelectedItems(new Set(response.data.map((item) => item.file_path)));
+				}
+			} catch (e) {
+				console.error("Failed to fetch all items for select all", e);
+				showToast({
+					title: "Error",
+					message: "Failed to fetch all items",
+					type: "error",
+				});
+			}
+		}
+	};
+
 	const handleBulkDelete = () => {
 		if (selectedItems.size === 0) return;
 		setDeleteModal({ show: true, isBulk: true });
@@ -813,6 +848,7 @@ export function HealthPage() {
 											isUnmaskPending={unmaskItem.isPending}
 											onSelectItem={handleSelectItem}
 											onSelectAll={handleSelectAll}
+											onSelectAllPages={handleSelectAllPages}
 											onSort={handleSort}
 											onCancelCheck={handleCancelCheck}
 											onManualCheck={handleManualCheck}

--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthTable.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthTable.tsx
@@ -22,6 +22,7 @@ interface HealthTableProps {
 	isRegeneratePending?: boolean;
 	onSelectItem: (filePath: string, checked: boolean) => void;
 	onSelectAll: (checked: boolean) => void;
+	onSelectAllPages: () => void;
 	onSort: (column: SortBy) => void;
 	onCancelCheck: (id: number) => void;
 	onManualCheck: (id: number) => void;
@@ -48,6 +49,7 @@ export function HealthTable({
 	isRegeneratePending,
 	onSelectItem,
 	onSelectAll,
+	onSelectAllPages,
 	onSort,
 	onCancelCheck,
 	onManualCheck,
@@ -104,7 +106,9 @@ export function HealthTable({
 									sortBy={sortBy}
 									sortOrder={sortOrder}
 									onSelectAll={onSelectAll}
+									onSelectAllPages={onSelectAllPages}
 									onSort={onSort}
+									allowSelectAllPages={["pending", "checking", "corrupted", "repair_triggered"].includes(statusFilter)}
 								/>
 								<tbody>
 									{data.map((item: FileHealth) => (

--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthTableHeader.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthTableHeader.tsx
@@ -7,7 +7,9 @@ interface HealthTableHeaderProps {
 	sortBy: SortBy;
 	sortOrder: SortOrder;
 	onSelectAll: (checked: boolean) => void;
+	onSelectAllPages: () => void;
 	onSort: (column: SortBy) => void;
+	allowSelectAllPages: boolean;
 }
 
 export function HealthTableHeader({
@@ -16,23 +18,50 @@ export function HealthTableHeader({
 	sortBy,
 	sortOrder,
 	onSelectAll,
+	onSelectAllPages,
 	onSort,
+	allowSelectAllPages,
 }: HealthTableHeaderProps) {
 	return (
 		<thead>
 			<tr>
-				<th className="w-12">
-					<label className="cursor-pointer">
-						<input
-							type="checkbox"
-							className="checkbox"
-							checked={isAllSelected}
-							ref={(input) => {
-								if (input) input.indeterminate = Boolean(isIndeterminate);
-							}}
-							onChange={(e) => onSelectAll(e.target.checked)}
-						/>
-					</label>
+				<th className="w-16">
+					<div className="dropdown">
+						<label tabIndex={0} className="cursor-pointer flex items-center gap-1">
+							<input
+								type="checkbox"
+								className="checkbox checkbox-sm"
+								checked={isAllSelected}
+								ref={(input) => {
+									if (input) input.indeterminate = Boolean(isIndeterminate);
+								}}
+								onChange={(e) => onSelectAll(e.target.checked)}
+							/>
+							<ChevronDown className="h-3 w-3" />
+						</label>
+						<ul
+							tabIndex={0}
+							className="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52"
+						>
+							<li>
+								<button type="button" onClick={() => onSelectAll(true)}>
+									Select all on page
+								</button>
+							</li>
+							{allowSelectAllPages && (
+								<li>
+									<button type="button" onClick={() => onSelectAllPages()}>
+										Select all pages
+									</button>
+								</li>
+							)}
+							<li>
+								<button type="button" onClick={() => onSelectAll(false)}>
+									Clear selection
+								</button>
+							</li>
+						</ul>
+					</div>
 				</th>
 				<th>
 					<button

--- a/frontend/src/pages/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage.tsx
@@ -1,3 +1,4 @@
+import { apiClient } from "../api/client";
 import { useQueryClient } from "@tanstack/react-query";
 import {
 	Activity,
@@ -311,6 +312,40 @@ export function QueuePage() {
 			setSelectedItems(new Set(enrichedQueueData.map((item) => item.id)));
 		} else {
 			setSelectedItems(new Set());
+		}
+	};
+
+	const handleSelectAllPages = async () => {
+		if (!meta?.total) return;
+
+		const confirmed = await confirmAction(
+			"Select All Pages",
+			`Are you sure you want to select all ${meta.total} matching items across all pages? This might take a moment to fetch.`,
+			{
+				type: "info",
+				confirmText: "Select All",
+				confirmButtonClass: "btn-info",
+			},
+		);
+
+		if (confirmed) {
+			try {
+				const response = await apiClient.getQueue({
+					limit: meta.total,
+					search: searchTerm || undefined,
+					status: statusFilter || undefined,
+				});
+				if (response.data) {
+					setSelectedItems(new Set(response.data.map((item) => item.id)));
+				}
+			} catch (e) {
+				console.error("Failed to fetch all items for select all", e);
+				showToast({
+					title: "Error",
+					message: "Failed to fetch all items",
+					type: "error",
+				});
+			}
 		}
 	};
 
@@ -741,16 +776,44 @@ export function QueuePage() {
 												<table className="table-zebra table-sm sm:table-md table">
 													<thead className="bg-base-200/50">
 														<tr>
-															<th className="w-12 text-center">
-																<input
-																	type="checkbox"
-																	className="checkbox checkbox-sm"
-																	checked={isAllSelected}
-																	ref={(input) => {
-																		if (input) input.indeterminate = Boolean(isIndeterminate);
-																	}}
-																	onChange={(e) => handleSelectAll(e.target.checked)}
-																/>
+															<th className="w-16">
+																<div className="dropdown">
+																	<label
+																		tabIndex={0}
+																		className="cursor-pointer flex items-center gap-1"
+																	>
+																		<input
+																			type="checkbox"
+																			className="checkbox checkbox-sm"
+																			checked={isAllSelected}
+																			ref={(input) => {
+																				if (input) input.indeterminate = Boolean(isIndeterminate);
+																			}}
+																			onChange={(e) => handleSelectAll(e.target.checked)}
+																		/>
+																		<ChevronDown className="h-3 w-3" />
+																	</label>
+																	<ul
+																		tabIndex={0}
+																		className="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52"
+																	>
+																		<li>
+																			<button type="button" onClick={() => handleSelectAll(true)}>
+																				Select all on page
+																			</button>
+																		</li>
+																		<li>
+																			<button type="button" onClick={() => handleSelectAllPages()}>
+																				Select all pages
+																			</button>
+																		</li>
+																		<li>
+																			<button type="button" onClick={() => handleSelectAll(false)}>
+																				Clear selection
+																			</button>
+																		</li>
+																	</ul>
+																</div>
 															</th>
 															<th>
 																<button

--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -284,9 +284,6 @@ func (s *Server) handleDeleteHealthBulk(c *fiber.Ctx) error {
 		return RespondValidationError(c, "At least one file path is required", "")
 	}
 
-	if len(req.FilePaths) > 100 {
-		return RespondValidationError(c, "Too many file paths", "Maximum 100 files allowed per bulk operation")
-	}
 
 	metaDeletedCount := 0
 	symlinkDeletedCount := 0
@@ -491,9 +488,6 @@ func (s *Server) handleRepairHealthBulk(c *fiber.Ctx) error {
 		return RespondValidationError(c, "At least one file path is required", "")
 	}
 
-	if len(req.FilePaths) > 100 {
-		return RespondValidationError(c, "Too many file paths", "Maximum 100 files allowed per bulk operation")
-	}
 
 	ctx := c.Context()
 	cfg := s.configManager.GetConfig()
@@ -1025,9 +1019,6 @@ func (s *Server) handleRestartHealthChecksBulk(c *fiber.Ctx) error {
 		return RespondValidationError(c, "At least one file path is required", "")
 	}
 
-	if len(req.FilePaths) > 100 {
-		return RespondValidationError(c, "Too many file paths", "Maximum 100 files allowed per bulk operation")
-	}
 
 	// Cancel any active checks for these files
 	if s.healthWorker != nil {

--- a/internal/api/parsers.go
+++ b/internal/api/parsers.go
@@ -45,7 +45,7 @@ func ParsePaginationFiber(c *fiber.Ctx) Pagination {
 	pagination := DefaultPagination()
 
 	if limitStr := c.Query("limit"); limitStr != "" {
-		if limit, err := strconv.Atoi(limitStr); err == nil && limit > 0 && limit <= 1000 {
+		if limit, err := strconv.Atoi(limitStr); err == nil && limit > 0 && limit <= 100000 {
 			pagination.Limit = limit
 		}
 	}


### PR DESCRIPTION
### Summary
Implements a "Select All" functionality on the Health and Queue UI pages to allow bulk operations on all filtered items, and removes/fixes backend bulk limitations.

### Detailed Changes
1. **Frontend "Select All" UI**: Added support to select all items matching the current search filter in both `HealthPage.tsx` and `QueuePage.tsx` instead of only selecting visible items on the current page.
2. **Bulk Action Support**: Updated the health table header and queue components to support triggering actions on the entire selection.
3. **Backend Bulk Limit Fix**: Corrected backend limits on bulk operations in `internal/api` to accommodate large numbers of selected files.