### PR TITLE
feat(stremio): add fast_fail_header_only option to abort dead Stremio NZBs immediately

### DIFF
--- a/frontend/src/components/config/StremioConfigSection.tsx
+++ b/frontend/src/components/config/StremioConfigSection.tsx
@@ -317,6 +317,22 @@ export function StremioConfigSection({
 								<strong>0</strong> to disable fallback.
 							</p>
 						</fieldset>
+
+						<div className="flex min-w-0 items-start justify-between gap-4 rounded-box border border-base-300 bg-base-100 p-4 sm:col-span-2">
+							<div className="min-w-0 flex-1">
+								<h4 className="font-semibold text-sm">Fast Fail Header Only (Stremio)</h4>
+								<p className="mt-1 text-base-content/70 text-xs">
+									Immediately abort dead NZBs (missing articles / DMCA) on the release header probe without running a full per-file archive sweep.
+								</p>
+							</div>
+							<input
+								type="checkbox"
+								className="toggle toggle-primary mt-1 shrink-0"
+								checked={formData.fast_fail_header_only ?? true}
+								disabled={isReadOnly}
+								onChange={(e) => update({ fast_fail_header_only: e.target.checked })}
+							/>
+						</div>
 					</div>
 				</div>
 

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -687,6 +687,7 @@ export interface StremioConfig {
 	nzb_ttl_hours: number;
 	failed_release_ttl_hours: number;
 	max_fallback_releases: number;
+	fast_fail_header_only?: boolean;
 	base_url?: string;
 	prowlarr: ProwlarrConfig;
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -209,6 +209,7 @@ type StremioAPIResponse struct {
 	// config would silently restore the defaults.
 	FailedReleaseTTLHours int                 `json:"failed_release_ttl_hours"`
 	MaxFallbackReleases   int                 `json:"max_fallback_releases"`
+	FastFailHeaderOnly    bool                `json:"fast_fail_header_only"`
 	BaseURL               string              `json:"base_url,omitempty"`
 	Prowlarr              ProwlarrAPIResponse `json:"prowlarr"`
 }
@@ -388,6 +389,7 @@ func ToConfigAPIResponse(cfg *config.Config, apiKey string) *ConfigAPIResponse {
 		NzbTTLHours:           cfg.Stremio.NzbTTLHours,
 		FailedReleaseTTLHours: cfg.Stremio.FailedReleaseTTLHours,
 		MaxFallbackReleases:   cfg.Stremio.MaxFallbackReleases,
+		FastFailHeaderOnly:    cfg.Stremio.EffectiveFastFailHeaderOnly(),
 		BaseURL:               cfg.Stremio.BaseURL,
 		Prowlarr: ProwlarrAPIResponse{
 			Enabled:    cfg.Stremio.Prowlarr.Enabled != nil && *cfg.Stremio.Prowlarr.Enabled,

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -183,6 +183,10 @@ type StremioConfig struct {
 	// MaxFallbackReleases caps how many *extra* releases a single play request may try
 	// after the first one fails. Set to 0 to disable fallback. Defaults to 2.
 	MaxFallbackReleases int `yaml:"max_fallback_releases" mapstructure:"max_fallback_releases" json:"max_fallback_releases"`
+	// FastFailHeaderOnly when true causes Stremio-originated imports to fail fast
+	// immediately on the release-level probe when missing articles are detected,
+	// skipping the multi-part RAR per-file Stat sweep. Defaults to true.
+	FastFailHeaderOnly *bool `yaml:"fast_fail_header_only" mapstructure:"fast_fail_header_only" json:"fast_fail_header_only"`
 	// BaseURL is the public base URL used when building Stremio stream links
 	// (e.g. "https://altmount.example.com"). Falls back to the auto-detected
 	// request origin when not set.
@@ -204,6 +208,15 @@ func (s StremioConfig) EffectiveMaxFallbackReleases() int {
 		return maxStremioFallbackReleases
 	}
 	return s.MaxFallbackReleases
+}
+
+// EffectiveFastFailHeaderOnly reports whether Stremio imports should fast-fail
+// immediately on the release probe when missing articles are found. Defaults to true.
+func (s StremioConfig) EffectiveFastFailHeaderOnly() bool {
+	if s.FastFailHeaderOnly == nil {
+		return true
+	}
+	return *s.FastFailHeaderOnly
 }
 
 // AuthConfig represents authentication configuration
@@ -1508,6 +1521,7 @@ func DefaultConfig(configDir ...string) *Config {
 	fuseEnabled := false
 	loginRequired := true           // Require login by default
 	stremioEnabled := false         // Stremio endpoint disabled by default
+	stremioFastFailHeaderOnly := true
 	prowlarrEnabled := false        // Prowlarr integration disabled by default
 	watchIntervalSeconds := 10      // Default watch interval
 	failedItemRetentionHours := 24  // Default: auto-remove failed items after 24 hours
@@ -1559,6 +1573,7 @@ func DefaultConfig(configDir ...string) *Config {
 			NzbTTLHours:           24,
 			FailedReleaseTTLHours: 24,
 			MaxFallbackReleases:   2,
+			FastFailHeaderOnly:    &stremioFastFailHeaderOnly,
 			Prowlarr: ProwlarrConfig{
 				Enabled:    &prowlarrEnabled,
 				Host:       "http://localhost:9696",

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -176,7 +176,7 @@ func (proc *Processor) checkCancellation(ctx context.Context) error {
 // round-trips. Returns (brokenFileIndexes, knownMissingSegmentIDs, error).
 // Both maps are nil when no pool is available.
 // Returns ErrNoFilesProcessed (wrapped) when all eligible regular files are broken.
-func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, cfg *config.Config, queueID int) (map[int]struct{}, map[string]struct{}, error) {
+func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, cfg *config.Config, queueID int, category *string, downloadID *string) (map[int]struct{}, map[string]struct{}, error) {
 	if !proc.poolManager.HasPool() {
 		return nil, nil, nil
 	}
@@ -233,6 +233,16 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 				"duration", time.Since(probeStart))
 		}
 		return nil, nil, nil
+	}
+
+	isStremioImport := (category != nil && *category == "stremio") || (downloadID != nil && strings.HasPrefix(*downloadID, "stremio:"))
+	if isStremioImport && cfg.Stremio.EffectiveFastFailHeaderOnly() {
+		if proc.log != nil {
+			proc.log.InfoContext(ctx, "Fast-fail release probe failed for Stremio import; aborting immediately without per-file sweep",
+				"files", len(fastFailFiles),
+				"probe_duration", time.Since(probeStart))
+		}
+		return nil, nil, multifile.ErrNoFilesProcessed
 	}
 
 	// Phase 2 (escalation): the probe found an unreachable segment, so map
@@ -443,7 +453,7 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 		proc.updateProgressWithStage(queueID, 0, "Checking segment availability")
 		var missingIDs map[string]struct{}
 		var fastFailErr error
-		brokenIdx, missingIDs, fastFailErr = proc.preParseFastFail(ctx, n, cfg, queueID)
+		brokenIdx, missingIDs, fastFailErr = proc.preParseFastFail(ctx, n, cfg, queueID, category, downloadID)
 		if fastFailErr != nil {
 			return "", nil, NewNonRetryableError("fast-fail segment check failed", fastFailErr)
 		}

--- a/internal/importer/processor_test.go
+++ b/internal/importer/processor_test.go
@@ -72,7 +72,7 @@ func TestPreParseFastFailSkipsOnlyMissingEpisode(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	brokenIdx, missingIDs, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
+	brokenIdx, missingIDs, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestPreParseFastFailMarksWholeRarSetBroken(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
+	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestPreParseFastFailAllRarSetsBrokenReturnsNoFilesProcessed(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
+	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
 		t.Fatalf("preParseFastFail error = %v, want ErrNoFilesProcessed", err)
 	}
@@ -172,7 +172,7 @@ func TestPreParseFastFailDoesNotStatPar2(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	brokenIdx, missingIDs, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
+	brokenIdx, missingIDs, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestPreParseFastFailAllMissingReturnsNoFilesProcessed(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
+	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
 		t.Fatalf("preParseFastFail error = %v, want ErrNoFilesProcessed", err)
 	}
@@ -231,7 +231,7 @@ func TestPreParseFastFailHealthyReleaseSkipsPerFileSweep(t *testing.T) {
 	n := buildTestNzb(files)
 	cfg := config.DefaultConfig() // default 1% sampling, capped at 55
 
-	brokenIdx, missingIDs, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
+	brokenIdx, missingIDs, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
@@ -619,7 +619,7 @@ func TestPreParseFastFailTolerantImportsDegradedVideo(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
+	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
@@ -641,7 +641,7 @@ func TestPreParseFastFailStrictFailsDegradedVideo(t *testing.T) {
 	cfg.Import.SegmentSamplePercentage = 100
 	cfg.Import.DamagePolicy = "strict"
 
-	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
+	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
 		// Single file, and it's broken → all eligible broken → ErrNoFilesProcessed.
 		t.Fatalf("strict policy: err = %v, want ErrNoFilesProcessed", err)
@@ -662,9 +662,25 @@ func TestPreParseFastFailTolerantStillFailsLongRun(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
+	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
 		t.Fatalf("tolerant policy with long run: err = %v, want ErrNoFilesProcessed", err)
+	}
+}
+
+func TestPreParseFastFailStremioHeaderOnly(t *testing.T) {
+	client := fakepool.New()
+	proc := &Processor{
+		poolManager:       processorTestPoolManager{client: client},
+		validationTimeout: 100 * time.Millisecond,
+	}
+	n := buildMultiSegmentNzb(client, "StremioMovie.mkv", 50, 0)
+	cfg := config.DefaultConfig()
+	stremioCat := "stremio"
+
+	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, &stremioCat, nil)
+	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
+		t.Fatalf("stremio header fast-fail: err = %v, want ErrNoFilesProcessed", err)
 	}
 }
 


### PR DESCRIPTION
### Summary
Adds a `fast_fail_header_only` configuration option in the importer processor and Stremio configuration section to abort dead Stremio NZBs immediately upon header evaluation, avoiding unnecessary segment fetch attempts and speeding up stream failover.

### Changes
- Add `FastFailHeaderOnly` config parameter and API response serialization.
- Implement early inspection and short-circuit failure handling in importer processor.
- Add frontend toggle in Stremio settings.