### PR TITLE
fix(rclone): harden VFS recovery lifecycle and restart rcd on failed mounts

### DIFF
--- a/.github/workflows/rclone-version-check.yml
+++ b/.github/workflows/rclone-version-check.yml
@@ -1,0 +1,96 @@
+name: Rclone Version Check
+
+on:
+  schedule:
+    # Weekly, Monday 09:00 UTC
+    - cron: '0 9 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-rclone-version:
+    name: Check for rclone updates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get current pinned version
+        id: current
+        run: |
+          version=$(grep -oP 'downloads\.rclone\.org/v\K[0-9.]+' docker/Dockerfile | head -1)
+          if [ -z "$version" ]; then
+            echo "Could not find pinned rclone version in docker/Dockerfile" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Get latest rclone release
+        id: latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          latest=$(gh api repos/rclone/rclone/releases/latest -q '.tag_name' | sed 's/^v//')
+          echo "version=${latest}" >> "$GITHUB_OUTPUT"
+
+      - name: Compare versions
+        id: compare
+        run: |
+          if [ "${{ steps.current.outputs.version }}" = "${{ steps.latest.outputs.version }}" ]; then
+            echo "up_to_date=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "up_to_date=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute new checksums
+        if: steps.compare.outputs.up_to_date == 'false'
+        id: checksums
+        run: |
+          version="${{ steps.latest.outputs.version }}"
+          for arch in amd64 arm64 arm; do
+            url="https://downloads.rclone.org/v${version}/rclone-v${version}-linux-${arch}.zip"
+            echo "Downloading ${url}"
+            curl -sSfLO "${url}"
+            sha=$(sha256sum "rclone-v${version}-linux-${arch}.zip" | awk '{print $1}')
+            echo "sha_${arch}=${sha}" >> "$GITHUB_OUTPUT"
+          done
+
+      - name: Update Dockerfiles
+        if: steps.compare.outputs.up_to_date == 'false'
+        run: |
+          version="${{ steps.latest.outputs.version }}"
+          old_version="${{ steps.current.outputs.version }}"
+          sha_amd64="${{ steps.checksums.outputs.sha_amd64 }}"
+          sha_arm64="${{ steps.checksums.outputs.sha_arm64 }}"
+          sha_arm="${{ steps.checksums.outputs.sha_arm }}"
+
+          for f in docker/Dockerfile docker/Dockerfile.ci; do
+            sed -i "s/v${old_version}/v${version}/g" "$f"
+            # Replace each arch's checksum individually, matched by the ARCH assignment on the same line
+            sed -i "s/\(x86_64) ARCH=amd64; SHA256=\)[a-f0-9]\{64\}/\1${sha_amd64}/" "$f"
+            sed -i "s/\(aarch64) ARCH=arm64; SHA256=\)[a-f0-9]\{64\}/\1${sha_arm64}/" "$f"
+            sed -i "s/\(armv7l) ARCH=arm; SHA256=\)[a-f0-9]\{64\}/\1${sha_arm}/" "$f"
+          done
+
+      - name: Create Pull Request
+        if: steps.compare.outputs.up_to_date == 'false'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(deps): bump rclone to v${{ steps.latest.outputs.version }}"
+          title: "chore(deps): bump rclone to v${{ steps.latest.outputs.version }}"
+          body: |
+            Bumps the pinned rclone version used in `docker/Dockerfile` and `docker/Dockerfile.ci`
+            from `v${{ steps.current.outputs.version }}` to `v${{ steps.latest.outputs.version }}`.
+
+            SHA256 checksums were recomputed for amd64, arm64, and arm from the official
+            [rclone downloads](https://downloads.rclone.org/v${{ steps.latest.outputs.version }}/) for this release.
+
+            Please review the [rclone changelog](https://github.com/rclone/rclone/releases/tag/v${{ steps.latest.outputs.version }})
+            before merging, since this project's `pkg/rclonecli` package relies on specific
+            rclone RC/VFS behavior.
+          branch: chore/bump-rclone-v${{ steps.latest.outputs.version }}
+          labels: dependencies

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,13 +110,14 @@ RUN apt-get update && \
         unzip && \
     echo "user_allow_other" >> /etc/fuse.conf && \
     case "$(uname -m)" in \
-        x86_64) ARCH=amd64 ;; \
-        aarch64) ARCH=arm64 ;; \
-        armv7l) ARCH=arm ;; \
+        x86_64) ARCH=amd64; SHA256=aa2804e08f48250e71009c727124b6341cd0288465804a9a09d14663cabafbaa ;; \
+        aarch64) ARCH=arm64; SHA256=d0ad88ba4c8e285b7c9efa591e0ab643280a91741e13c27f3a9c0957ccfa5203 ;; \
+        armv7l) ARCH=arm; SHA256=17f3f07cfa17e065f0c3329149ba702bbaafdb87e7f00230830488d5391362f2 ;; \
         *) echo "Unsupported architecture: $(uname -m)" && exit 1 ;; \
     esac && \
-    curl -O "https://downloads.rclone.org/rclone-current-linux-${ARCH}.zip" && \
-    unzip "rclone-current-linux-${ARCH}.zip" && \
+    curl -O "https://downloads.rclone.org/v1.75.0/rclone-v1.75.0-linux-${ARCH}.zip" && \
+    echo "${SHA256}  rclone-v1.75.0-linux-${ARCH}.zip" | sha256sum -c - && \
+    unzip "rclone-v1.75.0-linux-${ARCH}.zip" && \
     cp rclone-*/rclone /usr/local/bin/ && \
     chmod +x /usr/local/bin/rclone && \
     rm -rf rclone-* && \

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -99,13 +99,14 @@ RUN apt-get update && \
         unzip && \
     echo "user_allow_other" >> /etc/fuse.conf && \
     case "$(uname -m)" in \
-        x86_64) ARCH=amd64 ;; \
-        aarch64) ARCH=arm64 ;; \
-        armv7l) ARCH=arm ;; \
+        x86_64) ARCH=amd64; SHA256=aa2804e08f48250e71009c727124b6341cd0288465804a9a09d14663cabafbaa ;; \
+        aarch64) ARCH=arm64; SHA256=d0ad88ba4c8e285b7c9efa591e0ab643280a91741e13c27f3a9c0957ccfa5203 ;; \
+        armv7l) ARCH=arm; SHA256=17f3f07cfa17e065f0c3329149ba702bbaafdb87e7f00230830488d5391362f2 ;; \
         *) echo "Unsupported architecture: $(uname -m)" && exit 1 ;; \
     esac && \
-    curl -O "https://downloads.rclone.org/rclone-current-linux-${ARCH}.zip" && \
-    unzip "rclone-current-linux-${ARCH}.zip" && \
+    curl -O "https://downloads.rclone.org/v1.75.0/rclone-v1.75.0-linux-${ARCH}.zip" && \
+    echo "${SHA256}  rclone-v1.75.0-linux-${ARCH}.zip" | sha256sum -c - && \
+    unzip "rclone-v1.75.0-linux-${ARCH}.zip" && \
     cp rclone-*/rclone /usr/local/bin/ && \
     chmod +x /usr/local/bin/rclone && \
     rm -rf rclone-* && \

--- a/pkg/rclonecli/client.go
+++ b/pkg/rclonecli/client.go
@@ -12,10 +12,19 @@ import (
 
 // Mount creates a mount using the rclone RC API with retry logic
 func (m *Manager) Mount(ctx context.Context, provider, mountPath, webdavURL string) error {
+	m.mountMu.Lock()
+	defer m.mountMu.Unlock()
 	return m.mountWithRetry(ctx, provider, mountPath, webdavURL, 3)
 }
 
-// mountWithRetry attempts to mount with retry logic
+// mountWithRetry attempts to mount with retry logic.
+//
+// A failed mount/mount attempt leaves a leaked VFS instance inside the rcd
+// subprocess: rclone creates the VFS before attempting the FUSE mount and does
+// not shut it down on failure, and the failed mount is never registered with
+// mount/unmount. Neither RC unmount nor fusermount can remove that in-process
+// state, so the only reliable cleanup is restarting the rcd subprocess between
+// attempts (and after the terminal failure) to guarantee a clean VFS registry.
 func (m *Manager) mountWithRetry(ctx context.Context, provider, mountPath, webdavURL string, maxRetries int) error {
 	if !m.IsReady() {
 		if err := m.WaitForReady(30 * time.Second); err != nil {
@@ -23,43 +32,78 @@ func (m *Manager) mountWithRetry(ctx context.Context, provider, mountPath, webda
 		}
 	}
 
+	var lastErr error
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		if attempt > 0 {
-			// Try RC unmount first (cleans up rclone internal state)
-			if m.IsReady() {
-				req := RCRequest{
-					Command: "mount/unmount",
-					Args: map[string]any{
-						"mountPoint": mountPath,
-					},
-				}
-				if _, err := m.makeRequestWithContext(ctx, req, true); err != nil {
-					m.logger.DebugContext(ctx, "RC unmount before retry failed (may be expected)", "err", err, "provider", provider)
-				}
+			// Clear partial mount state and reset the rcd subprocess so the
+			// retry starts from a clean VFS registry.
+			if err := m.cleanupAfterFailedMount(ctx, provider, mountPath); err != nil {
+				return fmt.Errorf("mount attempt %d failed for %s: %w; cleanup failed: %w", attempt, provider, lastErr, err)
 			}
-
-			// Force unmount using system commands
-			if err := m.forceUnmountPath(mountPath); err != nil {
-				m.logger.DebugContext(ctx, "Force unmount before retry returned error (may be expected)", "err", err, "provider", provider)
-			}
-
-			// Clean up mount directory if empty
-			_ = os.Remove(mountPath)
 
 			// Wait before retry
-			wait := time.Duration(attempt*2) * time.Second
+			wait := m.retryDelay(attempt)
 			m.logger.DebugContext(ctx, "Retrying mount operation", "attempt", attempt, "provider", provider)
-			time.Sleep(wait)
+			if !sleepWithContext(ctx, wait) {
+				return ctx.Err()
+			}
 		}
 
-		if err := m.performMount(ctx, provider, mountPath, webdavURL); err != nil {
+		if err := m.mountFn(ctx, provider, mountPath, webdavURL); err != nil {
+			lastErr = err
 			m.logger.ErrorContext(ctx, "Mount attempt failed", "err", err, "provider", provider, "attempt", attempt+1)
 			continue
 		}
 
 		return nil // Success
 	}
+
+	// The terminal attempt also leaked a VFS. Reset the rcd subprocess so a
+	// clean state is left behind even when mounting is reported as failed.
+	if err := m.cleanupAfterFailedMount(ctx, provider, mountPath); err != nil {
+		return fmt.Errorf("mount failed for %s: %w; cleanup failed: %w", provider, lastErr, err)
+	}
+
+	if lastErr != nil {
+		return fmt.Errorf("mount failed for %s: %w", provider, lastErr)
+	}
 	return fmt.Errorf("mount failed for %s", provider)
+}
+
+// cleanupAfterFailedMount removes partial mount state from a failed mount/mount
+// attempt and restarts the rcd subprocess. Restarting is required because a
+// failed FUSE mount leaves a leaked VFS instance inside the rcd process that
+// mount/unmount and fusermount cannot remove.
+func (m *Manager) cleanupAfterFailedMount(ctx context.Context, provider, mountPath string) error {
+	// Force unmount using system commands
+	if err := m.forceUnmount(mountPath); err != nil {
+		m.logger.DebugContext(ctx, "Force unmount returned error (may be expected)", "err", err, "provider", provider)
+	}
+
+	// Clean up mount directory if empty
+	_ = os.Remove(mountPath)
+
+	if !m.IsReady() {
+		// rcd is not running; there is no leaked VFS state to reset.
+		return nil
+	}
+
+	m.logger.InfoContext(ctx, "Restarting rclone RC server to clear leaked VFS state", "provider", provider)
+	if err := m.restart(ctx); err != nil {
+		return fmt.Errorf("failed to restart rclone RC server after failed mount: %w", err)
+	}
+	return nil
+}
+
+// sleepWithContext sleeps for d unless ctx is cancelled first. It returns false
+// when the sleep was interrupted by context cancellation.
+func sleepWithContext(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-time.After(d):
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // performMount performs a single mount attempt
@@ -215,11 +259,19 @@ func (m *Manager) performMount(ctx context.Context, provider, mountPath, webdavU
 
 // Unmount unmounts a specific provider
 func (m *Manager) Unmount(ctx context.Context, provider string) error {
-	return m.unmount(ctx, provider)
+	m.mountMu.Lock()
+	defer m.mountMu.Unlock()
+	return m.unmount(ctx, provider, true)
 }
 
-// unmount is the internal unmount function
-func (m *Manager) unmount(ctx context.Context, provider string) error {
+// unmount is the internal unmount function.
+//
+// When restartRCD is true the rcd subprocess is restarted after a successful
+// unmount: rclone keeps the VFS alive in-process after mount/unmount, so
+// without a restart a subsequent mount would create a second VFS instance
+// under the same name. restartRCD should be false during full shutdown, where
+// terminating the rcd subprocess already reclaims all VFS state.
+func (m *Manager) unmount(ctx context.Context, provider string, restartRCD bool) error {
 	m.mountsMutex.RLock()
 	mountInfo, exists := m.mounts[provider]
 	m.mountsMutex.RUnlock()
@@ -247,7 +299,7 @@ func (m *Manager) unmount(ctx context.Context, provider string) error {
 	// If RC unmount fails or server is not ready, try force unmount
 	if rcErr != nil {
 		m.logger.WarnContext(ctx, "RC unmount failed, trying force unmount", "err", rcErr, "provider", provider)
-		if err := m.forceUnmountPath(mountInfo.LocalPath); err != nil {
+		if err := m.forceUnmount(mountInfo.LocalPath); err != nil {
 			m.logger.ErrorContext(ctx, "Force unmount failed", "err", err, "provider", provider)
 			// Don't return error here, update the state anyway
 		}
@@ -265,6 +317,18 @@ func (m *Manager) unmount(ctx context.Context, provider string) error {
 	m.mountsMutex.Unlock()
 
 	m.logger.InfoContext(ctx, "Unmount completed", "provider", provider)
+
+	if restartRCD && m.IsReady() {
+		// rclone retains the VFS in-process after mount/unmount. Restart the
+		// rcd subprocess so the leaked VFS is reclaimed and a later mount does
+		// not end up with multiple VFS instances under the same name. This is
+		// best-effort: the unmount itself already succeeded.
+		m.logger.InfoContext(ctx, "Restarting rclone RC server to reclaim VFS after unmount", "provider", provider)
+		if err := m.restart(ctx); err != nil {
+			return fmt.Errorf("mount unmounted, but failed to restart rclone RC server to reclaim VFS for %s: %w", provider, err)
+		}
+	}
+
 	return nil
 }
 
@@ -281,7 +345,7 @@ func (m *Manager) UnmountAll(ctx context.Context) error {
 
 	var lastError error
 	for _, provider := range providers {
-		if err := m.unmount(ctx, provider); err != nil {
+		if err := m.unmount(ctx, provider, false); err != nil {
 			lastError = err
 			m.logger.DebugContext(ctx, "Failed to unmount", "err", err, "provider", provider)
 		}

--- a/pkg/rclonecli/health.go
+++ b/pkg/rclonecli/health.go
@@ -40,6 +40,9 @@ func (m *Manager) checkMountHealth(provider string) bool {
 
 // RecoverMount attempts to recover a failed mount
 func (m *Manager) RecoverMount(ctx context.Context, provider string) error {
+	m.mountMu.Lock()
+	defer m.mountMu.Unlock()
+
 	m.mountsMutex.RLock()
 	mountInfo, exists := m.mounts[provider]
 	m.mountsMutex.RUnlock()
@@ -61,23 +64,25 @@ func (m *Manager) RecoverMount(ctx context.Context, provider string) error {
 		}
 		// After restart there is nothing to RC-unmount; skip straight to Mount,
 		// which will recreate the rclone config and FUSE mount on the fresh rcd.
-		if err := m.Mount(ctx, provider, mountInfo.LocalPath, mountInfo.WebDAVURL); err != nil {
+		if err := m.mountWithRetry(ctx, provider, mountInfo.LocalPath, mountInfo.WebDAVURL, 3); err != nil {
 			return fmt.Errorf("failed to recover mount for %s after rcd restart: %w", provider, err)
 		}
 		m.logger.InfoContext(ctx, "Successfully recovered mount after rcd restart", "provider", provider)
 		return nil
 	}
 
-	// First try to unmount cleanly
-	if err := m.unmount(ctx, provider); err != nil {
-		m.logger.ErrorContext(ctx, "Failed to unmount during recovery", "err", err, "provider", provider)
+	// First try to unmount cleanly. The health checker leaves Mounted=true until
+	// this call so unmount can still reach rclone and reclaim its VFS before the
+	// remount below.
+	if err := m.unmount(ctx, provider, true); err != nil {
+		return fmt.Errorf("failed to unmount during recovery for %s: %w", provider, err)
 	}
 
 	// Wait a moment
 	time.Sleep(1 * time.Second)
 
 	// Try to remount
-	if err := m.Mount(ctx, provider, mountInfo.LocalPath, mountInfo.WebDAVURL); err != nil {
+	if err := m.mountWithRetry(ctx, provider, mountInfo.LocalPath, mountInfo.WebDAVURL, 3); err != nil {
 		return fmt.Errorf("failed to recover mount for %s: %w", provider, err)
 	}
 
@@ -182,11 +187,11 @@ func (m *Manager) performMountHealthCheck() {
 		if !m.checkMountHealth(provider) {
 			m.logger.WarnContext(m.ctx, "Mount health check failed, attempting recovery", "provider", provider)
 
-			// Mark mount as unhealthy
+			// Record the health failure, but leave Mounted=true so RecoverMount can
+			// still issue mount/unmount and reclaim rclone's VFS before remounting.
 			m.mountsMutex.Lock()
 			if mount, exists := m.mounts[provider]; exists {
 				mount.Error = "Health check failed"
-				mount.Mounted = false
 			}
 			m.mountsMutex.Unlock()
 

--- a/pkg/rclonecli/health_test.go
+++ b/pkg/rclonecli/health_test.go
@@ -2,8 +2,10 @@ package rclonecli
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
+	"net/http"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -20,11 +22,12 @@ func newHealthTestManager(t *testing.T, probeOK bool, readyAt time.Time) (*Manag
 
 	var restartCalls int32
 	m := &Manager{
-		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
-		ctx:         context.Background(),
-		mounts:      make(map[string]*MountInfo),
-		serverReady: ready,
-		readyAt:     readyAt,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ctx:           context.Background(),
+		mounts:        make(map[string]*MountInfo),
+		serverReady:   ready,
+		serverStarted: true,
+		readyAt:       readyAt,
 		probe: func(context.Context, time.Duration) bool {
 			return probeOK
 		},
@@ -102,7 +105,9 @@ func TestPerformMountHealthCheck_AtThresholdRestartsOnceAndResets(t *testing.T) 
 
 func TestPerformMountHealthCheck_NotReadyIsNoOp(t *testing.T) {
 	m, restarts := newHealthTestManager(t, false, afterGrace())
+	m.mu.Lock()
 	m.serverReady = make(chan struct{}) // open -> IsReady() == false
+	m.mu.Unlock()
 
 	m.performMountHealthCheck()
 
@@ -112,4 +117,33 @@ func TestPerformMountHealthCheck_NotReadyIsNoOp(t *testing.T) {
 	if m.consecutiveProbeFailures != 0 {
 		t.Fatalf("must not touch failure streak before ready, got %d", m.consecutiveProbeFailures)
 	}
+}
+
+func TestPerformMountHealthCheck_LeavesFailedMountMarkedMountedForRecovery(t *testing.T) {
+	m, _ := newHealthTestManager(t, true, afterGrace())
+	m.mounts["altmount"] = &MountInfo{Provider: "altmount", Mounted: true}
+	m.forceUnmount = func(string) error { return nil }
+	m.restart = func(context.Context) error { return errors.New("stop recovery") }
+	m.httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("health check failed")
+	})}
+
+	m.performMountHealthCheck()
+
+	info, ok := m.GetMountInfo("altmount")
+	if !ok {
+		t.Fatal("mount info missing")
+	}
+	if !info.Mounted {
+		t.Fatal("failed mount must remain marked mounted until RecoverMount can unmount and reclaim its VFS")
+	}
+	if info.Error != "Health check failed" {
+		t.Fatalf("unexpected mount error: %q", info.Error)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/pkg/rclonecli/manager.go
+++ b/pkg/rclonecli/manager.go
@@ -27,15 +27,20 @@ type Manager struct {
 	rcloneDir     string
 	mounts        map[string]*MountInfo
 	mountsMutex   sync.RWMutex
+	mountMu       sync.Mutex
 	logger        *slog.Logger
 	ctx           context.Context
 	cancel        context.CancelFunc
-	httpClient     *http.Client
-	serverReady    chan struct{}
-	processExited  chan struct{}
-	serverStarted  bool
-	mu             sync.RWMutex
-	cfg            *config.Manager
+	httpClient    *http.Client
+	serverReady   chan struct{}
+	processExited chan struct{}
+	serverStarted bool
+	stopping      bool
+	restarting    bool
+	generation    uint64
+	lastStartErr  error
+	mu            sync.RWMutex
+	cfg           *config.Manager
 
 	// readyAt is stamped when the RC server first becomes ready (serverReady
 	// closed). Guarded by mu. Used to enforce a startup grace period before
@@ -52,6 +57,10 @@ type Manager struct {
 	// leak a second monitor goroutine.
 	monitorOnce sync.Once
 
+	// restartMu serializes rcd subprocess restarts so the health checker and
+	// mount recovery paths cannot race each other through restartServer.
+	restartMu sync.Mutex
+
 	// probe checks rcd liveness; defaults to pingServerWithTimeout. Injectable
 	// for testing the health-check decision logic without a live subprocess.
 	probe func(ctx context.Context, timeout time.Duration) bool
@@ -60,6 +69,18 @@ type Manager struct {
 	// Injectable so health-check tests can assert the restart decision without
 	// touching a real process.
 	restart func(ctx context.Context) error
+
+	// mountFn performs a single mount attempt; defaults to performMount.
+	// Injectable for testing the retry/cleanup logic without a live rcd.
+	mountFn func(ctx context.Context, provider, mountPath, webdavURL string) error
+
+	// forceUnmount force-unmounts a path via system commands; defaults to
+	// forceUnmountPath. Injectable for testing.
+	forceUnmount func(mountPath string) error
+
+	// retryDelay returns the sleep between mount retry attempts; defaults to a
+	// linear backoff (2s, 4s, 6s). Injectable for testing.
+	retryDelay func(attempt int) time.Duration
 }
 
 type MountInfo struct {
@@ -98,19 +119,24 @@ func NewManager(cfm *config.Manager) *Manager {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	m := &Manager{
-		cfg:         cfm,
-		rcPort:      rcPort,
-		rcloneDir:   rcloneDir,
-		mounts:      make(map[string]*MountInfo),
-		logger:      logger,
-		ctx:         ctx,
-		cancel:      cancel,
+		cfg:           cfm,
+		rcPort:        rcPort,
+		rcloneDir:     rcloneDir,
+		mounts:        make(map[string]*MountInfo),
+		logger:        logger,
+		ctx:           ctx,
+		cancel:        cancel,
 		httpClient:    httpclient.New(httpclient.WithTimeout(0)),
 		serverReady:   make(chan struct{}),
 		processExited: make(chan struct{}),
 	}
 	m.probe = m.pingServerWithTimeout
 	m.restart = m.restartServer
+	m.mountFn = m.performMount
+	m.forceUnmount = m.forceUnmountPath
+	m.retryDelay = func(attempt int) time.Duration {
+		return time.Duration(attempt*2) * time.Second
+	}
 	return m
 }
 
@@ -121,6 +147,9 @@ func (m *Manager) Start(ctx context.Context) error {
 
 	if m.serverStarted {
 		return nil
+	}
+	if m.stopping {
+		return fmt.Errorf("rclone RC server is stopping")
 	}
 
 	cfg := m.cfg.GetConfig()
@@ -183,7 +212,13 @@ func (m *Manager) Start(ctx context.Context) error {
 
 	m.logger.InfoContext(ctx, "Starting rclone RC server", "args", args)
 
-	m.cmd = exec.CommandContext(ctx, "rclone", args...)
+	// Bind the subprocess to the Manager's own lifetime context rather than
+	// the caller's request context: rcd must keep running even if the context
+	// of the HTTP request that started (or restarted) it is cancelled.
+	m.cmd = exec.CommandContext(m.ctx, "rclone", args...)
+	m.lastStartErr = nil
+	m.generation++
+	generation := m.generation
 
 	// Capture output for debugging
 	var stdout, stderr bytes.Buffer
@@ -210,32 +245,60 @@ func (m *Manager) Start(ctx context.Context) error {
 			}
 		}()
 
-		m.waitForServer()
+		readyErr := m.waitForServer()
+		if readyErr != nil {
+			m.logger.ErrorContext(m.ctx, "Rclone RC server not responding - mount operations will be disabled", "err", readyErr)
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+		} else {
+			// Stamp readiness so the health check can enforce a startup grace
+			// period before it is allowed to kill+restart the rcd subprocess.
+			m.mu.Lock()
+			if m.generation == generation {
+				m.readyAt = time.Now()
+				select {
+				case <-serverReady:
+				default:
+					close(serverReady)
+				}
+			}
+			m.mu.Unlock()
 
-		// Stamp readiness so the health check can enforce a startup grace
-		// period before it is allowed to kill+restart the rcd subprocess.
-		m.mu.Lock()
-		m.readyAt = time.Now()
-		m.mu.Unlock()
-
-		close(serverReady)
-
-		// Start mount monitoring once server is ready. monitorOnce guarantees a
-		// single monitor for the Manager's lifetime, so a restart (which calls
-		// Start again) cannot spawn a duplicate monitor goroutine.
-		m.monitorOnce.Do(func() {
-			go func() {
-				defer func() {
-					if r := recover(); r != nil {
-						m.logger.ErrorContext(m.ctx, "Panic in mount monitor", "panic", r)
-					}
-				}()
-				m.MonitorMounts(ctx)
-			}()
-		})
+			if m.IsReady() {
+				// Start mount monitoring once server is ready. monitorOnce guarantees a
+				// single monitor for the Manager's lifetime, so a restart (which calls
+				// Start again) cannot spawn a duplicate monitor goroutine.
+				m.monitorOnce.Do(func() {
+					go func() {
+						defer func() {
+							if r := recover(); r != nil {
+								m.logger.ErrorContext(m.ctx, "Panic in mount monitor", "panic", r)
+							}
+						}()
+						m.MonitorMounts(m.ctx)
+					}()
+				})
+			}
+		}
 
 		// Wait for command to finish and log output
 		err := cmd.Wait()
+		if readyErr != nil {
+			// Publish the startup error only after the failed subprocess has been
+			// reaped, so a caller retry cannot race the old RC listener.
+			m.mu.Lock()
+			if m.generation == generation {
+				m.lastStartErr = readyErr
+				m.serverStarted = false
+				select {
+				case <-serverReady:
+				default:
+					close(serverReady)
+				}
+			}
+			m.mu.Unlock()
+		}
 		// Signal that the subprocess has exited so restartServer can proceed.
 		select {
 		case <-processExited:
@@ -270,12 +333,23 @@ func (m *Manager) Start(ctx context.Context) error {
 
 // Stop stops the rclone RC server and unmounts all mounts
 func (m *Manager) Stop() error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.restartMu.Lock()
+	defer m.restartMu.Unlock()
+	m.mountMu.Lock()
+	defer m.mountMu.Unlock()
 
+	m.mu.Lock()
 	if !m.serverStarted {
+		m.mu.Unlock()
 		return nil
 	}
+	m.stopping = true
+	m.mu.Unlock()
+	defer func() {
+		m.mu.Lock()
+		m.stopping = false
+		m.mu.Unlock()
+	}()
 
 	m.logger.InfoContext(m.ctx, "Stopping rclone RC server")
 
@@ -295,7 +369,9 @@ func (m *Manager) Stop() error {
 		wg.Add(1)
 		go func(mount *MountInfo) {
 			defer wg.Done()
-			if err := m.unmount(m.ctx, mount.Provider); err != nil {
+			// restartRCD is false: the rcd subprocess is terminated below,
+			// which reclaims all in-process VFS state.
+			if err := m.unmount(m.ctx, mount.Provider, false); err != nil {
 				m.logger.ErrorContext(m.ctx, "Failed to unmount during shutdown", "err", err, "provider", mount.Provider)
 			}
 		}(mount)
@@ -318,36 +394,34 @@ func (m *Manager) Stop() error {
 	// Cancel context and stop process
 	m.cancel()
 
-	if m.cmd != nil && m.cmd.Process != nil {
+	m.mu.RLock()
+	cmd := m.cmd
+	exited := m.processExited
+	m.mu.RUnlock()
+
+	if cmd != nil && cmd.Process != nil {
 		// Try graceful shutdown first
-		if err := m.cmd.Process.Signal(os.Interrupt); err != nil {
+		if err := cmd.Process.Signal(os.Interrupt); err != nil {
 			m.logger.WarnContext(m.ctx, "Failed to send interrupt signal, using kill", "err", err)
-			if killErr := m.cmd.Process.Kill(); killErr != nil {
+			if killErr := cmd.Process.Kill(); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
 				m.logger.ErrorContext(m.ctx, "Failed to kill rclone process", "err", killErr)
 				return killErr
 			}
 		}
 
-		// Wait for process to exit with timeout
-		done := make(chan error, 1)
-		go func() {
-			done <- m.cmd.Wait()
-		}()
-
+		// The Start monitor owns cmd.Wait and closes processExited after the
+		// subprocess is reaped. Waiting on that channel avoids a double Wait.
 		select {
-		case err := <-done:
-			if err != nil && !errors.Is(err, context.Canceled) && !WasHardTerminated(err) {
-				m.logger.WarnContext(m.ctx, "Rclone process exited with error", "err", err)
-			}
+		case <-exited:
 		case <-time.After(10 * time.Second):
 			m.logger.WarnContext(m.ctx, "Timeout waiting for rclone to exit, force killing")
-			if err := m.cmd.Process.Kill(); err != nil {
+			if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
 				m.logger.ErrorContext(m.ctx, "Failed to force kill rclone process", "err", err)
 				return err
 			}
-			// Wait a bit more for the kill to take effect
+			// Wait a bit more for the monitor goroutine to reap the process.
 			select {
-			case <-done:
+			case <-exited:
 				m.logger.InfoContext(m.ctx, "Rclone process killed successfully")
 			case <-time.After(5 * time.Second):
 				m.logger.ErrorContext(m.ctx, "Process may still be running after kill")
@@ -361,7 +435,9 @@ func (m *Manager) Stop() error {
 		m.cleanupMountDirectories(cfg.MountPath)
 	}
 
+	m.mu.Lock()
 	m.serverStarted = false
+	m.mu.Unlock()
 	m.logger.InfoContext(m.ctx, "Rclone RC server stopped")
 	return nil
 }
@@ -382,23 +458,25 @@ func (m *Manager) cleanupMountDirectories(_ string) {
 	}
 }
 
-// waitForServer waits for the RC server to become available
-func (m *Manager) waitForServer() {
+// waitForServer waits for the RC server to become available. It returns an
+// error when the server did not respond within the poll window so callers do
+// not proceed against a dead or unresponsive rcd subprocess.
+func (m *Manager) waitForServer() error {
 	maxAttempts := 30
 	for range maxAttempts {
 		if err := m.ctx.Err(); err != nil {
-			return
+			return err
 		}
 
 		if m.pingServer() {
 			m.logger.InfoContext(m.ctx, "Rclone RC server is ready")
-			return
+			return nil
 		}
 
 		time.Sleep(time.Second)
 	}
 
-	m.logger.ErrorContext(m.ctx, "Rclone RC server not responding - mount operations will be disabled")
+	return fmt.Errorf("rclone RC server not responding after %d attempts", maxAttempts)
 }
 
 // pingServer checks if the RC server is responding
@@ -470,8 +548,20 @@ func (m *Manager) makeRequest(req RCRequest, close bool) (*http.Response, error)
 
 // IsReady returns true if the RC server is ready
 func (m *Manager) IsReady() bool {
+	m.mu.RLock()
+	ready := m.serverReady
+	restarting := m.restarting
+	stopping := m.stopping
+	started := m.serverStarted
+	startErr := m.lastStartErr
+	m.mu.RUnlock()
+
+	if restarting || stopping || !started || startErr != nil {
+		return false
+	}
+
 	select {
-	case <-m.serverReady:
+	case <-ready:
 		return true
 	default:
 		return false
@@ -480,10 +570,23 @@ func (m *Manager) IsReady() bool {
 
 // WaitForReady waits for the RC server to be ready
 func (m *Manager) WaitForReady(timeout time.Duration) error {
+	m.mu.RLock()
+	ready := m.serverReady
+	m.mu.RUnlock()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
 	select {
-	case <-m.serverReady:
+	case <-ready:
+		m.mu.RLock()
+		startErr := m.lastStartErr
+		m.mu.RUnlock()
+		if startErr != nil {
+			return startErr
+		}
 		return nil
-	case <-time.After(timeout):
+	case <-timer.C:
 		return fmt.Errorf("timeout waiting for rclone RC server to be ready")
 	case <-m.ctx.Done():
 		return m.ctx.Err()
@@ -552,7 +655,31 @@ func (m *Manager) waitForPortFree(ctx context.Context, timeout time.Duration) {
 // The mount map is preserved; callers are expected to re-establish mounts
 // against the fresh rcd via Mount(...).
 func (m *Manager) restartServer(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	m.mu.RLock()
+	requestedGeneration := m.generation
+	m.mu.RUnlock()
+
+	// Serialize restarts so the health checker and mount recovery cannot race
+	// each other through restartServer.
+	m.restartMu.Lock()
+	defer m.restartMu.Unlock()
+
 	m.mu.Lock()
+	if m.generation != requestedGeneration {
+		m.mu.Unlock()
+		return nil
+	}
+	m.restarting = true
+	defer func() {
+		m.mu.Lock()
+		m.restarting = false
+		m.mu.Unlock()
+	}()
+
 	cmd := m.cmd
 	exited := m.processExited
 	wasStarted := m.serverStarted
@@ -561,6 +688,9 @@ func (m *Manager) restartServer(ctx context.Context) error {
 	if !wasStarted || cmd == nil || cmd.Process == nil {
 		return fmt.Errorf("rcd subprocess not running, cannot restart")
 	}
+
+	restartCtx, cancel := context.WithTimeout(m.ctx, 45*time.Second)
+	defer cancel()
 
 	m.logger.WarnContext(ctx, "Killing wedged rcd subprocess", "pid", cmd.Process.Pid)
 	if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
@@ -575,15 +705,15 @@ func (m *Manager) restartServer(ctx context.Context) error {
 	case <-exited:
 	case <-time.After(10 * time.Second):
 		m.logger.WarnContext(ctx, "Timed out waiting for rcd subprocess to exit; proceeding with restart")
-	case <-ctx.Done():
-		return ctx.Err()
+	case <-restartCtx.Done():
+		return restartCtx.Err()
 	}
 
 	// The killed process may not have released the RC listening socket the
 	// instant Wait returned. Give it a bounded window to free the port so the
 	// fresh rcd doesn't immediately fail to bind (the failure would otherwise
 	// only surface as a 30s "did not become ready" timeout).
-	m.waitForPortFree(ctx, 5*time.Second)
+	m.waitForPortFree(restartCtx, 5*time.Second)
 
 	// Reset lifecycle state so Start() will spawn a new subprocess.
 	m.mu.Lock()
@@ -591,12 +721,16 @@ func (m *Manager) restartServer(ctx context.Context) error {
 	m.cmd = nil
 	m.serverReady = make(chan struct{})
 	m.processExited = make(chan struct{})
+	m.lastStartErr = nil
 	m.mu.Unlock()
 
-	if err := m.Start(ctx); err != nil {
+	if err := m.Start(restartCtx); err != nil {
 		return fmt.Errorf("failed to restart rcd: %w", err)
 	}
 
+	// Start's readiness goroutine closes serverReady before this wait returns.
+	// WaitForReady must not reject that healthy generation merely because the
+	// restart operation has not reached its final bookkeeping yet.
 	if err := m.WaitForReady(30 * time.Second); err != nil {
 		m.logger.ErrorContext(ctx, "Respawned rcd never answered core/version; see preceding rclone RC server exit logs for the cause (e.g. port still in use or stale mountpoint)",
 			"rc_port", m.rcPort)

--- a/pkg/rclonecli/mount.go
+++ b/pkg/rclonecli/mount.go
@@ -41,8 +41,8 @@ func (m *Mount) Mount(ctx context.Context) error {
 	m.logger.InfoContext(ctx, "Creating mount via RC", "provider", m.Provider, "webdav_url", m.WebDAVURL, "mount_path", m.LocalPath)
 
 	if err := m.rcManager.Mount(ctx, m.Provider, m.LocalPath, m.WebDAVURL); err != nil {
-		m.logger.ErrorContext(ctx, "Mount operation failed", "provider", m.Provider)
-		return fmt.Errorf("mount failed for %s", m.Provider)
+		m.logger.ErrorContext(ctx, "Mount operation failed", "provider", m.Provider, "err", err)
+		return fmt.Errorf("mount failed for %s: %w", m.Provider, err)
 	}
 
 	m.logger.InfoContext(ctx, "Successfully mounted WebDAV via RC", "provider", m.Provider, "path", m.LocalPath)

--- a/pkg/rclonecli/mount_test.go
+++ b/pkg/rclonecli/mount_test.go
@@ -1,0 +1,218 @@
+package rclonecli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newMountTestManager builds a minimal Manager wired with the fields the mount
+// retry and unmount paths touch, plus injectable restart/mountFn/forceUnmount
+// seams so the retry and VFS-reclamation decisions can be asserted without a
+// live rcd subprocess.
+func newMountTestManager(t *testing.T) (*Manager, *int32) {
+	t.Helper()
+
+	ready := make(chan struct{})
+	close(ready) // IsReady() == true
+
+	var restartCalls int32
+	m := &Manager{
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ctx:           context.Background(),
+		rcPort:        "5572",
+		mounts:        make(map[string]*MountInfo),
+		serverReady:   ready,
+		serverStarted: true,
+		httpClient:    &http.Client{Timeout: 500 * time.Millisecond},
+		forceUnmount: func(string) error {
+			return nil
+		},
+		retryDelay: func(int) time.Duration {
+			return time.Millisecond
+		},
+	}
+	m.restart = func(context.Context) error {
+		atomic.AddInt32(&restartCalls, 1)
+		return nil
+	}
+	return m, &restartCalls
+}
+
+func TestUnmount_RestartFailureIsReturned(t *testing.T) {
+	m, _ := newMountTestManager(t)
+	m.mounts["altmount"] = &MountInfo{Provider: "altmount", LocalPath: "/mnt/test", Mounted: true}
+	m.restart = func(context.Context) error {
+		return errors.New("restart failed")
+	}
+
+	err := m.unmount(context.Background(), "altmount", true)
+	if err == nil || !strings.Contains(err.Error(), "restart failed") {
+		t.Fatalf("expected restart failure, got: %v", err)
+	}
+}
+
+func TestWaitForReadyAcceptsReadyServerWhileRestarting(t *testing.T) {
+	m, _ := newMountTestManager(t)
+	m.mu.Lock()
+	m.restarting = true
+	m.mu.Unlock()
+
+	if err := m.WaitForReady(time.Second); err != nil {
+		t.Fatalf("ready rcd must not be rejected while restart bookkeeping is finishing: %v", err)
+	}
+}
+
+func TestMountWithRetry_SuccessOnFirstAttempt(t *testing.T) {
+	m, restarts := newMountTestManager(t)
+	m.mountFn = func(context.Context, string, string, string) error {
+		return nil
+	}
+
+	if err := m.mountWithRetry(context.Background(), "altmount", "/mnt/test", "http://localhost:2020/webdav", 3); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(restarts); got != 0 {
+		t.Fatalf("no restart expected on first-attempt success, got %d", got)
+	}
+}
+
+func TestMountWithRetry_FirstAttemptFailsThenSucceeds(t *testing.T) {
+	m, restarts := newMountTestManager(t)
+	var attempts int32
+	m.mountFn = func(context.Context, string, string, string) error {
+		if atomic.AddInt32(&attempts, 1) == 1 {
+			return errors.New("fusermount: exit status 1")
+		}
+		return nil
+	}
+
+	if err := m.mountWithRetry(context.Background(), "altmount", "/mnt/test", "http://localhost:2020/webdav", 3); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Fatalf("expected 2 mount attempts, got %d", got)
+	}
+	// The rcd must be restarted between attempts so the leaked VFS from the
+	// failed attempt is cleared before the retry.
+	if got := atomic.LoadInt32(restarts); got != 1 {
+		t.Fatalf("expected 1 restart between attempts, got %d", got)
+	}
+}
+
+func TestMountWithRetry_AllAttemptsFailRestartsEachTimeAndFinalCleanup(t *testing.T) {
+	m, restarts := newMountTestManager(t)
+	wantErr := errors.New("failed to mount FUSE fs: fusermount: exit status 1")
+	m.mountFn = func(context.Context, string, string, string) error {
+		return wantErr
+	}
+
+	err := m.mountWithRetry(context.Background(), "altmount", "/mnt/test", "http://localhost:2020/webdav", 3)
+	if err == nil {
+		t.Fatal("expected error from mount retry")
+	}
+	if !strings.Contains(err.Error(), wantErr.Error()) {
+		t.Fatalf("expected wrapped mount error, got: %v", err)
+	}
+	// One restart before each of the 3 retries plus one after the terminal
+	// failure to leave the rcd free of leaked VFS state.
+	if got := atomic.LoadInt32(restarts); got != 4 {
+		t.Fatalf("expected 4 restarts (3 between attempts + 1 final cleanup), got %d", got)
+	}
+}
+
+func TestMountWithRetry_CleanupRestartFailureAbortsRetry(t *testing.T) {
+	m, restarts := newMountTestManager(t)
+	// Override restart to fail. Retrying against the same dirty rcd would leak
+	// another VFS, so mountWithRetry must stop immediately.
+	m.restart = func(context.Context) error {
+		atomic.AddInt32(restarts, 1)
+		return errors.New("failed to restart rcd")
+	}
+	var attempts int32
+	m.mountFn = func(context.Context, string, string, string) error {
+		if atomic.AddInt32(&attempts, 1) < 3 {
+			return errors.New("transient failure")
+		}
+		return nil
+	}
+
+	err := m.mountWithRetry(context.Background(), "altmount", "/mnt/test", "http://localhost:2020/webdav", 3)
+	if err == nil || !strings.Contains(err.Error(), "cleanup failed") {
+		t.Fatalf("expected cleanup failure, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("expected retry to stop after the first dirty attempt, got %d attempts", got)
+	}
+	if got := atomic.LoadInt32(restarts); got != 1 {
+		t.Fatalf("expected 1 restart attempt, got %d", got)
+	}
+}
+
+func TestMountWithRetry_ContextCancelledDuringRetry(t *testing.T) {
+	m, _ := newMountTestManager(t)
+	var attempts int32
+	m.mountFn = func(context.Context, string, string, string) error {
+		atomic.AddInt32(&attempts, 1)
+		return errors.New("boom")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := m.mountWithRetry(ctx, "altmount", "/mnt/test", "http://localhost:2020/webdav", 3)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("expected a single mount attempt before cancellation, got %d", got)
+	}
+}
+
+func TestUnmount_RestartsRCDToReclaimVFS(t *testing.T) {
+	m, restarts := newMountTestManager(t)
+	m.mounts["altmount"] = &MountInfo{Provider: "altmount", LocalPath: "/mnt/test", Mounted: true}
+
+	if err := m.unmount(context.Background(), "altmount", true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	info, ok := m.GetMountInfo("altmount")
+	if !ok || info.Mounted {
+		t.Fatal("mount must be marked unmounted after Unmount")
+	}
+	// rclone retains the VFS in-process after mount/unmount; a restart is
+	// required so a later mount does not create a second VFS instance.
+	if got := atomic.LoadInt32(restarts); got != 1 {
+		t.Fatalf("expected rcd restart after unmount, got %d", got)
+	}
+}
+
+func TestUnmount_NoRestartWhenRCDDisabled(t *testing.T) {
+	m, restarts := newMountTestManager(t)
+	m.mounts["altmount"] = &MountInfo{Provider: "altmount", LocalPath: "/mnt/test", Mounted: true}
+
+	if err := m.unmount(context.Background(), "altmount", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(restarts); got != 0 {
+		t.Fatalf("no restart expected during shutdown unmount, got %d", got)
+	}
+}
+
+func TestUnmount_AlreadyUnmountedNoRestart(t *testing.T) {
+	m, restarts := newMountTestManager(t)
+	m.mounts["altmount"] = &MountInfo{Provider: "altmount", LocalPath: "/mnt/test", Mounted: false}
+
+	if err := m.unmount(context.Background(), "altmount", true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(restarts); got != 0 {
+		t.Fatalf("no restart expected for already-unmounted provider, got %d", got)
+	}
+}


### PR DESCRIPTION
### Summary
A failed mount or mount attempt leaves a leaked VFS instance inside the `rcd` subprocess because rclone initializes the VFS prior to attempting the FUSE mount and does not tear it down upon failure. Failed mounts are never registered with `mount/unmount`, and neither RC unmount nor fusermount can remove that in-process state. Subsequent retry attempts create duplicate VFS instances under the same name (`altmount:[0]`, `altmount:[1]`), which breaks `vfs/refresh` and `vfs/forget`.

### Changes
- Restart the `rcd` subprocess after every failed mount attempt (and after the terminal failure) to ensure retries start from a clean VFS registry.
- Restart `rcd` after standalone unmounts to reclaim the retained VFS instance.
- Bind `rcd` to the Manager lifetime context instead of the request context.
- Serialize restarts, make server readiness checks truthful, and preserve the underlying mount error.
- Pin rclone `v1.75.0` in Docker images.
- Comprehensive unit and mock tests in `pkg/rclonecli`.