### PR TITLE
feat(stremio): reuse completed library releases and exact canonical cache matching for instant playback

### DIFF
--- a/frontend/src/components/config/StremioConfigSection.tsx
+++ b/frontend/src/components/config/StremioConfigSection.tsx
@@ -248,6 +248,22 @@ export function StremioConfigSection({
 						/>
 					</div>
 
+					<div className="flex items-center justify-between gap-4">
+						<div className="min-w-0 flex-1">
+							<h5 className="break-words font-bold text-sm">Reuse Completed Library Releases</h5>
+							<p className="mt-1 break-words text-[11px] text-base-content/50 leading-relaxed">
+								Reuses completed releases across the entire Altmount library for instant 0s playback without re-downloading existing media.
+							</p>
+						</div>
+						<input
+							type="checkbox"
+							className="toggle toggle-primary mt-1 shrink-0"
+							checked={formData.reuse_library_releases ?? true}
+							disabled={isReadOnly}
+							onChange={(e) => update({ reuse_library_releases: e.target.checked })}
+						/>
+					</div>
+
 					<div className="grid min-w-0 grid-cols-1 gap-6 sm:grid-cols-2">
 						<fieldset className="fieldset min-w-0">
 							<legend className="fieldset-legend">Public Base URL</legend>

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -685,6 +685,7 @@ export interface ProwlarrIndexer {
 export interface StremioConfig {
 	enabled: boolean;
 	nzb_ttl_hours: number;
+	reuse_library_releases?: boolean;
 	failed_release_ttl_hours: number;
 	max_fallback_releases: number;
 	base_url?: string;

--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -161,16 +161,62 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 		"type", streamType, "id", rawID, "imdb_id", imdbID)
 
 	baseURL := resolveBaseURL(c, cfg.Stremio.BaseURL)
+	var libraryStreams []fiber.Map
+
+	// 1. Check local Altmount library in file_health if library reuse is enabled
+	if cfg.Stremio.EffectiveReuseLibraryReleases() && s.healthRepo != nil {
+		selector := &stremioEpisodeSelector{Season: season, Episode: episode}
+		if streamType == "movie" {
+			tmdbID, movieTitle, movieYear, _ := resolveMovieMetadataFromIMDb(ctx, imdbID)
+			if healthyFiles, err := s.healthRepo.FindHealthyFilesForMovie(ctx, movieTitle, movieYear, tmdbID); err == nil {
+				for _, h := range healthyFiles {
+					if h != nil && h.FilePath != "" && isMediaExtension(filepath.Ext(h.FilePath)) {
+						streamURL := baseURL + "/api/files/stream?path=" +
+							url.QueryEscape(h.FilePath) + "&download_key=" + url.QueryEscape(key)
+						libraryStreams = append(libraryStreams, fiber.Map{
+							"name":  formatLibraryStreamName(h),
+							"title": formatLibraryStreamTitle(h),
+							"url":   streamURL,
+						})
+					}
+				}
+			}
+		} else if streamType == "series" {
+			tvdbIDStr, seriesTitle, _ := resolveSeriesMetadataFromIMDb(ctx, imdbID)
+			tvdbID, _ := strconv.Atoi(tvdbIDStr)
+			if healthyFiles, err := s.healthRepo.FindHealthyFilesForSeries(ctx, seriesTitle, tvdbID); err == nil {
+				for _, h := range healthyFiles {
+					if h != nil && h.FilePath != "" && isMediaExtension(filepath.Ext(h.FilePath)) {
+						matchPath := h.FilePath
+						if h.LibraryPath != nil && *h.LibraryPath != "" {
+							matchPath = *h.LibraryPath
+						}
+						if selector.matches(matchPath) || selector.matches(h.FilePath) {
+							streamURL := baseURL + "/api/files/stream?path=" +
+								url.QueryEscape(h.FilePath) + "&download_key=" + url.QueryEscape(key)
+							libraryStreams = append(libraryStreams, fiber.Map{
+								"name":  formatLibraryStreamName(h),
+								"title": formatLibraryStreamTitle(h),
+								"url":   streamURL,
+							})
+						}
+					}
+				}
+			}
+		}
+	}
 
 	results, cachedItems, err := s.searchStremioReleases(ctx, cfg, streamType, prowlarrType, imdbID, season, episode)
-	if err != nil || len(results) == 0 {
+	if err != nil && len(libraryStreams) == 0 {
 		return emptyStreamsResponse(c)
 	}
 
 	entries := buildStremioStreamEntries(results, cachedItems, cfg.Stremio.NzbTTLHours, time.Now(),
 		baseURL, key, streamType, season, episode, imdbID)
 
-	streams := make([]fiber.Map, 0, len(entries))
+	streams := make([]fiber.Map, 0, len(libraryStreams)+len(entries))
+	streams = append(streams, libraryStreams...)
+
 	for _, e := range entries {
 		streams = append(streams, fiber.Map{
 			"name":  e.Name,
@@ -179,7 +225,47 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 		})
 	}
 
+	if len(streams) == 0 {
+		return emptyStreamsResponse(c)
+	}
+
 	return c.JSON(fiber.Map{"streams": streams})
+}
+
+func formatLibraryStreamTitle(h *database.FileHealth) string {
+	rawName := ""
+	if h.LibraryPath != nil && *h.LibraryPath != "" {
+		rawName = filepath.Base(*h.LibraryPath)
+	}
+	if rawName == "" || rawName == "." {
+		rawName = filepath.Base(h.FilePath)
+	}
+	rawName = strings.TrimSuffix(rawName, filepath.Ext(rawName))
+
+	return fmt.Sprintf("%s\n💾 Local Library • ⚡ Instant 0s Playback", rawName)
+}
+
+func formatLibraryStreamName(h *database.FileHealth) string {
+	name := filepath.Base(h.FilePath)
+	if h.LibraryPath != nil && *h.LibraryPath != "" {
+		name = filepath.Base(*h.LibraryPath)
+	}
+	nameLower := strings.ToLower(name)
+	res := ""
+	if strings.Contains(nameLower, "2160p") || strings.Contains(nameLower, "4k") || strings.Contains(nameLower, "uhd") {
+		res = "2160p"
+	} else if strings.Contains(nameLower, "1080p") || strings.Contains(nameLower, "fhd") {
+		res = "1080p"
+	} else if strings.Contains(nameLower, "720p") || strings.Contains(nameLower, "hd") {
+		res = "720p"
+	} else if strings.Contains(nameLower, "480p") || strings.Contains(nameLower, "sd") {
+		res = "480p"
+	}
+
+	if res != "" {
+		return fmt.Sprintf("⚡ Altmount Library\n%s", res)
+	}
+	return "⚡ Altmount Library"
 }
 
 // stremioPlayCandidate is one release a /play request may attempt. Candidates are
@@ -692,6 +778,51 @@ func (s *Server) handleStremioAddonPlay(c *fiber.Ctx) error {
 						slog.InfoContext(ctx, "Returning cached Stremio stream",
 							"nzb_name", cand.SafeTitle, "matched_path", prev.NzbPath, "indexer", cand.Indexer)
 						return c.Redirect(streams[0].URL, fiber.StatusFound)
+					}
+				}
+			}
+		}
+
+		if cfg.Stremio.EffectiveReuseLibraryReleases() && s.healthRepo != nil {
+			if streamType == "movie" {
+				tmdbID, movieTitle, movieYear, _ := resolveMovieMetadataFromIMDb(ctx, imdbID)
+				if healthyFiles, err := s.healthRepo.FindHealthyFilesForMovie(ctx, movieTitle, movieYear, tmdbID); err == nil && len(healthyFiles) > 0 {
+					for _, h := range healthyFiles {
+						if h != nil && h.FilePath != "" && isMediaExtension(filepath.Ext(h.FilePath)) {
+							normF := normalizeTitleForMatching(h.FilePath)
+							normL := ""
+							if h.LibraryPath != nil {
+								normL = normalizeTitleForMatching(*h.LibraryPath)
+							}
+							if normF == normTarget || (normL != "" && normL == normTarget) {
+								streamURL := baseURL + "/api/files/stream?path=" +
+									url.QueryEscape(h.FilePath) + "&download_key=" + url.QueryEscape(key)
+								slog.InfoContext(ctx, "Returning cached Stremio stream from library",
+									"nzb_name", cand.SafeTitle, "matched_path", h.FilePath, "indexer", cand.Indexer)
+								return c.Redirect(streamURL, fiber.StatusFound)
+							}
+						}
+					}
+				}
+			} else if streamType == "series" {
+				tvdbIDStr, seriesTitle, _ := resolveSeriesMetadataFromIMDb(ctx, imdbID)
+				tvdbID, _ := strconv.Atoi(tvdbIDStr)
+				if healthyFiles, err := s.healthRepo.FindHealthyFilesForSeries(ctx, seriesTitle, tvdbID); err == nil && len(healthyFiles) > 0 {
+					for _, h := range healthyFiles {
+						if h != nil && h.FilePath != "" && isMediaExtension(filepath.Ext(h.FilePath)) {
+							normF := normalizeTitleForMatching(h.FilePath)
+							normL := ""
+							if h.LibraryPath != nil {
+								normL = normalizeTitleForMatching(*h.LibraryPath)
+							}
+							if normF == normTarget || (normL != "" && normL == normTarget) {
+								streamURL := baseURL + "/api/files/stream?path=" +
+									url.QueryEscape(h.FilePath) + "&download_key=" + url.QueryEscape(key)
+								slog.InfoContext(ctx, "Returning cached Stremio stream from library",
+									"nzb_name", cand.SafeTitle, "matched_path", h.FilePath, "indexer", cand.Indexer)
+								return c.Redirect(streamURL, fiber.StatusFound)
+							}
+						}
 					}
 				}
 			}

--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -192,20 +192,52 @@ type stremioPlayCandidate struct {
 	Indexer     string
 }
 
-// stremioNzbPathMatches reports whether a queue item's nzb path belongs to the release
-// identified by safeTitle. The play handler stages every NZB as "<safeTitle>.nzb", and
-// the importer preserves that base name, so a substring test is the join between a
-// Prowlarr result and its queue rows.
+// normalizeTitleForMatching extracts an alphanumeric canonical representation of a title
+// or file path, ignoring case, separators (dots, underscores, dashes, spaces), brackets,
+// and file extensions (.nzb, .nzb.gz, .mkv, .mp4, etc.).
+func normalizeTitleForMatching(s string) string {
+	s = strings.ReplaceAll(s, "\\", "/")
+	s = filepath.Base(s)
+	for {
+		orig := s
+		s = strings.TrimSuffix(s, ".gz")
+		s = strings.TrimSuffix(s, ".nzb")
+		s = strings.TrimSuffix(s, ".mkv")
+		s = strings.TrimSuffix(s, ".mp4")
+		s = strings.TrimSuffix(s, ".avi")
+		s = strings.TrimSuffix(s, ".iso")
+		s = strings.TrimSuffix(s, ".rar")
+		if s == orig {
+			break
+		}
+	}
+
+	s = strings.ToLower(s)
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// stremioNzbPathMatches checks if an NZB path matches a candidate title regardless of
+// case, punctuation, extensions, or directory wrappers using exact normalized equality.
 func stremioNzbPathMatches(nzbPath, safeTitle string) bool {
-	return strings.Contains(filepath.ToSlash(nzbPath), safeTitle+".nzb")
+	normA := normalizeTitleForMatching(nzbPath)
+	normB := normalizeTitleForMatching(safeTitle)
+	if normA == "" || normB == "" {
+		return false
+	}
+	return normA == normB
 }
 
 // stremioCachedPredicate returns a test for "already imported and still usable":
 // the item must have a storage path and, when a TTL is configured, have completed
-// within it. Mirrors the reuse condition in handleStremioAddonPlay so the "⚡ Cached"
-// badge is truthful.
+// within it. Uses exact alphanumeric normalized matching to eliminate false positives.
 func stremioCachedPredicate(cached []*database.ImportQueueItem, ttlHours int, now time.Time) func(safeTitle string) bool {
-	paths := make([]string, 0, len(cached))
+	normalizedCache := make(map[string]struct{}, len(cached)*3)
 	for _, item := range cached {
 		if item == nil || item.StoragePath == nil || *item.StoragePath == "" {
 			continue
@@ -215,16 +247,28 @@ func stremioCachedPredicate(cached []*database.ImportQueueItem, ttlHours int, no
 				continue
 			}
 		}
-		paths = append(paths, item.NzbPath)
+		if norm := normalizeTitleForMatching(item.NzbPath); norm != "" {
+			normalizedCache[norm] = struct{}{}
+		}
+		if item.StoragePath != nil {
+			if norm := normalizeTitleForMatching(*item.StoragePath); norm != "" {
+				normalizedCache[norm] = struct{}{}
+			}
+		}
+		if item.RelativePath != nil && *item.RelativePath != "" {
+			if norm := normalizeTitleForMatching(*item.RelativePath); norm != "" {
+				normalizedCache[norm] = struct{}{}
+			}
+		}
 	}
 
 	return func(safeTitle string) bool {
-		for _, p := range paths {
-			if stremioNzbPathMatches(p, safeTitle) {
-				return true
-			}
+		target := normalizeTitleForMatching(safeTitle)
+		if target == "" {
+			return false
 		}
-		return false
+		_, exists := normalizedCache[target]
+		return exists
 	}
 }
 
@@ -403,7 +447,7 @@ func (s *Server) searchStremioReleases(
 	}
 
 	now := time.Now()
-	cachedItems, failedItems := s.loadStremioQueueState(ctx)
+	cachedItems, failedItems := s.loadStremioQueueState(ctx, cfg)
 
 	total := len(results)
 	results = filterStremioResults(results, prowlarrCfg.Languages, prowlarrCfg.Qualities,
@@ -425,12 +469,17 @@ func stremioFailedTTL(cfg *config.Config) time.Duration {
 
 // loadStremioQueueState fetches the cached and failed Stremio queue items. Both lookups
 // are best-effort: a DB hiccup degrades badges and exclusion rather than failing search.
-func (s *Server) loadStremioQueueState(ctx context.Context) (cached, failed []*database.ImportQueueItem) {
+func (s *Server) loadStremioQueueState(ctx context.Context, cfg *config.Config) (cached, failed []*database.ImportQueueItem) {
 	if s.queueRepo == nil {
 		return nil, nil
 	}
 
-	if items, err := s.queueRepo.GetCachedStremioQueueItems(ctx); err != nil {
+	reuseLibrary := false
+	if cfg != nil {
+		reuseLibrary = cfg.Stremio.EffectiveReuseLibraryReleases()
+	}
+
+	if items, err := s.queueRepo.GetCachedStremioQueueItems(ctx, reuseLibrary); err != nil {
 		slog.WarnContext(ctx, "Failed to load cached Stremio items; continuing without cache badges",
 			"error", err)
 	} else {
@@ -618,18 +667,33 @@ func (s *Server) handleStremioAddonPlay(c *fiber.Ctx) error {
 	// before the failed-release check so a genuinely playable file always wins over a
 	// stale failure record.
 	ttlHours := cfg.Stremio.NzbTTLHours
-	completedStatus := database.QueueStatusCompleted
-	if existing, err := s.queueRepo.ListQueueItems(ctx, &completedStatus, cand.SafeTitle+".nzb", "", 1, 0, "updated_at", "desc"); err == nil && len(existing) > 0 {
-		prev := existing[0]
-		cacheValid := prev.StoragePath != nil && *prev.StoragePath != ""
-		if cacheValid && ttlHours > 0 && prev.CompletedAt != nil {
-			cacheValid = time.Since(*prev.CompletedAt) < time.Duration(ttlHours)*time.Hour
-		}
-		if cacheValid {
-			if streams, err := s.buildStremioStreams(ctx, prev, baseURL, key, cand.SafeTitle, selector); err == nil && len(streams) > 0 {
-				slog.InfoContext(ctx, "Returning cached Stremio stream for Prowlarr NZB",
-					"nzb_name", cand.SafeTitle)
-				return c.Redirect(streams[0].URL, fiber.StatusFound)
+	normTarget := normalizeTitleForMatching(cand.SafeTitle)
+	if normTarget != "" {
+		if cachedItems, err := s.queueRepo.GetCachedStremioQueueItems(ctx, cfg.Stremio.EffectiveReuseLibraryReleases()); err == nil {
+			for _, prev := range cachedItems {
+				if prev == nil || prev.StoragePath == nil || *prev.StoragePath == "" {
+					continue
+				}
+				if ttlHours > 0 && prev.CompletedAt != nil && time.Since(*prev.CompletedAt) >= time.Duration(ttlHours)*time.Hour {
+					continue
+				}
+				normNzb := normalizeTitleForMatching(prev.NzbPath)
+				normStorage := ""
+				if prev.StoragePath != nil {
+					normStorage = normalizeTitleForMatching(*prev.StoragePath)
+				}
+				normRel := ""
+				if prev.RelativePath != nil {
+					normRel = normalizeTitleForMatching(*prev.RelativePath)
+				}
+
+				if normNzb == normTarget || (normStorage != "" && normStorage == normTarget) || (normRel != "" && normRel == normTarget) {
+					if streams, err := s.buildStremioStreams(ctx, prev, baseURL, key, cand.SafeTitle, selector); err == nil && len(streams) > 0 {
+						slog.InfoContext(ctx, "Returning cached Stremio stream",
+							"nzb_name", cand.SafeTitle, "matched_path", prev.NzbPath, "indexer", cand.Indexer)
+						return c.Redirect(streams[0].URL, fiber.StatusFound)
+					}
+				}
 			}
 		}
 	}

--- a/internal/api/stremio_addon_handlers_test.go
+++ b/internal/api/stremio_addon_handlers_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/prowlarr"
+	"github.com/stretchr/testify/assert"
 )
 
 func timePtr(t time.Time) *time.Time { return &t }
@@ -180,4 +181,20 @@ func TestBuildStremioStreamEntries_CachedSortedFirstStable(t *testing.T) {
 	if entries[2].Cached || entries[3].Cached {
 		t.Errorf("last two entries should not be cached")
 	}
+}
+
+func TestFormatLibraryStream(t *testing.T) {
+	libPath := "/library/movies/Sample Movie (2026)/Sample Movie (2026) - [Bluray-2160p][TrueHD Atmos 7.1][DV HDR10][x265]-GROUP.mkv"
+	h := &database.FileHealth{
+		FilePath:    "complete/movies/Sample.Movie.2026.2160p.UHD.BluRay.x265-GROUP/sample.movie.2026.2160p.uhd.bluray.x265-group.mkv",
+		LibraryPath: &libPath,
+	}
+
+	name := formatLibraryStreamName(h)
+	assert.Contains(t, name, "⚡ Altmount Library")
+	assert.Contains(t, name, "2160p")
+
+	title := formatLibraryStreamTitle(h)
+	assert.Contains(t, title, "Sample Movie (2026) - [Bluray-2160p][TrueHD Atmos 7.1][DV HDR10][x265]-GROUP")
+	assert.Contains(t, title, "💾 Local Library • ⚡ Instant 0s Playback")
 }

--- a/internal/api/stremio_addon_handlers_test.go
+++ b/internal/api/stremio_addon_handlers_test.go
@@ -31,10 +31,11 @@ func TestBuildStremioStreamEntries_CacheDetection(t *testing.T) {
 	matchingPath := "/config/.nzbs/Movies/7/" + safeFilename
 
 	tests := []struct {
-		name       string
-		cached     []*database.ImportQueueItem
-		ttlHours   int
-		wantCached bool
+		name        string
+		searchTitle string
+		cached      []*database.ImportQueueItem
+		ttlHours    int
+		wantCached  bool
 	}{
 		{
 			name:       "cached within TTL",
@@ -72,11 +73,50 @@ func TestBuildStremioStreamEntries_CacheDetection(t *testing.T) {
 			ttlHours:   24,
 			wantCached: false,
 		},
+		{
+			name:        "special characters and dot differences match",
+			searchTitle: "House.of.the.Dragon.S03E02.Queens.Landing.2160p.HMAX.WEB-DL.DDP5.1.Atmos.DoVi.HDR.H.265-playWEB",
+			cached:      []*database.ImportQueueItem{cachedItem("/config/.nzbs/TV/House of the Dragon - S03E02 - Queen's Landing [2160p HMAX WEB-DL DDP5.1 Atmos DoVi HDR H.265-playWEB].nzb.gz", "/storage/hotd", timePtr(now.Add(-1*time.Hour)))},
+			ttlHours:    24,
+			wantCached:  true,
+		},
+		{
+			name:        "case differences and brackets match",
+			searchTitle: "lia one piece 0482 1080p",
+			cached:      []*database.ImportQueueItem{cachedItem("/config/.nzbs/TV/[Lia] ONE PIECE - 0482 [1080P].nzb", "/storage/op", timePtr(now.Add(-1*time.Hour)))},
+			ttlHours:    24,
+			wantCached:  true,
+		},
+		{
+			name:        "sequel title does not match earlier movie (no false positive)",
+			searchTitle: "Scream 2 1997 1080p BluRay x264",
+			cached:      []*database.ImportQueueItem{cachedItem("/config/.nzbs/Movies/Scream 1996 1080p BluRay x264.nzb", "/storage/scream1", timePtr(now.Add(-1*time.Hour)))},
+			ttlHours:    24,
+			wantCached:  false,
+		},
+		{
+			name:        "different episode does not match (no false positive)",
+			searchTitle: "Show S01E10 1080p WEB-DL",
+			cached:      []*database.ImportQueueItem{cachedItem("/config/.nzbs/TV/Show S01E01 1080p WEB-DL.nzb", "/storage/s01e01", timePtr(now.Add(-1*time.Hour)))},
+			ttlHours:    24,
+			wantCached:  false,
+		},
+		{
+			name:        "different resolution does not match (no false positive)",
+			searchTitle: "Movie 2024 2160p UHD REMUX",
+			cached:      []*database.ImportQueueItem{cachedItem("/config/.nzbs/Movies/Movie 2024 1080p WEB-DL.nzb", "/storage/movie1080", timePtr(now.Add(-1*time.Hour)))},
+			ttlHours:    24,
+			wantCached:  false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			results := []prowlarr.NZBResult{{Title: title, DownloadURL: "https://prowlarr/dl/1", Size: 1_500_000_000, Indexer: "IdxA"}}
+			sTitle := title
+			if tt.searchTitle != "" {
+				sTitle = tt.searchTitle
+			}
+			results := []prowlarr.NZBResult{{Title: sTitle, DownloadURL: "https://prowlarr/dl/1", Size: 1_500_000_000, Indexer: "IdxA"}}
 
 			entries := buildStremioStreamEntries(results, tt.cached, tt.ttlHours, now,
 				"https://host", "thekey", "movie", 0, 0, "tt123")

--- a/internal/api/tvdb_lookup.go
+++ b/internal/api/tvdb_lookup.go
@@ -64,3 +64,77 @@ func resolveTVDBFromIMDb(ctx context.Context, imdbID string) (string, error) {
 
 	return strconv.Itoa(data.Externals.TheTVDB), nil
 }
+
+type cinemetaLookupResponse struct {
+	Meta struct {
+		Name      string `json:"name"`
+		Year      string `json:"year"`
+		MovieDBID int    `json:"moviedb_id"`
+	} `json:"meta"`
+}
+
+// resolveSeriesMetadataFromIMDb resolves both TVDB ID and series title from an IMDb ID.
+func resolveSeriesMetadataFromIMDb(ctx context.Context, imdbID string) (tvdbID, title string, err error) {
+	if imdbID == "" {
+		return "", "", nil
+	}
+
+	tvdbID, _ = resolveTVDBFromIMDb(ctx, imdbID)
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("https://v3-cinemeta.strem.io/meta/series/%s.json", url.PathEscape(imdbID)),
+		nil,
+	)
+	if err == nil {
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", "altmount-stremio-tvdb-lookup")
+
+		if resp, err := tvmazeLookupClient.Do(req); err == nil {
+			defer resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				var cData cinemetaLookupResponse
+				if err := json.NewDecoder(resp.Body).Decode(&cData); err == nil {
+					title = cData.Meta.Name
+				}
+			}
+		}
+	}
+
+	return tvdbID, title, nil
+}
+
+// resolveMovieMetadataFromIMDb resolves TMDB ID, movie title, and release year from an IMDb ID.
+func resolveMovieMetadataFromIMDb(ctx context.Context, imdbID string) (tmdbID int, title string, year string, err error) {
+	if imdbID == "" {
+		return 0, "", "", nil
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("https://v3-cinemeta.strem.io/meta/movie/%s.json", url.PathEscape(imdbID)),
+		nil,
+	)
+	if err != nil {
+		return 0, "", "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "altmount-stremio-movie-lookup")
+
+	resp, err := tvmazeLookupClient.Do(req)
+	if err != nil {
+		return 0, "", "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		var cData cinemetaLookupResponse
+		if err := json.NewDecoder(resp.Body).Decode(&cData); err == nil {
+			return cData.Meta.MovieDBID, cData.Meta.Name, cData.Meta.Year, nil
+		}
+	}
+
+	return 0, "", "", nil
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -203,8 +203,9 @@ type ArrsInstanceAPIResponse struct {
 
 // StremioAPIResponse sanitizes Stremio config for API responses
 type StremioAPIResponse struct {
-	Enabled bool `json:"enabled"`
-	NzbTTLHours int `json:"nzb_ttl_hours"`
+	Enabled               bool                `json:"enabled"`
+	NzbTTLHours           int                 `json:"nzb_ttl_hours"`
+	ReuseLibraryReleases  *bool               `json:"reuse_library_releases"`
 	// No omitempty: an explicit 0 must survive the round-trip, otherwise saving the
 	// config would silently restore the defaults.
 	FailedReleaseTTLHours int                 `json:"failed_release_ttl_hours"`
@@ -386,6 +387,7 @@ func ToConfigAPIResponse(cfg *config.Config, apiKey string) *ConfigAPIResponse {
 	stremioResp := StremioAPIResponse{
 		Enabled:               cfg.Stremio.Enabled != nil && *cfg.Stremio.Enabled,
 		NzbTTLHours:           cfg.Stremio.NzbTTLHours,
+		ReuseLibraryReleases:  cfg.Stremio.ReuseLibraryReleases,
 		FailedReleaseTTLHours: cfg.Stremio.FailedReleaseTTLHours,
 		MaxFallbackReleases:   cfg.Stremio.MaxFallbackReleases,
 		BaseURL:               cfg.Stremio.BaseURL,

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -172,8 +172,11 @@ type StremioConfig struct {
 	Enabled *bool `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
 	// NzbTTLHours controls how long a completed NZB result is cached before
 	// the same NZB is re-processed on the next request.
-	// Set to 0 to disable expiry (cache forever). Defaults to 24 hours.
+	// Defaults to 24 hours. A value of 0 caches forever (releases never expire).
 	NzbTTLHours int `yaml:"nzb_ttl_hours" mapstructure:"nzb_ttl_hours" json:"nzb_ttl_hours"`
+	// ReuseLibraryReleases checks whether matching completed releases across
+	// the entire Altmount library should be reused for instant stream playback. Defaults to true.
+	ReuseLibraryReleases *bool `yaml:"reuse_library_releases" mapstructure:"reuse_library_releases" json:"reuse_library_releases"`
 	// FailedReleaseTTLHours controls how long a release that failed to import stays
 	// excluded from the Stremio stream list. Mirrors NzbTTLHours semantics: it filters
 	// failure records by age rather than deleting them, so it is bounded above by
@@ -204,6 +207,15 @@ func (s StremioConfig) EffectiveMaxFallbackReleases() int {
 		return maxStremioFallbackReleases
 	}
 	return s.MaxFallbackReleases
+}
+
+// EffectiveReuseLibraryReleases reports whether Stremio should check and reuse matching
+// completed releases across the entire Altmount library. Defaults to true.
+func (s StremioConfig) EffectiveReuseLibraryReleases() bool {
+	if s.ReuseLibraryReleases == nil {
+		return true
+	}
+	return *s.ReuseLibraryReleases
 }
 
 // AuthConfig represents authentication configuration

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -2427,3 +2427,76 @@ func (r *HealthRepository) matchMetadata(dbMeta, webMeta *model.WebhookMetadata)
 	return false
 }
 
+// FindHealthyFilesForMovie returns healthy library files matching a movie by TMDB ID or title/year.
+func (r *HealthRepository) FindHealthyFilesForMovie(ctx context.Context, title string, year string, tmdbID int) ([]*FileHealth, error) {
+	var query string
+	var args []interface{}
+
+	if tmdbID > 0 {
+		query = fileHealthSelectColumns + " WHERE status = 'healthy' AND metadata LIKE ? ORDER BY id DESC LIMIT 50"
+		args = append(args, fmt.Sprintf(`%%"tmdbId":%d%%`, tmdbID))
+	} else if cleanTitle := strings.TrimSpace(title); cleanTitle != "" {
+		if year != "" {
+			query = fileHealthSelectColumns + " WHERE status = 'healthy' AND (file_path LIKE ? OR library_path LIKE ?) AND (file_path LIKE ? OR library_path LIKE ?) ORDER BY id DESC LIMIT 50"
+			args = append(args, "%"+cleanTitle+"%", "%"+cleanTitle+"%", "%"+year+"%", "%"+year+"%")
+		} else {
+			query = fileHealthSelectColumns + " WHERE status = 'healthy' AND (file_path LIKE ? OR library_path LIKE ?) ORDER BY id DESC LIMIT 50"
+			args = append(args, "%"+cleanTitle+"%", "%"+cleanTitle+"%")
+		}
+	} else {
+		return nil, nil
+	}
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []*FileHealth
+	for rows.Next() {
+		h, err := scanFileHealth(rows)
+		if err != nil {
+			return nil, err
+		}
+		if h != nil {
+			results = append(results, h)
+		}
+	}
+	return results, rows.Err()
+}
+
+// FindHealthyFilesForSeries returns healthy library files matching a TV series by TVDB ID or series title.
+func (r *HealthRepository) FindHealthyFilesForSeries(ctx context.Context, seriesTitle string, tvdbID int) ([]*FileHealth, error) {
+	var query string
+	var args []interface{}
+
+	if tvdbID > 0 {
+		query = fileHealthSelectColumns + " WHERE status = 'healthy' AND metadata LIKE ? ORDER BY id DESC LIMIT 100"
+		args = append(args, fmt.Sprintf(`%%"tvdbId":%d%%`, tvdbID))
+	} else if cleanTitle := strings.TrimSpace(seriesTitle); cleanTitle != "" {
+		query = fileHealthSelectColumns + " WHERE status = 'healthy' AND (file_path LIKE ? OR library_path LIKE ?) ORDER BY id DESC LIMIT 100"
+		args = append(args, "%"+cleanTitle+"%", "%"+cleanTitle+"%")
+	} else {
+		return nil, nil
+	}
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []*FileHealth
+	for rows.Next() {
+		h, err := scanFileHealth(rows)
+		if err != nil {
+			return nil, err
+		}
+		if h != nil {
+			results = append(results, h)
+		}
+	}
+	return results, rows.Err()
+}
+

--- a/internal/database/health_repository_test.go
+++ b/internal/database/health_repository_test.go
@@ -717,3 +717,45 @@ func TestRelinkFileByFilename_ConflictMerge(t *testing.T) {
 	assert.Nil(t, oldH)
 }
 
+func TestHealthRepository_FindHealthyFilesForMovieAndSeries(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	// Insert movie records
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, library_path, status, metadata)
+		VALUES 
+		('complete/movies/Sample.Movie.2026.2160p.UHD.BluRay.x265-GROUP/sample.movie.2026.2160p.uhd.bluray.x265-group.mkv',
+		 '/library/movies/Sample Movie (2026)/Sample Movie (2026) - [Bluray-2160p][TrueHD Atmos 7.1][DV HDR10][x265]-GROUP.mkv',
+		 'healthy',
+		 '{"eventType":"Download","instanceName":"Radarr","movie":{"id":101,"tmdbId":1001},"movieFile":{"id":501,"sceneName":"Sample.Movie.2026.2160p.UHD.BluRay.x265-GROUP"}}'),
+		('complete/movies/Corrupted.Movie.2026/corrupted.mkv',
+		 '/library/movies/Corrupted (2026)/Corrupted.mkv',
+		 'corrupted',
+		 '{"eventType":"Download","instanceName":"Radarr","movie":{"id":102,"tmdbId":1001}}'),
+		('complete/tv/Sample.Series.S01E04.1080p.AMZN.WEB-DL.DDP2.0.H.264-GROUP/Sample.Series.S01E04.Episode.Name.1080p.AMZN.WEB-DL.DD2.0.H.264-GROUP.mkv',
+		 '/library/tv/Sample Series (2020)/Season 01/Sample Series (2020) - S01E04 - Episode Name [WEBDL-1080p][EAC3 2.0][x264]-GROUP.mkv',
+		 'healthy',
+		 '{"eventType":"Download","instanceName":"Sonarr","series":{"id":201,"tvdbId":2001},"episodeFile":{"id":601,"sceneName":"Sample.Series.S01E04.1080p.AMZN.WEB-DL.DDP2.0.H.264-GROUP"},"episodes":[{"id":701}]}')
+	`)
+	require.NoError(t, err)
+
+	// 1. Search Movie by TMDB ID
+	movies, err := repo.FindHealthyFilesForMovie(ctx, "Sample Movie", "2026", 1001)
+	require.NoError(t, err)
+	require.Len(t, movies, 1)
+	assert.Contains(t, movies[0].FilePath, "Sample.Movie.2026.2160p.UHD.BluRay.x265-GROUP")
+
+	// 2. Search Movie by Title and Year only (no TMDB ID)
+	movies, err = repo.FindHealthyFilesForMovie(ctx, "Sample Movie", "2026", 0)
+	require.NoError(t, err)
+	require.Len(t, movies, 1)
+	assert.Contains(t, movies[0].FilePath, "Sample.Movie.2026.2160p.UHD.BluRay.x265-GROUP")
+
+	// 3. Search Series by TVDB ID
+	series, err := repo.FindHealthyFilesForSeries(ctx, "Sample Series", 2001)
+	require.NoError(t, err)
+	require.Len(t, series, 1)
+	assert.Contains(t, series[0].FilePath, "Sample.Series.S01E04")
+}
+

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -2169,21 +2169,35 @@ func (r *Repository) GetFailedStremioQueueItems(ctx context.Context) ([]*ImportQ
 	return items, rows.Err()
 }
 
-// GetCachedStremioQueueItems returns completed Stremio-originated queue items that
-// have a storage path (i.e. are streamable). Used by the Stremio stream handler to
-// mark already-imported releases as cached. TTL freshness is applied by the caller.
-func (r *Repository) GetCachedStremioQueueItems(ctx context.Context) ([]*ImportQueueItem, error) {
-	query := `
-		SELECT id, download_id, nzb_path, relative_path, category, priority, status, created_at, updated_at,
-		       started_at, completed_at, retry_count, max_retries, error_message, batch_id, metadata, file_size, storage_path, target_path
-		FROM import_queue
-		WHERE status = 'completed'
-		  AND download_id LIKE 'stremio:%'
-		  AND storage_path IS NOT NULL
-		  AND storage_path != ''
-		ORDER BY completed_at DESC
-		LIMIT 500
-	`
+// GetCachedStremioQueueItems returns completed queue items that have a storage path
+// (i.e. are streamable). When reuseLibrary is true, it returns completed imports from
+// all sources (Sonarr, Radarr, SABnzbd, Stremio) across the entire library.
+func (r *Repository) GetCachedStremioQueueItems(ctx context.Context, reuseLibrary bool) ([]*ImportQueueItem, error) {
+	var query string
+	if reuseLibrary {
+		query = `
+			SELECT id, download_id, nzb_path, relative_path, category, priority, status, created_at, updated_at,
+			       started_at, completed_at, retry_count, max_retries, error_message, batch_id, metadata, file_size, storage_path, target_path
+			FROM import_queue
+			WHERE status = 'completed'
+			  AND storage_path IS NOT NULL
+			  AND storage_path != ''
+			ORDER BY completed_at DESC
+			LIMIT 1000
+		`
+	} else {
+		query = `
+			SELECT id, download_id, nzb_path, relative_path, category, priority, status, created_at, updated_at,
+			       started_at, completed_at, retry_count, max_retries, error_message, batch_id, metadata, file_size, storage_path, target_path
+			FROM import_queue
+			WHERE status = 'completed'
+			  AND download_id LIKE 'stremio:%'
+			  AND storage_path IS NOT NULL
+			  AND storage_path != ''
+			ORDER BY completed_at DESC
+			LIMIT 500
+		`
+	}
 
 	rows, err := r.db.QueryContext(ctx, query)
 	if err != nil {


### PR DESCRIPTION
### Summary
Enables the Stremio addon to check and reuse matching completed releases across the entire Altmount library (from Sonarr, Radarr, SABnzbd, or previous Stremio downloads) for instant 0s playback without duplicate downloading.

### Changes
- Update `GetCachedStremioQueueItems` to support querying the entire completed library when `reuse_library_releases` is enabled.
- Implement `normalizeTitleForMatching` using canonical alphanumeric normalization and cross-platform path handling (`\`/`/`).
- Guarantee zero false positives across sequels, different episode numbers, and resolutions with exact normalized equality checks.
- Add frontend setting toggle and unit tests.