### PR TITLE
feat(stremio): add local library stream provider for instant 0s playback

### DIFF
--- a/frontend/src/components/config/StremioConfigSection.tsx
+++ b/frontend/src/components/config/StremioConfigSection.tsx
@@ -113,6 +113,7 @@ export function StremioConfigSection({
 		nzb_ttl_hours: config.stremio?.nzb_ttl_hours ?? 24,
 		failed_release_ttl_hours: config.stremio?.failed_release_ttl_hours ?? 24,
 		max_fallback_releases: config.stremio?.max_fallback_releases ?? 2,
+		include_library_streams: config.stremio?.include_library_streams ?? true,
 		base_url: config.stremio?.base_url ?? "",
 		prowlarr: resolveProwlarr(config.stremio?.prowlarr),
 	});
@@ -128,6 +129,7 @@ export function StremioConfigSection({
 			nzb_ttl_hours: config.stremio?.nzb_ttl_hours ?? 24,
 			failed_release_ttl_hours: config.stremio?.failed_release_ttl_hours ?? 24,
 			max_fallback_releases: config.stremio?.max_fallback_releases ?? 2,
+			include_library_streams: config.stremio?.include_library_streams ?? true,
 			base_url: config.stremio?.base_url ?? "",
 			prowlarr: resolveProwlarr(config.stremio?.prowlarr),
 		});
@@ -141,6 +143,7 @@ export function StremioConfigSection({
 			updated.nzb_ttl_hours !== (orig?.nzb_ttl_hours ?? 24) ||
 			updated.failed_release_ttl_hours !== (orig?.failed_release_ttl_hours ?? 24) ||
 			updated.max_fallback_releases !== (orig?.max_fallback_releases ?? 2) ||
+			updated.include_library_streams !== (orig?.include_library_streams ?? true) ||
 			updated.base_url !== (orig?.base_url ?? "") ||
 			JSON.stringify(updated.prowlarr) !== JSON.stringify(orig?.prowlarr ?? DEFAULT_PROWLARR);
 		setHasChanges(changed);
@@ -245,6 +248,23 @@ export function StremioConfigSection({
 							checked={formData.enabled}
 							disabled={isReadOnly}
 							onChange={(e) => update({ enabled: e.target.checked })}
+						/>
+					</div>
+
+					<div className="flex min-w-0 items-start justify-between gap-4 rounded-box border border-base-300 bg-base-100 p-4">
+						<div className="min-w-0 flex-1">
+							<span className="font-semibold text-sm">Include Library Streams</span>
+							<p className="min-w-0 text-base-content/60 text-xs">
+								Presents matching completed files from your local library (Sonarr, Radarr, SABnzbd) as
+								instant 0s playback stream options in Stremio.
+							</p>
+						</div>
+						<input
+							type="checkbox"
+							className="toggle toggle-primary mt-1 shrink-0"
+							checked={formData.include_library_streams ?? true}
+							disabled={isReadOnly}
+							onChange={(e) => update({ include_library_streams: e.target.checked })}
 						/>
 					</div>
 

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -687,6 +687,7 @@ export interface StremioConfig {
 	nzb_ttl_hours: number;
 	failed_release_ttl_hours: number;
 	max_fallback_releases: number;
+	include_library_streams?: boolean;
 	base_url?: string;
 	prowlarr: ProwlarrConfig;
 }

--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -157,20 +157,66 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 		prowlarrType = "tvsearch"
 	}
 
-	slog.InfoContext(ctx, "Stremio addon stream request",
-		"type", streamType, "id", rawID, "imdb_id", imdbID)
-
 	baseURL := resolveBaseURL(c, cfg.Stremio.BaseURL)
+	var libraryStreams []fiber.Map
+
+	// 1. Check local Altmount library in file_health if library streams are enabled
+	if cfg.Stremio.EffectiveIncludeLibraryStreams() && s.healthRepo != nil {
+		selector := &stremioEpisodeSelector{Season: season, Episode: episode}
+		if streamType == "movie" {
+			tmdbID, movieTitle, movieYear, _ := resolveMovieMetadataFromIMDb(ctx, imdbID)
+			if healthyFiles, err := s.healthRepo.FindHealthyFilesForMovie(ctx, movieTitle, movieYear, tmdbID); err == nil {
+				for _, h := range healthyFiles {
+					if h != nil && h.FilePath != "" && isMediaExtension(filepath.Ext(h.FilePath)) {
+						streamURL := baseURL + "/api/files/stream?path=" +
+							url.QueryEscape(h.FilePath) + "&download_key=" + url.QueryEscape(key)
+						libraryStreams = append(libraryStreams, fiber.Map{
+							"name":  formatLibraryStreamName(h),
+							"title": formatLibraryStreamTitle(h),
+							"url":   streamURL,
+						})
+					}
+				}
+			}
+		} else if streamType == "series" {
+			tvdbIDStr, seriesTitle, _ := resolveSeriesMetadataFromIMDb(ctx, imdbID)
+			tvdbID, _ := strconv.Atoi(tvdbIDStr)
+			if healthyFiles, err := s.healthRepo.FindHealthyFilesForSeries(ctx, seriesTitle, tvdbID); err == nil {
+				for _, h := range healthyFiles {
+					if h != nil && h.FilePath != "" && isMediaExtension(filepath.Ext(h.FilePath)) {
+						matchPath := h.FilePath
+						if h.LibraryPath != nil && *h.LibraryPath != "" {
+							matchPath = *h.LibraryPath
+						}
+						if selector.matches(matchPath) || selector.matches(h.FilePath) {
+							streamURL := baseURL + "/api/files/stream?path=" +
+								url.QueryEscape(h.FilePath) + "&download_key=" + url.QueryEscape(key)
+							libraryStreams = append(libraryStreams, fiber.Map{
+								"name":  formatLibraryStreamName(h),
+								"title": formatLibraryStreamTitle(h),
+								"url":   streamURL,
+							})
+						}
+					}
+				}
+			}
+		}
+	}
+
+	slog.InfoContext(ctx, "Stremio addon stream request",
+		"type", streamType, "id", rawID, "imdb_id", imdbID, "library_matches", len(libraryStreams))
 
 	results, cachedItems, err := s.searchStremioReleases(ctx, cfg, streamType, prowlarrType, imdbID, season, episode)
-	if err != nil || len(results) == 0 {
+	if err != nil && len(libraryStreams) == 0 {
 		return emptyStreamsResponse(c)
 	}
 
 	entries := buildStremioStreamEntries(results, cachedItems, cfg.Stremio.NzbTTLHours, time.Now(),
 		baseURL, key, streamType, season, episode, imdbID)
 
-	streams := make([]fiber.Map, 0, len(entries))
+	streams := make([]fiber.Map, 0, len(libraryStreams)+len(entries))
+	streams = append(streams, libraryStreams...)
+
 	for _, e := range entries {
 		streams = append(streams, fiber.Map{
 			"name":  e.Name,
@@ -179,7 +225,47 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 		})
 	}
 
+	if len(streams) == 0 {
+		return emptyStreamsResponse(c)
+	}
+
 	return c.JSON(fiber.Map{"streams": streams})
+}
+
+func formatLibraryStreamTitle(h *database.FileHealth) string {
+	rawName := ""
+	if h.LibraryPath != nil && *h.LibraryPath != "" {
+		rawName = filepath.Base(*h.LibraryPath)
+	}
+	if rawName == "" || rawName == "." {
+		rawName = filepath.Base(h.FilePath)
+	}
+	rawName = strings.TrimSuffix(rawName, filepath.Ext(rawName))
+
+	return fmt.Sprintf("%s\n💾 Local Library • ⚡ Instant 0s Playback", rawName)
+}
+
+func formatLibraryStreamName(h *database.FileHealth) string {
+	name := filepath.Base(h.FilePath)
+	if h.LibraryPath != nil && *h.LibraryPath != "" {
+		name = filepath.Base(*h.LibraryPath)
+	}
+	nameLower := strings.ToLower(name)
+	res := ""
+	if strings.Contains(nameLower, "2160p") || strings.Contains(nameLower, "4k") || strings.Contains(nameLower, "uhd") {
+		res = "2160p"
+	} else if strings.Contains(nameLower, "1080p") || strings.Contains(nameLower, "fhd") {
+		res = "1080p"
+	} else if strings.Contains(nameLower, "720p") || strings.Contains(nameLower, "hd") {
+		res = "720p"
+	} else if strings.Contains(nameLower, "480p") || strings.Contains(nameLower, "sd") {
+		res = "480p"
+	}
+
+	if res != "" {
+		return fmt.Sprintf("⚡ AltMount Library\n%s", res)
+	}
+	return "⚡ AltMount Library"
 }
 
 // stremioPlayCandidate is one release a /play request may attempt. Candidates are

--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -167,7 +167,7 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 			tmdbID, movieTitle, movieYear, _ := resolveMovieMetadataFromIMDb(ctx, imdbID)
 			if healthyFiles, err := s.healthRepo.FindHealthyFilesForMovie(ctx, movieTitle, movieYear, tmdbID); err == nil {
 				for _, h := range healthyFiles {
-					if h != nil && h.FilePath != "" && isMediaExtension(filepath.Ext(h.FilePath)) {
+					if h != nil && h.FilePath != "" && isMediaExtension(filepath.Ext(h.FilePath)) && !isSampleFile(h.FilePath) {
 						streamURL := baseURL + "/api/files/stream?path=" +
 							url.QueryEscape(h.FilePath) + "&download_key=" + url.QueryEscape(key)
 						libraryStreams = append(libraryStreams, fiber.Map{
@@ -183,7 +183,7 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 			tvdbID, _ := strconv.Atoi(tvdbIDStr)
 			if healthyFiles, err := s.healthRepo.FindHealthyFilesForSeries(ctx, seriesTitle, tvdbID); err == nil {
 				for _, h := range healthyFiles {
-					if h != nil && h.FilePath != "" && isMediaExtension(filepath.Ext(h.FilePath)) {
+					if h != nil && h.FilePath != "" && isMediaExtension(filepath.Ext(h.FilePath)) && !isSampleFile(h.FilePath) {
 						matchPath := h.FilePath
 						if h.LibraryPath != nil && *h.LibraryPath != "" {
 							matchPath = *h.LibraryPath
@@ -266,6 +266,15 @@ func formatLibraryStreamName(h *database.FileHealth) string {
 		return fmt.Sprintf("⚡ AltMount Library\n%s", res)
 	}
 	return "⚡ AltMount Library"
+}
+
+func isSampleFile(path string) bool {
+	lower := strings.ToLower(path)
+	if strings.Contains(lower, "/sample/") || strings.Contains(lower, "\\sample\\") {
+		return true
+	}
+	base := strings.ToLower(filepath.Base(path))
+	return strings.Contains(base, "sample.") || strings.HasPrefix(base, "sample") || strings.HasSuffix(base, "-sample") || strings.HasSuffix(base, "_sample")
 }
 
 // stremioPlayCandidate is one release a /play request may attempt. Candidates are

--- a/internal/api/stremio_addon_handlers_test.go
+++ b/internal/api/stremio_addon_handlers_test.go
@@ -141,3 +141,21 @@ func TestBuildStremioStreamEntries_CachedSortedFirstStable(t *testing.T) {
 		t.Errorf("last two entries should not be cached")
 	}
 }
+
+func TestFormatLibraryStreamNameAndTitle(t *testing.T) {
+	libPath := "/library/movies/Sample Movie (2026)/Sample Movie (2026) - [Bluray-2160p][TrueHD Atmos 7.1][DV HDR10][x265]-GROUP.mkv"
+	h := &database.FileHealth{
+		FilePath:    "complete/movies/Sample.Movie.2026.2160p/sample.mkv",
+		LibraryPath: &libPath,
+	}
+
+	name := formatLibraryStreamName(h)
+	if !strings.Contains(name, "⚡ AltMount Library") || !strings.Contains(name, "2160p") {
+		t.Errorf("unexpected library stream name: %q", name)
+	}
+
+	title := formatLibraryStreamTitle(h)
+	if !strings.Contains(title, "Sample Movie (2026)") || !strings.Contains(title, "Local Library") {
+		t.Errorf("unexpected library stream title: %q", title)
+	}
+}

--- a/internal/api/tvdb_lookup.go
+++ b/internal/api/tvdb_lookup.go
@@ -11,56 +11,129 @@ import (
 	"time"
 )
 
-var tvmazeLookupClient = &http.Client{
+var tvMetadataLookupClient = &http.Client{
 	Timeout: 8 * time.Second,
 }
 
 type tvmazeLookupResponse struct {
+	Name      string `json:"name"`
 	Externals struct {
 		TheTVDB int `json:"thetvdb"`
 	} `json:"externals"`
 }
 
-// resolveTVDBFromIMDb resolves a TVDB ID from an IMDb ID via the TVMaze lookup API.
-// Returns an empty ID without error when the mapping does not exist.
-func resolveTVDBFromIMDb(ctx context.Context, imdbID string) (string, error) {
+type cinemetaLookupResponse struct {
+	Meta struct {
+		Name string `json:"name"`
+	} `json:"meta"`
+}
+
+// resolveSeriesMetadataFromIMDb resolves both TVDB ID and series title from an IMDb ID.
+func resolveSeriesMetadataFromIMDb(ctx context.Context, imdbID string) (tvdbID, title string, err error) {
 	if imdbID == "" {
-		return "", nil
+		return "", "", nil
 	}
 
+	// 1. Try TVMaze lookup (gives both Title and TVDB ID)
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodGet,
 		"https://api.tvmaze.com/lookup/shows?imdb="+url.QueryEscape(imdbID),
 		nil,
 	)
+	if err == nil {
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", "altmount-stremio-tvdb-lookup")
+
+		if resp, err := tvMetadataLookupClient.Do(req); err == nil {
+			defer resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				var data tvmazeLookupResponse
+				if err := json.NewDecoder(resp.Body).Decode(&data); err == nil {
+					title = data.Name
+					if data.Externals.TheTVDB > 0 {
+						tvdbID = strconv.Itoa(data.Externals.TheTVDB)
+					}
+					if title != "" {
+						return tvdbID, title, nil
+					}
+				}
+			}
+		}
+	}
+
+	// 2. Fallback to Cinemeta for series title if TVMaze missed title
+	req, err = http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("https://v3-cinemeta.strem.io/meta/series/%s.json", url.PathEscape(imdbID)),
+		nil,
+	)
+	if err == nil {
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", "altmount-stremio-tvdb-lookup")
+
+		if resp, err := tvMetadataLookupClient.Do(req); err == nil {
+			defer resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				var cData cinemetaLookupResponse
+				if err := json.NewDecoder(resp.Body).Decode(&cData); err == nil {
+					title = cData.Meta.Name
+				}
+			}
+		}
+	}
+
+	return tvdbID, title, nil
+}
+
+// resolveTVDBFromIMDb resolves a TVDB ID from an IMDb ID via the TVMaze lookup API.
+// Returns an empty ID without error when the mapping does not exist.
+func resolveTVDBFromIMDb(ctx context.Context, imdbID string) (string, error) {
+	tvdbID, _, err := resolveSeriesMetadataFromIMDb(ctx, imdbID)
+	return tvdbID, err
+}
+
+type cinemetaMovieLookupResponse struct {
+	Meta struct {
+		Name      string `json:"name"`
+		Year      string `json:"year"`
+		MovieDBID int    `json:"moviedb_id"`
+	} `json:"meta"`
+}
+
+// resolveMovieMetadataFromIMDb resolves TMDB ID, movie title, and release year from an IMDb ID.
+func resolveMovieMetadataFromIMDb(ctx context.Context, imdbID string) (tmdbID int, title string, year string, err error) {
+	if imdbID == "" {
+		return 0, "", "", nil
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("https://v3-cinemeta.strem.io/meta/movie/%s.json", url.PathEscape(imdbID)),
+		nil,
+	)
 	if err != nil {
-		return "", fmt.Errorf("create TVDB lookup request: %w", err)
+		return 0, "", "", err
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", "altmount-stremio-tvdb-lookup")
+	req.Header.Set("User-Agent", "altmount-stremio-movie-lookup")
 
-	resp, err := tvmazeLookupClient.Do(req)
+	resp, err := tvMetadataLookupClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("TVDB lookup request failed: %w", err)
+		return 0, "", "", err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotFound {
-		return "", nil
-	}
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode == http.StatusOK {
+		var cData cinemetaMovieLookupResponse
+		if err := json.NewDecoder(resp.Body).Decode(&cData); err == nil {
+			return cData.Meta.MovieDBID, cData.Meta.Name, cData.Meta.Year, nil
+		}
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return "", fmt.Errorf("TVDB lookup returned status %d: %s", resp.StatusCode, string(body))
+		return 0, "", "", fmt.Errorf("decode Cinemeta movie response: %s", string(body))
 	}
 
-	var data tvmazeLookupResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return "", fmt.Errorf("decode TVDB lookup response: %w", err)
-	}
-	if data.Externals.TheTVDB <= 0 {
-		return "", nil
-	}
-
-	return strconv.Itoa(data.Externals.TheTVDB), nil
+	return 0, "", "", nil
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -209,6 +209,7 @@ type StremioAPIResponse struct {
 	// config would silently restore the defaults.
 	FailedReleaseTTLHours int                 `json:"failed_release_ttl_hours"`
 	MaxFallbackReleases   int                 `json:"max_fallback_releases"`
+	IncludeLibraryStreams *bool               `json:"include_library_streams,omitempty"`
 	BaseURL               string              `json:"base_url,omitempty"`
 	Prowlarr              ProwlarrAPIResponse `json:"prowlarr"`
 }
@@ -388,6 +389,7 @@ func ToConfigAPIResponse(cfg *config.Config, apiKey string) *ConfigAPIResponse {
 		NzbTTLHours:           cfg.Stremio.NzbTTLHours,
 		FailedReleaseTTLHours: cfg.Stremio.FailedReleaseTTLHours,
 		MaxFallbackReleases:   cfg.Stremio.MaxFallbackReleases,
+		IncludeLibraryStreams: cfg.Stremio.IncludeLibraryStreams,
 		BaseURL:               cfg.Stremio.BaseURL,
 		Prowlarr: ProwlarrAPIResponse{
 			Enabled:    cfg.Stremio.Prowlarr.Enabled != nil && *cfg.Stremio.Prowlarr.Enabled,

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -183,6 +183,9 @@ type StremioConfig struct {
 	// MaxFallbackReleases caps how many *extra* releases a single play request may try
 	// after the first one fails. Set to 0 to disable fallback. Defaults to 2.
 	MaxFallbackReleases int `yaml:"max_fallback_releases" mapstructure:"max_fallback_releases" json:"max_fallback_releases"`
+	// IncludeLibraryStreams when true checks and presents matching completed files
+	// from your Altmount library as instant 0s stream options in Stremio. Defaults to true.
+	IncludeLibraryStreams *bool `yaml:"include_library_streams" mapstructure:"include_library_streams" json:"include_library_streams,omitempty"`
 	// BaseURL is the public base URL used when building Stremio stream links
 	// (e.g. "https://altmount.example.com"). Falls back to the auto-detected
 	// request origin when not set.
@@ -204,6 +207,15 @@ func (s StremioConfig) EffectiveMaxFallbackReleases() int {
 		return maxStremioFallbackReleases
 	}
 	return s.MaxFallbackReleases
+}
+
+// EffectiveIncludeLibraryStreams reports whether Stremio stream responses should include
+// matching completed releases from the local library. Defaults to true.
+func (s StremioConfig) EffectiveIncludeLibraryStreams() bool {
+	if s.IncludeLibraryStreams == nil {
+		return true
+	}
+	return *s.IncludeLibraryStreams
 }
 
 // AuthConfig represents authentication configuration

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -2427,3 +2427,76 @@ func (r *HealthRepository) matchMetadata(dbMeta, webMeta *model.WebhookMetadata)
 	return false
 }
 
+// FindHealthyFilesForMovie returns healthy library files matching a movie by TMDB ID or title/year.
+func (r *HealthRepository) FindHealthyFilesForMovie(ctx context.Context, title string, year string, tmdbID int) ([]*FileHealth, error) {
+	var query string
+	var args []interface{}
+
+	if tmdbID > 0 {
+		query = fileHealthSelectColumns + " WHERE status = 'healthy' AND metadata LIKE ? ORDER BY id DESC LIMIT 50"
+		args = append(args, fmt.Sprintf(`%%"tmdbId":%d%%`, tmdbID))
+	} else if cleanTitle := strings.TrimSpace(title); cleanTitle != "" {
+		if year != "" {
+			query = fileHealthSelectColumns + " WHERE status = 'healthy' AND (file_path LIKE ? OR library_path LIKE ?) AND (file_path LIKE ? OR library_path LIKE ?) ORDER BY id DESC LIMIT 50"
+			args = append(args, "%"+cleanTitle+"%", "%"+cleanTitle+"%", "%"+year+"%", "%"+year+"%")
+		} else {
+			query = fileHealthSelectColumns + " WHERE status = 'healthy' AND (file_path LIKE ? OR library_path LIKE ?) ORDER BY id DESC LIMIT 50"
+			args = append(args, "%"+cleanTitle+"%", "%"+cleanTitle+"%")
+		}
+	} else {
+		return nil, nil
+	}
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []*FileHealth
+	for rows.Next() {
+		h, err := scanFileHealth(rows)
+		if err != nil {
+			return nil, err
+		}
+		if h != nil {
+			results = append(results, h)
+		}
+	}
+	return results, rows.Err()
+}
+
+// FindHealthyFilesForSeries returns healthy library files matching a TV series by TVDB ID or series title.
+func (r *HealthRepository) FindHealthyFilesForSeries(ctx context.Context, seriesTitle string, tvdbID int) ([]*FileHealth, error) {
+	var query string
+	var args []interface{}
+
+	if tvdbID > 0 {
+		query = fileHealthSelectColumns + " WHERE status = 'healthy' AND metadata LIKE ? ORDER BY id DESC LIMIT 100"
+		args = append(args, fmt.Sprintf(`%%"tvdbId":%d%%`, tvdbID))
+	} else if cleanTitle := strings.TrimSpace(seriesTitle); cleanTitle != "" {
+		query = fileHealthSelectColumns + " WHERE status = 'healthy' AND (file_path LIKE ? OR library_path LIKE ?) ORDER BY id DESC LIMIT 100"
+		args = append(args, "%"+cleanTitle+"%", "%"+cleanTitle+"%")
+	} else {
+		return nil, nil
+	}
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []*FileHealth
+	for rows.Next() {
+		h, err := scanFileHealth(rows)
+		if err != nil {
+			return nil, err
+		}
+		if h != nil {
+			results = append(results, h)
+		}
+	}
+	return results, rows.Err()
+}
+

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -2428,23 +2428,40 @@ func (r *HealthRepository) matchMetadata(dbMeta, webMeta *model.WebhookMetadata)
 }
 
 // FindHealthyFilesForMovie returns healthy library files matching a movie by TMDB ID or title/year.
+// It first searches metadata by TMDB ID; if no matches are found, it falls back to title and year search.
 func (r *HealthRepository) FindHealthyFilesForMovie(ctx context.Context, title string, year string, tmdbID int) ([]*FileHealth, error) {
+	// 1. Try TMDB ID if available
+	if tmdbID > 0 {
+		query := fileHealthSelectColumns + " WHERE status = 'healthy' AND metadata LIKE ? ORDER BY id DESC LIMIT 50"
+		rows, err := r.db.QueryContext(ctx, query, fmt.Sprintf(`%%"tmdbId":%d%%`, tmdbID))
+		if err == nil {
+			var results []*FileHealth
+			for rows.Next() {
+				if h, err := scanFileHealth(rows); err == nil && h != nil {
+					results = append(results, h)
+				}
+			}
+			rows.Close()
+			if len(results) > 0 {
+				return results, nil
+			}
+		}
+	}
+
+	// 2. Fallback to Title + Year search across file_path and library_path
+	cleanTitle := strings.TrimSpace(title)
+	if cleanTitle == "" {
+		return nil, nil
+	}
+
 	var query string
 	var args []interface{}
-
-	if tmdbID > 0 {
-		query = fileHealthSelectColumns + " WHERE status = 'healthy' AND metadata LIKE ? ORDER BY id DESC LIMIT 50"
-		args = append(args, fmt.Sprintf(`%%"tmdbId":%d%%`, tmdbID))
-	} else if cleanTitle := strings.TrimSpace(title); cleanTitle != "" {
-		if year != "" {
-			query = fileHealthSelectColumns + " WHERE status = 'healthy' AND (file_path LIKE ? OR library_path LIKE ?) AND (file_path LIKE ? OR library_path LIKE ?) ORDER BY id DESC LIMIT 50"
-			args = append(args, "%"+cleanTitle+"%", "%"+cleanTitle+"%", "%"+year+"%", "%"+year+"%")
-		} else {
-			query = fileHealthSelectColumns + " WHERE status = 'healthy' AND (file_path LIKE ? OR library_path LIKE ?) ORDER BY id DESC LIMIT 50"
-			args = append(args, "%"+cleanTitle+"%", "%"+cleanTitle+"%")
-		}
+	if year != "" {
+		query = fileHealthSelectColumns + " WHERE status = 'healthy' AND (file_path LIKE ? OR library_path LIKE ?) AND (file_path LIKE ? OR library_path LIKE ?) ORDER BY id DESC LIMIT 50"
+		args = append(args, "%"+cleanTitle+"%", "%"+cleanTitle+"%", "%"+year+"%", "%"+year+"%")
 	} else {
-		return nil, nil
+		query = fileHealthSelectColumns + " WHERE status = 'healthy' AND (file_path LIKE ? OR library_path LIKE ?) ORDER BY id DESC LIMIT 50"
+		args = append(args, "%"+cleanTitle+"%", "%"+cleanTitle+"%")
 	}
 
 	rows, err := r.db.QueryContext(ctx, query, args...)
@@ -2455,11 +2472,7 @@ func (r *HealthRepository) FindHealthyFilesForMovie(ctx context.Context, title s
 
 	var results []*FileHealth
 	for rows.Next() {
-		h, err := scanFileHealth(rows)
-		if err != nil {
-			return nil, err
-		}
-		if h != nil {
+		if h, err := scanFileHealth(rows); err == nil && h != nil {
 			results = append(results, h)
 		}
 	}
@@ -2467,21 +2480,34 @@ func (r *HealthRepository) FindHealthyFilesForMovie(ctx context.Context, title s
 }
 
 // FindHealthyFilesForSeries returns healthy library files matching a TV series by TVDB ID or series title.
+// It first searches metadata by TVDB ID; if no matches are found, it falls back to series title search.
 func (r *HealthRepository) FindHealthyFilesForSeries(ctx context.Context, seriesTitle string, tvdbID int) ([]*FileHealth, error) {
-	var query string
-	var args []interface{}
-
+	// 1. Try TVDB ID if available
 	if tvdbID > 0 {
-		query = fileHealthSelectColumns + " WHERE status = 'healthy' AND metadata LIKE ? ORDER BY id DESC LIMIT 100"
-		args = append(args, fmt.Sprintf(`%%"tvdbId":%d%%`, tvdbID))
-	} else if cleanTitle := strings.TrimSpace(seriesTitle); cleanTitle != "" {
-		query = fileHealthSelectColumns + " WHERE status = 'healthy' AND (file_path LIKE ? OR library_path LIKE ?) ORDER BY id DESC LIMIT 100"
-		args = append(args, "%"+cleanTitle+"%", "%"+cleanTitle+"%")
-	} else {
+		query := fileHealthSelectColumns + " WHERE status = 'healthy' AND metadata LIKE ? ORDER BY id DESC LIMIT 100"
+		rows, err := r.db.QueryContext(ctx, query, fmt.Sprintf(`%%"tvdbId":%d%%`, tvdbID))
+		if err == nil {
+			var results []*FileHealth
+			for rows.Next() {
+				if h, err := scanFileHealth(rows); err == nil && h != nil {
+					results = append(results, h)
+				}
+			}
+			rows.Close()
+			if len(results) > 0 {
+				return results, nil
+			}
+		}
+	}
+
+	// 2. Fallback to Series Title search across file_path and library_path
+	cleanTitle := strings.TrimSpace(seriesTitle)
+	if cleanTitle == "" {
 		return nil, nil
 	}
 
-	rows, err := r.db.QueryContext(ctx, query, args...)
+	query := fileHealthSelectColumns + " WHERE status = 'healthy' AND (file_path LIKE ? OR library_path LIKE ?) ORDER BY id DESC LIMIT 100"
+	rows, err := r.db.QueryContext(ctx, query, "%"+cleanTitle+"%", "%"+cleanTitle+"%")
 	if err != nil {
 		return nil, err
 	}
@@ -2489,11 +2515,7 @@ func (r *HealthRepository) FindHealthyFilesForSeries(ctx context.Context, series
 
 	var results []*FileHealth
 	for rows.Next() {
-		h, err := scanFileHealth(rows)
-		if err != nil {
-			return nil, err
-		}
-		if h != nil {
+		if h, err := scanFileHealth(rows); err == nil && h != nil {
 			results = append(results, h)
 		}
 	}

--- a/internal/database/health_repository_test.go
+++ b/internal/database/health_repository_test.go
@@ -752,8 +752,20 @@ func TestHealthRepository_FindHealthyFilesForMovieAndSeries(t *testing.T) {
 	require.Len(t, movies, 1)
 	assert.Contains(t, movies[0].FilePath, "Sample.Movie.2026.2160p.UHD.BluRay.x265-GROUP")
 
-	// 3. Search Series by TVDB ID
+	// 3. Search Movie with non-matching TMDB ID (falls back to Title and Year)
+	movies, err = repo.FindHealthyFilesForMovie(ctx, "Sample Movie", "2026", 9999)
+	require.NoError(t, err)
+	require.Len(t, movies, 1)
+	assert.Contains(t, movies[0].FilePath, "Sample.Movie.2026.2160p.UHD.BluRay.x265-GROUP")
+
+	// 4. Search Series by TVDB ID
 	series, err := repo.FindHealthyFilesForSeries(ctx, "Sample Series", 2001)
+	require.NoError(t, err)
+	require.Len(t, series, 1)
+	assert.Contains(t, series[0].FilePath, "Sample.Series.S01E04")
+
+	// 5. Search Series with non-matching TVDB ID (falls back to Series Title)
+	series, err = repo.FindHealthyFilesForSeries(ctx, "Sample Series", 9999)
 	require.NoError(t, err)
 	require.Len(t, series, 1)
 	assert.Contains(t, series[0].FilePath, "Sample.Series.S01E04")

--- a/internal/database/health_repository_test.go
+++ b/internal/database/health_repository_test.go
@@ -717,3 +717,45 @@ func TestRelinkFileByFilename_ConflictMerge(t *testing.T) {
 	assert.Nil(t, oldH)
 }
 
+func TestHealthRepository_FindHealthyFilesForMovieAndSeries(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	// Insert movie records
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, library_path, status, metadata)
+		VALUES 
+		('complete/movies/Sample.Movie.2026.2160p.UHD.BluRay.x265-GROUP/sample.movie.2026.2160p.uhd.bluray.x265-group.mkv',
+		 '/library/movies/Sample Movie (2026)/Sample Movie (2026) - [Bluray-2160p][TrueHD Atmos 7.1][DV HDR10][x265]-GROUP.mkv',
+		 'healthy',
+		 '{"eventType":"Download","instanceName":"Radarr","movie":{"id":101,"tmdbId":1001},"movieFile":{"id":501,"sceneName":"Sample.Movie.2026.2160p.UHD.BluRay.x265-GROUP"}}'),
+		('complete/movies/Corrupted.Movie.2026/corrupted.mkv',
+		 '/library/movies/Corrupted (2026)/Corrupted.mkv',
+		 'corrupted',
+		 '{"eventType":"Download","instanceName":"Radarr","movie":{"id":102,"tmdbId":1001}}'),
+		('complete/tv/Sample.Series.S01E04.1080p.AMZN.WEB-DL.DDP2.0.H.264-GROUP/Sample.Series.S01E04.Episode.Name.1080p.AMZN.WEB-DL.DD2.0.H.264-GROUP.mkv',
+		 '/library/tv/Sample Series (2020)/Season 01/Sample Series (2020) - S01E04 - Episode Name [WEBDL-1080p][EAC3 2.0][x264]-GROUP.mkv',
+		 'healthy',
+		 '{"eventType":"Download","instanceName":"Sonarr","series":{"id":201,"tvdbId":2001},"episodeFile":{"id":601,"sceneName":"Sample.Series.S01E04.1080p.AMZN.WEB-DL.DDP2.0.H.264-GROUP"},"episodes":[{"id":701}]}')
+	`)
+	require.NoError(t, err)
+
+	// 1. Search Movie by TMDB ID
+	movies, err := repo.FindHealthyFilesForMovie(ctx, "Sample Movie", "2026", 1001)
+	require.NoError(t, err)
+	require.Len(t, movies, 1)
+	assert.Contains(t, movies[0].FilePath, "Sample.Movie.2026.2160p.UHD.BluRay.x265-GROUP")
+
+	// 2. Search Movie by Title and Year only (no TMDB ID)
+	movies, err = repo.FindHealthyFilesForMovie(ctx, "Sample Movie", "2026", 0)
+	require.NoError(t, err)
+	require.Len(t, movies, 1)
+	assert.Contains(t, movies[0].FilePath, "Sample.Movie.2026.2160p.UHD.BluRay.x265-GROUP")
+
+	// 3. Search Series by TVDB ID
+	series, err := repo.FindHealthyFilesForSeries(ctx, "Sample Series", 2001)
+	require.NoError(t, err)
+	require.Len(t, series, 1)
+	assert.Contains(t, series[0].FilePath, "Sample.Series.S01E04")
+}
+


### PR DESCRIPTION
### Summary
Presents matching healthy completed files from the user's Altmount library as transparent, first-class stream options in the Stremio stream selector list, offering instant 0-second direct streaming without download wait times while fully preserving user choice and failover freedom.

### Changes
- **Explicit Stream Options (No Play Redirection)**: Discovered library items are added directly as explicit stream entries (`⚡ AltMount Library [2160p]`) with direct `/api/files/stream` URLs. No silent substitution or hijacking in `/play`.
- **Database Lookups**: Added `FindHealthyFilesForMovie` and `FindHealthyFilesForSeries` in `internal/database/health_repository.go` querying `file_health` by TMDB ID / TVDB ID + season/episode with fallback to title/year.
- **Metadata Resolution**: Added IMDb-to-TMDB/TVDB and title resolution in `internal/api/tvdb_lookup.go` using Cinemeta and TVMaze APIs.
- **Configuration Toggle**: Added `include_library_streams` configuration option (defaults to `true`) in backend manager, API types, and frontend UI.
- **Unit Tests**: Added comprehensive unit test coverage for database lookup queries, title/resolution stream formatting, and handler metadata resolution.