### PR TITLE
feat(metadata): migrate legacy inline-segment metadata to the v3 shared NZB store

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -207,6 +207,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 		apiServer.SetLibrarySyncWorker(librarySyncWorker)
 	}
 
+	// Legacy metadata → v3 store migration. Manually triggered from the panel;
+	// creating the worker starts nothing.
+	apiServer.SetMetadataMigrationWorker(
+		metadata.NewMigrationWorker(metadataService, configManager.GetConfigGetter()),
+	)
+
 	// Register health system config change handler for dynamic enable/disable
 	if healthWorker != nil && librarySyncWorker != nil {
 		healthController := health.NewHealthSystemController(healthWorker, librarySyncWorker)

--- a/docs/superpowers/plans/2026-08-21-metadata-v3-migration.md
+++ b/docs/superpowers/plans/2026-08-21-metadata-v3-migration.md
@@ -1,0 +1,2484 @@
+# Legacy Metadata → v3 Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate legacy inline-segment `.meta` files to the v3 store-backed format, merging each release onto one shared `.nzbz`, driven manually from the AltMount panel with a dry run first.
+
+**Architecture:** A `MigrationWorker` in `internal/metadata` (modeled on `internal/health.LibrarySyncWorker`) walks the metadata root, groups legacy metas by release, builds one `NzbStore` per group (faithful from a surviving source `.nzb`, else synthesized from the inline segments), writes and verifies the `.nzbz`, then repoints each meta through the existing `MetadataService.WriteFileMetadataV3`. Fiber handlers expose status/dry-run/start/cancel; a React card in the metadata config section drives it.
+
+**Tech Stack:** Go 1.x, protobuf (`google.golang.org/protobuf`), `github.com/javi11/nzbparser`, zstd (`klauspost/compress`), Fiber v2, React + TypeScript, TanStack Query, DaisyUI, Vitest-free (Go tests only), Bun.
+
+**Spec:** `docs/superpowers/specs/2026-08-21-metadata-v1-to-v3-migration-design.md`
+
+## Global Constraints
+
+- Go logging MUST use `slog` context methods (`InfoContext`, `ErrorContext`, `WarnContext`, `DebugContext`), never bare `slog.Info`.
+- API handlers MUST use the response builders in `internal/api/response.go` (`RespondSuccess`, `RespondConflict`, `RespondInternalError`, `RespondMessage`), never inline `c.JSON` envelopes.
+- Frontend MUST use named exports, explicit `type` attributes on every `<button>`, DaisyUI components, Lucide icons, and direct imports (no barrel/`index.ts` files).
+- Never delete or rewrite `.id` sidecar files; `ReadFileMetadata` populates `NzbdavId` from them and `WriteFileMetadata` leaves them alone.
+- Store files are written under `<configDir>/.nzbs/_migrated/`, where `configDir` is the absolute `filepath.Dir(cfg.Database.Path)`.
+- The default synthesized newsgroup is `alt.binaries.misc`.
+- Conventional Commits on every commit (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`, with optional scope).
+- Never overwrite an existing `.nzbz` belonging to a different segment set: store filenames embed a content hash.
+
+---
+
+### Task 1: Move `BuildStore` into `internal/metadata`
+
+The faithful-store path needs `BuildStore`, but `internal/metadata` must not depend on `internal/importer`. `internal/importer/parser` depends only on `internal/metadata/proto`, so moving the function to `internal/metadata` (where `NzbStore` lives) is cycle-free and keeps store construction in one place. There are exactly two call sites.
+
+**Files:**
+- Create: `internal/metadata/build_store.go`
+- Create: `internal/metadata/build_store_test.go`
+- Modify: `internal/importer/parser/parser.go:138` and delete `BuildStore` at `internal/importer/parser/parser.go:1478-1507`
+- Delete: `internal/importer/parser/build_store_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `metadata.BuildStore(n *nzbparser.Nzb) (*metapb.NzbStore, map[string]int64)` — used by Task 5.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/metadata/build_store_test.go`:
+
+```go
+package metadata
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/javi11/nzbparser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildStore(t *testing.T) {
+	nzb := &nzbparser.Nzb{
+		Files: nzbparser.NzbFiles{
+			{Subject: "Movie.mkv (1/2)", Poster: "p@x", Date: 1000, Groups: []string{"a.b.test"},
+				Segments: nzbparser.NzbSegments{{ID: "m1@x", Number: 1, Bytes: 700000}, {ID: "m2@x", Number: 2, Bytes: 500000}}},
+			{Subject: "Movie.par2 (1/1)", Poster: "p@x", Date: 1000, Groups: []string{"a.b.test"},
+				Segments: nzbparser.NzbSegments{{ID: "p1@x", Number: 1, Bytes: 4096}}},
+		},
+	}
+	for i := range nzb.Files {
+		sort.Sort(nzb.Files[i].Segments)
+	}
+
+	store, index := BuildStore(nzb)
+	require.NotNil(t, store)
+	require.Len(t, store.Files, 2)
+	assert.Equal(t, "Movie.mkv (1/2)", store.Files[0].Subject)
+	assert.Equal(t, "p@x", store.Files[0].Poster)
+	assert.EqualValues(t, 1000, store.Files[0].Date)
+	assert.Equal(t, []string{"a.b.test"}, store.Files[0].Groups)
+	require.Len(t, store.Files[0].Segments, 2)
+	assert.Equal(t, "m1@x", store.Files[0].Segments[0].Id)
+	assert.EqualValues(t, 700000, store.Files[0].Segments[0].Bytes)
+
+	assert.EqualValues(t, 0, index["m1@x"])
+	assert.EqualValues(t, 1, index["m2@x"])
+	assert.EqualValues(t, 2, index["p1@x"])
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/metadata/ -run TestBuildStore -v`
+Expected: FAIL — `undefined: BuildStore`
+
+- [ ] **Step 3: Create the new file**
+
+Create `internal/metadata/build_store.go`:
+
+```go
+package metadata
+
+import (
+	"sort"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/javi11/nzbparser"
+)
+
+// BuildStore converts a parsed NZB into a NzbStore (for persistence) plus a
+// message-id → flat-store-index lookup used to emit SegmentRefs.
+// Segments are stored in their natural NzbSegments order (by Number after sort).
+func BuildStore(n *nzbparser.Nzb) (*metapb.NzbStore, map[string]int64) {
+	store := &metapb.NzbStore{Files: make([]*metapb.NzbFileEntry, 0, len(n.Files))}
+	index := make(map[string]int64)
+	var flat int64
+	for _, f := range n.Files {
+		fe := &metapb.NzbFileEntry{
+			Subject: f.Subject,
+			Poster:  f.Poster,
+			Date:    int64(f.Date),
+			Groups:  f.Groups,
+		}
+		segs := make(nzbparser.NzbSegments, len(f.Segments))
+		copy(segs, f.Segments)
+		sort.Sort(segs)
+		for _, s := range segs {
+			fe.Segments = append(fe.Segments, &metapb.NzbSeg{
+				Id:     s.ID,
+				Number: int32(s.Number),
+				Bytes:  int64(s.Bytes),
+			})
+			index[s.ID] = flat
+			flat++
+		}
+		store.Files = append(store.Files, fe)
+	}
+	return store, index
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/metadata/ -run TestBuildStore -v`
+Expected: PASS
+
+- [ ] **Step 5: Remove the old copy and repoint the caller**
+
+Delete the whole `BuildStore` function from `internal/importer/parser/parser.go` (the block starting with the comment `// BuildStore converts a parsed NZB into a NzbStore (for persistence) plus a` and ending with the closing `}` of the function, around lines 1478-1507).
+
+Delete `internal/importer/parser/build_store_test.go`.
+
+Change `internal/importer/parser/parser.go:138` from:
+
+```go
+	parsed.Store, parsed.SegmentIndex = BuildStore(n)
+```
+
+to:
+
+```go
+	parsed.Store, parsed.SegmentIndex = metadata.BuildStore(n)
+```
+
+Add `"github.com/javi11/altmount/internal/metadata"` to the import block of `internal/importer/parser/parser.go`. If `sort` becomes unused there, leave it — it is used elsewhere in that file (`sort.Sort(segs)` appears in other functions); run the build to confirm.
+
+- [ ] **Step 6: Verify the whole build and the parser package**
+
+Run: `go build ./... && go test ./internal/importer/parser/ ./internal/metadata/ 2>&1 | tail -20`
+Expected: build succeeds, both packages PASS (or `no test files` for a package without tests)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/metadata/build_store.go internal/metadata/build_store_test.go internal/importer/parser/parser.go
+git rm internal/importer/parser/build_store_test.go
+git commit -m "refactor(metadata): move BuildStore next to the NzbStore it builds"
+```
+
+---
+
+### Task 2: Add `metadata.migration.default_group` config
+
+**Files:**
+- Modify: `internal/config/manager.go:326-330` (`MetadataConfig`) and the defaults block at `internal/config/manager.go:1686-1691`
+- Modify: `frontend/src/types/config.ts:70-81`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `config.MetadataMigrationConfig{DefaultGroup string}`, reachable as `cfg.Metadata.Migration.DefaultGroup`; TS `MetadataMigrationConfig { default_group: string }` on `MetadataConfig.migration`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/config/metadata_migration_test.go`:
+
+```go
+package config
+
+import "testing"
+
+func TestDefaultConfig_MetadataMigrationDefaultGroup(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Metadata.Migration.DefaultGroup != "alt.binaries.misc" {
+		t.Fatalf("expected default group alt.binaries.misc, got %q", cfg.Metadata.Migration.DefaultGroup)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/config/ -run TestDefaultConfig_MetadataMigrationDefaultGroup -v`
+Expected: FAIL — `cfg.Metadata.Migration undefined`
+
+- [ ] **Step 3: Add the config struct and default**
+
+In `internal/config/manager.go`, change `MetadataConfig` (line 326) to add the field:
+
+```go
+type MetadataConfig struct {
+	RootPath                 string                  `yaml:"root_path" mapstructure:"root_path" json:"root_path"`
+	DeleteSourceNzbOnRemoval *bool                   `yaml:"delete_source_nzb_on_removal" mapstructure:"delete_source_nzb_on_removal" json:"delete_source_nzb_on_removal,omitempty"`
+	Backup                   MetadataBackupConfig    `yaml:"backup" mapstructure:"backup" json:"backup"`
+	Migration                MetadataMigrationConfig `yaml:"migration" mapstructure:"migration" json:"migration"`
+}
+
+// MetadataMigrationConfig configures the legacy-metadata → v3 migration.
+type MetadataMigrationConfig struct {
+	// DefaultGroup is the newsgroup written into synthesized NzbStore entries.
+	// Legacy metas do not retain the original groups, and nzb.BuildNZB renders an
+	// empty <groups> element without this, which most NZB clients reject.
+	DefaultGroup string `yaml:"default_group" mapstructure:"default_group" json:"default_group"`
+}
+```
+
+In the defaults block (after the `Backup: MetadataBackupConfig{...}` literal ending at line 1691), add:
+
+```go
+			Migration: MetadataMigrationConfig{
+				DefaultGroup: "alt.binaries.misc",
+			},
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/config/ -run TestDefaultConfig_MetadataMigrationDefaultGroup -v`
+Expected: PASS
+
+- [ ] **Step 5: Add the TypeScript type**
+
+In `frontend/src/types/config.ts`, change `MetadataConfig` (line 70) and add the new interface after `MetadataBackupConfig`:
+
+```ts
+export interface MetadataConfig {
+	root_path: string;
+	delete_source_nzb_on_removal?: boolean;
+	backup: MetadataBackupConfig;
+	migration?: MetadataMigrationConfig;
+}
+
+export interface MetadataMigrationConfig {
+	default_group: string;
+}
+```
+
+- [ ] **Step 6: Verify**
+
+Run: `go build ./... && cd frontend && bun run check`
+Expected: both succeed
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/config/manager.go internal/config/metadata_migration_test.go frontend/src/types/config.ts
+git commit -m "feat(config): add metadata.migration.default_group"
+```
+
+---
+
+### Task 3: Scan and group legacy metas
+
+**Files:**
+- Create: `internal/metadata/migration_scan.go`
+- Create: `internal/metadata/migration_scan_test.go`
+
+**Interfaces:**
+- Consumes: `isV3Meta(data []byte) bool` (`service.go:32`), `MetadataService.ReadFileMetadata(virtualPath string) (*metapb.FileMetadata, error)`.
+- Produces:
+  - `type LegacyMeta struct { MetaPath, VirtualPath string; SizeBytes int64; Meta *metapb.FileMetadata }`
+  - `type LegacyGroup struct { Key string; Files []LegacyMeta }`
+  - `func (ms *MetadataService) ScanLegacyMetas() ([]LegacyGroup, error)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/metadata/migration_scan_test.go`:
+
+```go
+package metadata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeLegacyMeta writes a v1 (inline-segment, no magic) meta at virtualPath.
+func writeLegacyMeta(t *testing.T, ms *MetadataService, virtualPath, sourceNzb string, ids ...string) {
+	t.Helper()
+	segs := make([]*metapb.SegmentData, 0, len(ids))
+	for _, id := range ids {
+		segs = append(segs, &metapb.SegmentData{Id: id, SegmentSize: 100, StartOffset: 0, EndOffset: 99})
+	}
+	meta := &metapb.FileMetadata{
+		FileSize:      int64(100 * len(ids)),
+		Status:        metapb.FileStatus_FILE_STATUS_HEALTHY,
+		SourceNzbPath: sourceNzb,
+		SegmentData:   segs,
+	}
+	require.NoError(t, ms.WriteFileMetadata(virtualPath, meta))
+}
+
+func TestScanLegacyMetas_GroupsBySourceNzbPath(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	writeLegacyMeta(t, ms, filepath.Join("movies", "A.mkv"), "/nzbs/rel.nzb", "a1@n", "a2@n")
+	writeLegacyMeta(t, ms, filepath.Join("movies", "B.mkv"), "/nzbs/rel.nzb", "b1@n")
+	writeLegacyMeta(t, ms, filepath.Join("other", "C.mkv"), "", "c1@n")
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 2, "two releases: one keyed by source nzb, one by parent dir")
+
+	byKey := map[string][]LegacyMeta{}
+	for _, g := range groups {
+		byKey[g.Key] = g.Files
+	}
+	require.Len(t, byKey["/nzbs/rel.nzb"], 2)
+	assert.Equal(t, filepath.Join("movies", "A.mkv"), byKey["/nzbs/rel.nzb"][0].VirtualPath)
+	assert.Equal(t, filepath.Join("movies", "B.mkv"), byKey["/nzbs/rel.nzb"][1].VirtualPath)
+
+	dirKey := filepath.Join(root, "other")
+	require.Len(t, byKey[dirKey], 1, "empty source_nzb_path falls back to the parent directory")
+	assert.Positive(t, byKey[dirKey][0].SizeBytes)
+	require.Len(t, byKey[dirKey][0].Meta.SegmentData, 1)
+}
+
+func TestScanLegacyMetas_SkipsV3Metas(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+	storeRef := filepath.Join(t.TempDir(), "rel.nzbz")
+
+	store := &metapb.NzbStore{Files: []*metapb.NzbFileEntry{
+		{Subject: "V3.mkv", Segments: []*metapb.NzbSeg{{Id: "v1@n", Number: 1, Bytes: 100}}},
+	}}
+	require.NoError(t, ms.Store().WriteStore(storeRef, store))
+	require.NoError(t, ms.WriteFileMetadata(filepath.Join("movies", "V3.mkv"), &metapb.FileMetadata{
+		FileSize: 100,
+		StoreRef: storeRef,
+		SegmentRefs: []*metapb.SegmentRef{
+			{StoreIndex: 0, StartOffset: 0, EndOffset: 99, DecodedBytes: 100},
+		},
+	}))
+	writeLegacyMeta(t, ms, filepath.Join("movies", "Old.mkv"), "/nzbs/old.nzb", "o1@n")
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 1, "already-migrated metas are skipped")
+	assert.Equal(t, "/nzbs/old.nzb", groups[0].Key)
+
+	// Sanity: a non-.meta file in the tree is ignored.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "movies", "stray.txt"), []byte("x"), 0644))
+	groups, err = ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/metadata/ -run TestScanLegacyMetas -v`
+Expected: FAIL — `ms.ScanLegacyMetas undefined`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/metadata/migration_scan.go`:
+
+```go
+package metadata
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+)
+
+// LegacyMeta is one v1 (inline-segment) metadata file discovered by a scan.
+type LegacyMeta struct {
+	MetaPath    string
+	VirtualPath string
+	SizeBytes   int64
+	Meta        *metapb.FileMetadata
+}
+
+// LegacyGroup is the set of legacy metas belonging to one release. Files are
+// sorted by meta path so a migration run is deterministic.
+type LegacyGroup struct {
+	Key   string
+	Files []LegacyMeta
+}
+
+// ScanLegacyMetas walks the metadata root and returns every legacy (non-v3)
+// meta, grouped by release. The group key is source_nzb_path when set, and the
+// meta's parent directory otherwise. Unreadable files are skipped rather than
+// failing the whole scan: a migration should convert what it can.
+func (ms *MetadataService) ScanLegacyMetas() ([]LegacyGroup, error) {
+	byKey := make(map[string][]LegacyMeta)
+
+	err := filepath.WalkDir(ms.rootPath, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() || !strings.HasSuffix(path, ".meta") {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil || isV3Meta(data) {
+			return nil
+		}
+		rel, relErr := filepath.Rel(ms.rootPath, path)
+		if relErr != nil {
+			return nil
+		}
+		virtualPath := strings.TrimSuffix(rel, ".meta")
+
+		// Read through the service so the .id sidecar populates NzbdavId.
+		meta, metaErr := ms.ReadFileMetadata(virtualPath)
+		if metaErr != nil || meta == nil {
+			return nil
+		}
+
+		key := meta.SourceNzbPath
+		if key == "" {
+			key = filepath.Dir(path)
+		}
+		byKey[key] = append(byKey[key], LegacyMeta{
+			MetaPath:    path,
+			VirtualPath: virtualPath,
+			SizeBytes:   int64(len(data)),
+			Meta:        meta,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk metadata root: %w", err)
+	}
+
+	groups := make([]LegacyGroup, 0, len(byKey))
+	for key, files := range byKey {
+		sort.Slice(files, func(a, b int) bool { return files[a].MetaPath < files[b].MetaPath })
+		groups = append(groups, LegacyGroup{Key: key, Files: files})
+	}
+	sort.Slice(groups, func(a, b int) bool { return groups[a].Key < groups[b].Key })
+	return groups, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/metadata/ -run TestScanLegacyMetas -v`
+Expected: PASS (both subtests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/metadata/migration_scan.go internal/metadata/migration_scan_test.go
+git commit -m "feat(metadata): scan and group legacy metas by release"
+```
+
+---
+
+### Task 4: Synthesize a store from inline segments
+
+**Files:**
+- Create: `internal/metadata/migration_store.go`
+- Create: `internal/metadata/migration_store_test.go`
+
+**Interfaces:**
+- Consumes: `LegacyMeta` (Task 3), `ExpandSharedOuterSources(meta *metapb.FileMetadata) error` (`expand.go`).
+- Produces:
+  - `func synthesizeStore(files []LegacyMeta, defaultGroup string) (*metapb.NzbStore, map[string]int64, error)`
+  - `func allSegmentLists(m *metapb.FileMetadata) [][]*metapb.SegmentData`
+  - `func storeHashPath(dir, groupKey string, store *metapb.NzbStore) string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/metadata/migration_store_test.go`:
+
+```go
+package metadata
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func legacyMeta(virtualPath string, meta *metapb.FileMetadata) LegacyMeta {
+	return LegacyMeta{
+		MetaPath:    virtualPath + ".meta",
+		VirtualPath: virtualPath,
+		SizeBytes:   1,
+		Meta:        meta,
+	}
+}
+
+func TestSynthesizeStore_FlatIndexAndDedup(t *testing.T) {
+	a := &metapb.FileMetadata{
+		CreatedAt: 111,
+		SegmentData: []*metapb.SegmentData{
+			{Id: "s1@n", SegmentSize: 100, EndOffset: 99},
+			{Id: "s2@n", SegmentSize: 100, EndOffset: 99},
+		},
+		Par2Files: []*metapb.Par2FileReference{
+			{Filename: "rel.par2", SegmentData: []*metapb.SegmentData{{Id: "p1@n", SegmentSize: 50, EndOffset: 49}}},
+		},
+	}
+	// b re-uses s2@n (shared outer RAR segment) and adds one of its own.
+	b := &metapb.FileMetadata{
+		CreatedAt: 222,
+		SegmentData: []*metapb.SegmentData{
+			{Id: "s2@n", SegmentSize: 100, EndOffset: 99},
+			{Id: "s3@n", SegmentSize: 70, EndOffset: 69},
+		},
+	}
+
+	store, index, err := synthesizeStore(
+		[]LegacyMeta{legacyMeta("movies/A.mkv", a), legacyMeta("movies/B.mkv", b)},
+		"alt.binaries.misc",
+	)
+	require.NoError(t, err)
+	require.Len(t, store.Files, 2, "one NzbFileEntry per contributing meta")
+
+	assert.Equal(t, "A.mkv", store.Files[0].Subject)
+	assert.Equal(t, []string{"alt.binaries.misc"}, store.Files[0].Groups)
+	assert.EqualValues(t, 111, store.Files[0].Date)
+
+	// Flat order: s1, s2, p1 (from A), then s3 (from B; s2 already indexed).
+	assert.EqualValues(t, 0, index["s1@n"])
+	assert.EqualValues(t, 1, index["s2@n"])
+	assert.EqualValues(t, 2, index["p1@n"])
+	assert.EqualValues(t, 3, index["s3@n"])
+	require.Len(t, store.Files[1].Segments, 1, "duplicate ids are not stored twice")
+	assert.Equal(t, "s3@n", store.Files[1].Segments[0].Id)
+
+	// Sizes are the decoded sizes from SegmentData.
+	assert.EqualValues(t, 100, store.Files[0].Segments[0].Bytes)
+	assert.EqualValues(t, 70, store.Files[1].Segments[0].Bytes)
+
+	// Segment numbers are 1-based within their entry.
+	assert.EqualValues(t, 1, store.Files[0].Segments[0].Number)
+	assert.EqualValues(t, 2, store.Files[0].Segments[1].Number)
+}
+
+func TestSynthesizeStore_ExpandsSharedOuterSources(t *testing.T) {
+	m := &metapb.FileMetadata{
+		SharedOuterSources: []*metapb.NestedSegmentSource{
+			{Segments: []*metapb.SegmentData{{Id: "outer@n", SegmentSize: 500, EndOffset: 499}}, InnerVolumeSize: 500},
+		},
+		NestedSources: []*metapb.NestedSegmentSource{
+			{SharedOuterSourceIndex: 1, InnerOffset: 0, InnerLength: 250},
+			{SharedOuterSourceIndex: 1, InnerOffset: 250, InnerLength: 250},
+		},
+	}
+
+	_, index, err := synthesizeStore([]LegacyMeta{legacyMeta("movies/BD.m2ts", m)}, "alt.binaries.misc")
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, index["outer@n"], "shared outer segments are expanded and indexed")
+	assert.Len(t, index, 1)
+}
+
+func TestSynthesizeStore_RejectsEmptySegmentID(t *testing.T) {
+	m := &metapb.FileMetadata{SegmentData: []*metapb.SegmentData{{Id: "", SegmentSize: 10, EndOffset: 9}}}
+	_, _, err := synthesizeStore([]LegacyMeta{legacyMeta("movies/Bad.mkv", m)}, "alt.binaries.misc")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty segment id")
+}
+
+func TestStoreHashPath_StableAndContentAddressed(t *testing.T) {
+	s1 := &metapb.NzbStore{Files: []*metapb.NzbFileEntry{
+		{Segments: []*metapb.NzbSeg{{Id: "x@n"}, {Id: "y@n"}}},
+	}}
+	s2 := &metapb.NzbStore{Files: []*metapb.NzbFileEntry{
+		{Segments: []*metapb.NzbSeg{{Id: "x@n"}}},
+	}}
+
+	p1 := storeHashPath("/store", "/nzbs/My Release [2024].nzb", s1)
+	assert.Equal(t, p1, storeHashPath("/store", "/nzbs/My Release [2024].nzb", s1), "stable across calls")
+	assert.NotEqual(t, p1, storeHashPath("/store", "/nzbs/My Release [2024].nzb", s2), "different segments, different path")
+
+	base := filepath.Base(p1)
+	assert.True(t, strings.HasSuffix(base, ".nzbz"))
+	assert.True(t, strings.HasPrefix(base, "My_Release__2024_-"), "unsafe characters are replaced, got %q", base)
+	assert.NotContains(t, base, "/")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/metadata/ -run 'TestSynthesizeStore|TestStoreHashPath' -v`
+Expected: FAIL — `undefined: synthesizeStore`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/metadata/migration_store.go`:
+
+```go
+package metadata
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+)
+
+// allSegmentLists returns every inline SegmentData slice a metadata carries:
+// the main file, each PAR2 file, and each nested source. Call
+// ExpandSharedOuterSources first so nested sources carry their segments.
+func allSegmentLists(m *metapb.FileMetadata) [][]*metapb.SegmentData {
+	lists := make([][]*metapb.SegmentData, 0, 1+len(m.Par2Files)+len(m.NestedSources))
+	lists = append(lists, m.SegmentData)
+	for _, p := range m.Par2Files {
+		lists = append(lists, p.SegmentData)
+	}
+	for _, ns := range m.NestedSources {
+		lists = append(lists, ns.Segments)
+	}
+	return lists
+}
+
+// synthesizeStore builds an NzbStore from the inline segments of a legacy
+// release group, plus the message-id → flat-index map used to emit SegmentRefs.
+//
+// Subject/poster/groups are not retained by legacy metas, so entries carry the
+// virtual filename as subject and defaultGroup as the single group — enough for
+// nzb.BuildNZB to emit a structurally valid NZB. Segment sizes are the decoded
+// sizes from SegmentData, which is what segDataToRefs records in decoded_bytes
+// and what the read path prefers, so no size information is lost.
+//
+// One NzbFileEntry per contributing meta keeps each file's segments on a
+// contiguous, increasing index range, which is what lets splitRefs collapse
+// them into compact SegmentRuns.
+func synthesizeStore(files []LegacyMeta, defaultGroup string) (*metapb.NzbStore, map[string]int64, error) {
+	store := &metapb.NzbStore{Files: make([]*metapb.NzbFileEntry, 0, len(files))}
+	index := make(map[string]int64)
+	var flat int64
+
+	var groups []string
+	if defaultGroup != "" {
+		groups = []string{defaultGroup}
+	}
+
+	for _, lm := range files {
+		if err := ExpandSharedOuterSources(lm.Meta); err != nil {
+			return nil, nil, fmt.Errorf("expand shared outer sources for %s: %w", lm.VirtualPath, err)
+		}
+		entry := &metapb.NzbFileEntry{
+			Subject: filepath.Base(lm.VirtualPath),
+			Date:    lm.Meta.CreatedAt,
+			Groups:  groups,
+		}
+		for _, segs := range allSegmentLists(lm.Meta) {
+			for _, s := range segs {
+				if s.Id == "" {
+					return nil, nil, fmt.Errorf("empty segment id in %s", lm.VirtualPath)
+				}
+				if _, seen := index[s.Id]; seen {
+					continue
+				}
+				index[s.Id] = flat
+				flat++
+				entry.Segments = append(entry.Segments, &metapb.NzbSeg{
+					Id:     s.Id,
+					Number: int32(len(entry.Segments) + 1),
+					Bytes:  s.SegmentSize,
+				})
+			}
+		}
+		store.Files = append(store.Files, entry)
+	}
+	return store, index, nil
+}
+
+// storeHashPath returns the .nzbz path for a group's store. The name embeds the
+// first 8 hex characters of the SHA-256 over the store's segment ids in flat
+// order, so a store is never overwritten by one holding a different segment set
+// — which would silently invalidate the refs of already-migrated metas.
+func storeHashPath(dir, groupKey string, store *metapb.NzbStore) string {
+	h := sha256.New()
+	for _, f := range store.Files {
+		for _, s := range f.Segments {
+			_, _ = h.Write([]byte(s.Id))
+			_, _ = h.Write([]byte{'\n'})
+		}
+	}
+	sum := hex.EncodeToString(h.Sum(nil))[:8]
+	return filepath.Join(dir, fmt.Sprintf("%s-%s.nzbz", sanitizeStoreBase(groupKey), sum))
+}
+
+// sanitizeStoreBase turns a group key (an nzb path or a directory) into a safe,
+// bounded filename component.
+func sanitizeStoreBase(groupKey string) string {
+	base := filepath.Base(filepath.FromSlash(strings.ReplaceAll(groupKey, `\`, "/")))
+	base = strings.TrimSuffix(base, ".nzb")
+
+	var b strings.Builder
+	for _, r := range base {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	out := b.String()
+	if len(out) > 80 {
+		out = out[:80]
+	}
+	if out == "" || out == "." || out == ".." {
+		out = "release"
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/metadata/ -run 'TestSynthesizeStore|TestStoreHashPath' -v`
+Expected: PASS (all four tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/metadata/migration_store.go internal/metadata/migration_store_test.go
+git commit -m "feat(metadata): synthesize NzbStore from legacy inline segments"
+```
+
+---
+
+### Task 5: Faithful store from a surviving source NZB
+
+**Files:**
+- Modify: `internal/metadata/migration_store.go` (append)
+- Modify: `internal/metadata/migration_store_test.go` (append)
+
+**Interfaces:**
+- Consumes: `BuildStore` (Task 1), `synthesizeStore`, `allSegmentLists` (Task 4), `LegacyGroup` (Task 3).
+- Produces: `func buildGroupStore(g LegacyGroup, defaultGroup string) (*metapb.NzbStore, map[string]int64, bool, error)` — the bool reports whether the faithful path was used.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/metadata/migration_store_test.go`:
+
+```go
+const testNZB = `<?xml version="1.0" encoding="UTF-8"?>
+<nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+  <file poster="poster@example.com" date="1700000000" subject="[1/1] &quot;A.mkv&quot; yEnc (1/2)">
+    <groups><group>alt.binaries.real</group></groups>
+    <segments>
+      <segment bytes="140" number="1">s1@n</segment>
+      <segment bytes="140" number="2">s2@n</segment>
+    </segments>
+  </file>
+</nzb>
+`
+
+func TestBuildGroupStore_FaithfulWhenSourceNzbExists(t *testing.T) {
+	dir := t.TempDir()
+	nzbPath := filepath.Join(dir, "rel.nzb")
+	require.NoError(t, os.WriteFile(nzbPath, []byte(testNZB), 0644))
+
+	g := LegacyGroup{Key: nzbPath, Files: []LegacyMeta{legacyMeta("movies/A.mkv", &metapb.FileMetadata{
+		SegmentData: []*metapb.SegmentData{
+			{Id: "s1@n", SegmentSize: 100, EndOffset: 99},
+			{Id: "s2@n", SegmentSize: 100, EndOffset: 99},
+		},
+	})}}
+
+	store, index, faithful, err := buildGroupStore(g, "alt.binaries.misc")
+	require.NoError(t, err)
+	assert.True(t, faithful)
+	require.Len(t, store.Files, 1)
+	assert.Equal(t, []string{"alt.binaries.real"}, store.Files[0].Groups, "real groups survive")
+	assert.Equal(t, "poster@example.com", store.Files[0].Poster)
+	assert.EqualValues(t, 0, index["s1@n"])
+	assert.EqualValues(t, 1, index["s2@n"])
+
+	// A faithful store regenerates an NZB that parses back with its group intact.
+	regenerated := nzb.BuildNZB(store)
+	reparsed, parseErr := nzbparser.Parse(bytes.NewReader(regenerated))
+	require.NoError(t, parseErr)
+	require.Len(t, reparsed.Files, 1)
+	assert.Equal(t, []string{"alt.binaries.real"}, reparsed.Files[0].Groups)
+	require.Len(t, reparsed.Files[0].Segments, 2)
+}
+
+func TestBuildGroupStore_FallsBackWhenNzbMissing(t *testing.T) {
+	g := LegacyGroup{Key: "/nzbs/gone.nzb", Files: []LegacyMeta{legacyMeta("movies/A.mkv", &metapb.FileMetadata{
+		SegmentData: []*metapb.SegmentData{{Id: "s1@n", SegmentSize: 100, EndOffset: 99}},
+	})}}
+
+	store, index, faithful, err := buildGroupStore(g, "alt.binaries.misc")
+	require.NoError(t, err)
+	assert.False(t, faithful)
+	require.Len(t, store.Files, 1)
+	assert.Equal(t, []string{"alt.binaries.misc"}, store.Files[0].Groups)
+	assert.EqualValues(t, 0, index["s1@n"])
+}
+
+func TestBuildGroupStore_FallsBackWhenNzbDoesNotCoverSegments(t *testing.T) {
+	dir := t.TempDir()
+	nzbPath := filepath.Join(dir, "rel.nzb")
+	require.NoError(t, os.WriteFile(nzbPath, []byte(testNZB), 0644))
+
+	// The meta references a segment the NZB does not contain.
+	g := LegacyGroup{Key: nzbPath, Files: []LegacyMeta{legacyMeta("movies/A.mkv", &metapb.FileMetadata{
+		SegmentData: []*metapb.SegmentData{
+			{Id: "s1@n", SegmentSize: 100, EndOffset: 99},
+			{Id: "unknown@n", SegmentSize: 100, EndOffset: 99},
+		},
+	})}}
+
+	store, index, faithful, err := buildGroupStore(g, "alt.binaries.misc")
+	require.NoError(t, err)
+	assert.False(t, faithful, "a mismatched NZB must not be trusted")
+	assert.Equal(t, []string{"alt.binaries.misc"}, store.Files[0].Groups)
+	assert.Contains(t, index, "unknown@n")
+}
+```
+
+Add `"bytes"`, `"os"`, `"github.com/javi11/altmount/internal/nzb"` and `"github.com/javi11/nzbparser"` to the import block of `internal/metadata/migration_store_test.go`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/metadata/ -run TestBuildGroupStore -v`
+Expected: FAIL — `undefined: buildGroupStore`
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `internal/metadata/migration_store.go`:
+
+```go
+// buildGroupStore returns the store and flat index for a release group. It
+// prefers a faithful store parsed from the surviving source .nzb (real
+// subjects, posters, groups and segment numbers) and falls back to synthesis
+// from the inline segments. The bool reports which path was taken.
+func buildGroupStore(g LegacyGroup, defaultGroup string) (*metapb.NzbStore, map[string]int64, bool, error) {
+	if store, index, ok := tryFaithfulStore(g); ok {
+		return store, index, true, nil
+	}
+	store, index, err := synthesizeStore(g.Files, defaultGroup)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	return store, index, false, nil
+}
+
+// tryFaithfulStore parses the group's source .nzb, if it still exists, and
+// returns the resulting store only when it covers every segment referenced by
+// every meta in the group. A partial or mismatched NZB (edited, replaced, or
+// belonging to a different release) is rejected outright: half a faithful index
+// is worse than an honest synthesized one.
+func tryFaithfulStore(g LegacyGroup) (*metapb.NzbStore, map[string]int64, bool) {
+	if g.Key == "" {
+		return nil, nil, false
+	}
+	f, err := os.Open(g.Key)
+	if err != nil {
+		return nil, nil, false
+	}
+	defer func() { _ = f.Close() }()
+
+	parsed, err := nzbparser.Parse(f)
+	if err != nil || parsed == nil || len(parsed.Files) == 0 {
+		return nil, nil, false
+	}
+	store, index := BuildStore(parsed)
+
+	for _, lm := range g.Files {
+		if expandErr := ExpandSharedOuterSources(lm.Meta); expandErr != nil {
+			return nil, nil, false
+		}
+		for _, segs := range allSegmentLists(lm.Meta) {
+			for _, s := range segs {
+				if _, ok := index[s.Id]; !ok {
+					return nil, nil, false
+				}
+			}
+		}
+	}
+	return store, index, true
+}
+```
+
+Add `"os"` and `"github.com/javi11/nzbparser"` to the import block of `internal/metadata/migration_store.go`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/metadata/ -run TestBuildGroupStore -v`
+Expected: PASS (all three tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/metadata/migration_store.go internal/metadata/migration_store_test.go
+git commit -m "feat(metadata): prefer faithful store from surviving source nzb"
+```
+
+---
+
+### Task 6: Migrate one group, preserving resolved segments exactly
+
+This task carries the core invariant: after migration, `ReadFileMetadata` must return the same resolved `SegmentData` it returned before.
+
+**Files:**
+- Create: `internal/metadata/migration_convert.go`
+- Create: `internal/metadata/migration_convert_test.go`
+
+**Interfaces:**
+- Consumes: `buildGroupStore` (Task 5), `LegacyGroup`/`LegacyMeta` (Task 3), `MetadataService.Store()`, `MetadataService.WriteFileMetadataV3(ctx, virtualPath, metadata, index, storeRef)`.
+- Produces:
+  - `type GroupResult struct { Key, StoreRef string; Faithful bool; FilesMigrated, FilesFailed int; BytesBefore, BytesAfter int64; Failures []string }`
+  - `func (ms *MetadataService) MigrateGroup(ctx context.Context, g LegacyGroup, storeDir, defaultGroup string) (GroupResult, error)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/metadata/migration_convert_test.go`:
+
+```go
+package metadata
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// readResolved returns the SegmentData a consumer would see for a virtual path.
+func readResolved(t *testing.T, ms *MetadataService, virtualPath string) *metapb.FileMetadata {
+	t.Helper()
+	got, err := ms.ReadFileMetadata(virtualPath)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	return got
+}
+
+func TestMigrateGroup_PreservesResolvedSegments(t *testing.T) {
+	root := t.TempDir()
+	storeDir := t.TempDir()
+	ms := NewMetadataService(root)
+
+	pathA := filepath.Join("movies", "A.mkv")
+	pathB := filepath.Join("movies", "B.mkv")
+	metaA := &metapb.FileMetadata{
+		FileSize:      300,
+		Status:        metapb.FileStatus_FILE_STATUS_HEALTHY,
+		SourceNzbPath: "/nzbs/rel.nzb",
+		CreatedAt:     10,
+		ModifiedAt:    20,
+		ReleaseDate:   30,
+		KnownHoles:    []*metapb.HoleRun{{StartSegment: 1, Count: 1}},
+		SegmentData: []*metapb.SegmentData{
+			{Id: "s1@n", SegmentSize: 100, StartOffset: 0, EndOffset: 99},
+			{Id: "s2@n", SegmentSize: 100, StartOffset: 0, EndOffset: 99},
+			{Id: "s3@n", SegmentSize: 100, StartOffset: 0, EndOffset: 99},
+		},
+		Par2Files: []*metapb.Par2FileReference{
+			{Filename: "rel.par2", FileSize: 50, SegmentData: []*metapb.SegmentData{
+				{Id: "p1@n", SegmentSize: 50, StartOffset: 0, EndOffset: 49},
+			}},
+		},
+	}
+	// B is archive-sliced: partial offsets that must survive verbatim.
+	metaB := &metapb.FileMetadata{
+		FileSize:      120,
+		Status:        metapb.FileStatus_FILE_STATUS_HEALTHY,
+		SourceNzbPath: "/nzbs/rel.nzb",
+		SegmentData: []*metapb.SegmentData{
+			{Id: "s2@n", SegmentSize: 100, StartOffset: 40, EndOffset: 99},
+			{Id: "s3@n", SegmentSize: 100, StartOffset: 0, EndOffset: 59},
+		},
+	}
+	require.NoError(t, ms.WriteFileMetadata(pathA, metaA))
+	require.NoError(t, ms.WriteFileMetadata(pathB, metaB))
+
+	beforeA := proto.Clone(readResolved(t, ms, pathA)).(*metapb.FileMetadata)
+	beforeB := proto.Clone(readResolved(t, ms, pathB)).(*metapb.FileMetadata)
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+
+	res, err := ms.MigrateGroup(context.Background(), groups[0], storeDir, "alt.binaries.misc")
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.FilesMigrated)
+	assert.Equal(t, 0, res.FilesFailed)
+	assert.False(t, res.Faithful, "no source nzb on disk")
+	assert.FileExists(t, res.StoreRef)
+
+	afterA := readResolved(t, ms, pathA)
+	afterB := readResolved(t, ms, pathB)
+
+	assert.Equal(t, res.StoreRef, afterA.StoreRef, "meta now points at the shared store")
+	require.Len(t, afterA.SegmentData, len(beforeA.SegmentData))
+	for i := range beforeA.SegmentData {
+		assert.Equal(t, beforeA.SegmentData[i].Id, afterA.SegmentData[i].Id)
+		assert.Equal(t, beforeA.SegmentData[i].SegmentSize, afterA.SegmentData[i].SegmentSize)
+		assert.Equal(t, beforeA.SegmentData[i].StartOffset, afterA.SegmentData[i].StartOffset)
+		assert.Equal(t, beforeA.SegmentData[i].EndOffset, afterA.SegmentData[i].EndOffset)
+	}
+	require.Len(t, afterA.Par2Files, 1)
+	require.Len(t, afterA.Par2Files[0].SegmentData, 1)
+	assert.Equal(t, "p1@n", afterA.Par2Files[0].SegmentData[0].Id)
+
+	require.Len(t, afterB.SegmentData, 2)
+	assert.EqualValues(t, 40, afterB.SegmentData[0].StartOffset, "archive slicing offsets survive")
+	assert.EqualValues(t, 59, afterB.SegmentData[1].EndOffset)
+
+	// Non-segment fields are untouched.
+	assert.Equal(t, beforeA.FileSize, afterA.FileSize)
+	assert.Equal(t, beforeA.ReleaseDate, afterA.ReleaseDate)
+	assert.Equal(t, metapb.FileStatus_FILE_STATUS_HEALTHY, afterA.Status)
+	require.Len(t, afterA.KnownHoles, 1)
+	assert.EqualValues(t, 1, afterA.KnownHoles[0].StartSegment)
+}
+
+func TestMigrateGroup_CompactsIntoSegmentRuns(t *testing.T) {
+	root := t.TempDir()
+	storeDir := t.TempDir()
+	ms := NewMetadataService(root)
+
+	segs := make([]*metapb.SegmentData, 0, 10)
+	for i := 0; i < 10; i++ {
+		segs = append(segs, &metapb.SegmentData{
+			Id: string(rune('a'+i)) + "@n", SegmentSize: 100, StartOffset: 0, EndOffset: 99,
+		})
+	}
+	vpath := filepath.Join("movies", "Plain.mkv")
+	require.NoError(t, ms.WriteFileMetadata(vpath, &metapb.FileMetadata{
+		FileSize: 1000, SourceNzbPath: "/nzbs/plain.nzb", SegmentData: segs,
+	}))
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	_, err = ms.MigrateGroup(context.Background(), groups[0], storeDir, "alt.binaries.misc")
+	require.NoError(t, err)
+
+	// Inspect the raw on-disk proto: a plain file must collapse to runs.
+	raw, err := os.ReadFile(filepath.Join(root, "movies", "Plain.mkv.meta"))
+	require.NoError(t, err)
+	require.True(t, isV3Meta(raw))
+	var stored metapb.FileMetadata
+	require.NoError(t, proto.Unmarshal(raw[5:], &stored))
+	assert.Len(t, stored.SegmentRefs, 0, "no explicit refs for a uniform file")
+	require.Len(t, stored.SegmentRuns, 1)
+	assert.EqualValues(t, 10, stored.SegmentRuns[0].Count)
+	assert.Empty(t, stored.SegmentData, "inline segments are gone")
+}
+
+func TestMigrateGroup_IsIdempotentAndSkipsMigratedFiles(t *testing.T) {
+	root := t.TempDir()
+	storeDir := t.TempDir()
+	ms := NewMetadataService(root)
+
+	vpath := filepath.Join("movies", "A.mkv")
+	require.NoError(t, ms.WriteFileMetadata(vpath, &metapb.FileMetadata{
+		FileSize: 100, SourceNzbPath: "/nzbs/rel.nzb",
+		SegmentData: []*metapb.SegmentData{{Id: "s1@n", SegmentSize: 100, EndOffset: 99}},
+	}))
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	first, err := ms.MigrateGroup(context.Background(), groups[0], storeDir, "alt.binaries.misc")
+	require.NoError(t, err)
+
+	// A second scan finds nothing, so a second run is a no-op.
+	groups, err = ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	assert.Empty(t, groups, "migrated metas are not rescanned")
+	assert.FileExists(t, first.StoreRef)
+}
+```
+
+Append the reference-count and partial-run tests to the same file:
+
+```go
+// countingRefCounter records IncStoreRef calls per store path.
+type countingRefCounter struct {
+	mu   sync.Mutex
+	inc  map[string]int
+	decs map[string]int
+}
+
+func newCountingRefCounter() *countingRefCounter {
+	return &countingRefCounter{inc: map[string]int{}, decs: map[string]int{}}
+}
+
+func (c *countingRefCounter) IncStoreRef(_ context.Context, storePath string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.inc[storePath]++
+	return nil
+}
+
+func (c *countingRefCounter) DecStoreRef(_ context.Context, storePath string) (int64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.decs[storePath]++
+	return int64(c.inc[storePath] - c.decs[storePath]), nil
+}
+
+func TestMigrateGroup_RefCountMatchesMigratedFiles(t *testing.T) {
+	root := t.TempDir()
+	storeDir := t.TempDir()
+	ms := NewMetadataService(root)
+	counter := newCountingRefCounter()
+	ms.SetStoreRefCounter(counter)
+
+	for _, name := range []string{"A.mkv", "B.mkv", "C.mkv"} {
+		require.NoError(t, ms.WriteFileMetadata(filepath.Join("movies", name), &metapb.FileMetadata{
+			FileSize: 100, SourceNzbPath: "/nzbs/rel.nzb",
+			SegmentData: []*metapb.SegmentData{{Id: name + "@n", SegmentSize: 100, EndOffset: 99}},
+		}))
+	}
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+
+	res, err := ms.MigrateGroup(context.Background(), groups[0], storeDir, "alt.binaries.misc")
+	require.NoError(t, err)
+	assert.Equal(t, 3, res.FilesMigrated)
+
+	counter.mu.Lock()
+	defer counter.mu.Unlock()
+	assert.Equal(t, 3, counter.inc[res.StoreRef], "one reference per migrated meta")
+}
+
+func TestMigrateGroup_PartialRunLeavesFirstStoreIntact(t *testing.T) {
+	root := t.TempDir()
+	storeDir := t.TempDir()
+	ms := NewMetadataService(root)
+
+	pathA := filepath.Join("movies", "A.mkv")
+	pathB := filepath.Join("movies", "B.mkv")
+	for _, p := range []struct{ path, id string }{{pathA, "a@n"}, {pathB, "b@n"}} {
+		require.NoError(t, ms.WriteFileMetadata(p.path, &metapb.FileMetadata{
+			FileSize: 100, SourceNzbPath: "/nzbs/rel.nzb",
+			SegmentData: []*metapb.SegmentData{{Id: p.id, SegmentSize: 100, EndOffset: 99}},
+		}))
+	}
+
+	// Simulate a run that only got through the first file: migrate a group
+	// containing just A, then rescan and migrate what is left.
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups[0].Files, 2)
+
+	firstOnly := LegacyGroup{Key: groups[0].Key, Files: groups[0].Files[:1]}
+	firstRes, err := ms.MigrateGroup(context.Background(), firstOnly, storeDir, "alt.binaries.misc")
+	require.NoError(t, err)
+	require.Equal(t, 1, firstRes.FilesMigrated)
+
+	remaining, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	require.Len(t, remaining[0].Files, 1, "only B is left")
+
+	secondRes, err := ms.MigrateGroup(context.Background(), remaining[0], storeDir, "alt.binaries.misc")
+	require.NoError(t, err)
+	assert.Equal(t, 1, secondRes.FilesMigrated)
+	assert.NotEqual(t, firstRes.StoreRef, secondRes.StoreRef,
+		"a different segment set must not reuse the first store path")
+	assert.FileExists(t, firstRes.StoreRef, "the first store is untouched")
+
+	// Both files still resolve correctly, each through its own store.
+	gotA := readResolved(t, ms, pathA)
+	gotB := readResolved(t, ms, pathB)
+	require.Len(t, gotA.SegmentData, 1)
+	require.Len(t, gotB.SegmentData, 1)
+	assert.Equal(t, "a@n", gotA.SegmentData[0].Id)
+	assert.Equal(t, "b@n", gotB.SegmentData[0].Id)
+}
+```
+
+Add `"sync"` to the import block of `internal/metadata/migration_convert_test.go`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/metadata/ -run TestMigrateGroup -v`
+Expected: FAIL — `ms.MigrateGroup undefined`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/metadata/migration_convert.go`:
+
+```go
+package metadata
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+// GroupResult reports what happened to one release group.
+type GroupResult struct {
+	Key           string   `json:"key"`
+	StoreRef      string   `json:"store_ref"`
+	Faithful      bool     `json:"faithful"`
+	FilesMigrated int      `json:"files_migrated"`
+	FilesFailed   int      `json:"files_failed"`
+	BytesBefore   int64    `json:"bytes_before"`
+	BytesAfter    int64    `json:"bytes_after"`
+	Failures      []string `json:"failures,omitempty"`
+}
+
+// MigrateGroup converts one release group to the v3 store-backed format.
+//
+// Ordering is load-bearing: the .nzbz is written and read back before any meta
+// is repointed at it, so a meta never names a store that is missing or corrupt.
+// Each meta is then rewritten atomically by WriteFileMetadataV3, which also
+// increments the store's reference count exactly once, leaving the count equal
+// to the number of migrated metas.
+//
+// A per-file failure leaves that file as v1 and is recorded; the rest of the
+// group still migrates. If every file fails, the freshly written store is
+// removed so no orphan is left behind.
+func (ms *MetadataService) MigrateGroup(ctx context.Context, g LegacyGroup, storeDir, defaultGroup string) (GroupResult, error) {
+	res := GroupResult{Key: g.Key}
+	for _, lm := range g.Files {
+		res.BytesBefore += lm.SizeBytes
+	}
+
+	store, index, faithful, err := buildGroupStore(g, defaultGroup)
+	if err != nil {
+		return res, fmt.Errorf("build store for %q: %w", g.Key, err)
+	}
+	res.Faithful = faithful
+
+	if err := os.MkdirAll(storeDir, 0755); err != nil {
+		return res, fmt.Errorf("create store dir %q: %w", storeDir, err)
+	}
+	storeRef := storeHashPath(storeDir, g.Key, store)
+	if err := ms.store.WriteStore(storeRef, store); err != nil {
+		return res, fmt.Errorf("write store %q: %w", storeRef, err)
+	}
+	if _, err := ms.store.ReadStore(storeRef); err != nil {
+		_ = os.Remove(storeRef)
+		return res, fmt.Errorf("store integrity check failed for %q: %w", storeRef, err)
+	}
+	res.StoreRef = storeRef
+
+	for _, lm := range g.Files {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return res, ctxErr
+		}
+		if err := ms.WriteFileMetadataV3(ctx, lm.VirtualPath, lm.Meta, index, storeRef); err != nil {
+			res.FilesFailed++
+			res.Failures = append(res.Failures, fmt.Sprintf("%s: %v", lm.VirtualPath, err))
+			slog.WarnContext(ctx, "Failed to migrate metadata file; leaving it in the legacy format",
+				"virtual_path", lm.VirtualPath, "error", err)
+			continue
+		}
+		res.FilesMigrated++
+		if info, statErr := os.Stat(lm.MetaPath); statErr == nil {
+			res.BytesAfter += info.Size()
+		}
+	}
+
+	if res.FilesMigrated == 0 {
+		if removeErr := os.Remove(storeRef); removeErr != nil && !os.IsNotExist(removeErr) {
+			slog.WarnContext(ctx, "Failed to remove orphaned store after a fully failed group",
+				"store_ref", storeRef, "error", removeErr)
+		}
+		res.StoreRef = ""
+		return res, nil
+	}
+
+	if info, statErr := os.Stat(storeRef); statErr == nil {
+		res.BytesAfter += info.Size()
+	}
+	return res, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/metadata/ -run TestMigrateGroup -v`
+Expected: PASS (all five tests)
+
+- [ ] **Step 5: Run the whole metadata package to catch regressions**
+
+Run: `go test ./internal/metadata/ 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/metadata/migration_convert.go internal/metadata/migration_convert_test.go
+git commit -m "feat(metadata): migrate a release group to the v3 store format"
+```
+
+---
+
+### Task 7: The migration worker
+
+**Files:**
+- Create: `internal/metadata/migration.go`
+- Create: `internal/metadata/migration_test.go`
+
+**Interfaces:**
+- Consumes: `MetadataService.ScanLegacyMetas` (Task 3), `MetadataService.MigrateGroup` (Task 6), `config.ConfigGetter`, `cfg.Metadata.Migration.DefaultGroup` (Task 2).
+- Produces:
+  - `type MigrationProgress`, `type MigrationResult`, `type MigrationStatus`
+  - `func NewMigrationWorker(ms *MetadataService, configGetter config.ConfigGetter) *MigrationWorker`
+  - `(*MigrationWorker) GetStatus() MigrationStatus`
+  - `(*MigrationWorker) Start(ctx context.Context) error`
+  - `(*MigrationWorker) DryRun(ctx context.Context) (*MigrationResult, error)`
+  - `(*MigrationWorker) Cancel()`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/metadata/migration_test.go`:
+
+```go
+package metadata
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testConfigGetter(t *testing.T) config.ConfigGetter {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "altmount.db")
+	cfg := &config.Config{}
+	cfg.Database.Path = dbPath
+	cfg.Metadata.Migration.DefaultGroup = "alt.binaries.misc"
+	return func() *config.Config { return cfg }
+}
+
+func seedLegacyRelease(t *testing.T, ms *MetadataService) {
+	t.Helper()
+	require.NoError(t, ms.WriteFileMetadata(filepath.Join("movies", "A.mkv"), &metapb.FileMetadata{
+		FileSize: 200, SourceNzbPath: "/nzbs/rel.nzb",
+		SegmentData: []*metapb.SegmentData{
+			{Id: "s1@n", SegmentSize: 100, EndOffset: 99},
+			{Id: "s2@n", SegmentSize: 100, EndOffset: 99},
+		},
+	}))
+	require.NoError(t, ms.WriteFileMetadata(filepath.Join("movies", "B.mkv"), &metapb.FileMetadata{
+		FileSize: 100, SourceNzbPath: "/nzbs/rel.nzb",
+		SegmentData: []*metapb.SegmentData{{Id: "s3@n", SegmentSize: 100, EndOffset: 99}},
+	}))
+}
+
+func TestMigrationWorker_DryRunLeavesLibraryUntouched(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+	seedLegacyRelease(t, ms)
+
+	w := NewMigrationWorker(ms, testConfigGetter(t))
+	res, err := w.DryRun(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	assert.True(t, res.DryRun)
+	assert.Equal(t, 1, res.Groups)
+	assert.Equal(t, 2, res.FilesMigrated)
+	assert.Equal(t, 0, res.FilesFailed)
+	assert.Positive(t, res.BytesBefore)
+	assert.Positive(t, res.BytesAfter)
+
+	// The real library is untouched: both metas are still legacy.
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Len(t, groups[0].Files, 2)
+
+	status := w.GetStatus()
+	assert.False(t, status.IsRunning)
+	require.NotNil(t, status.LastDryRun)
+	assert.Nil(t, status.LastResult, "a dry run is not a migration")
+}
+
+func TestMigrationWorker_StartMigratesEverything(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+	seedLegacyRelease(t, ms)
+
+	w := NewMigrationWorker(ms, testConfigGetter(t))
+	require.NoError(t, w.Start(context.Background()))
+
+	require.Eventually(t, func() bool {
+		return !w.GetStatus().IsRunning && w.GetStatus().LastResult != nil
+	}, 10*time.Second, 20*time.Millisecond)
+
+	res := w.GetStatus().LastResult
+	require.NotNil(t, res)
+	assert.False(t, res.DryRun)
+	assert.Equal(t, 2, res.FilesMigrated)
+	assert.Equal(t, 0, res.FilesFailed)
+	assert.Equal(t, 1, res.SynthesizedGroups)
+	assert.Equal(t, 0, res.FaithfulGroups)
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	assert.Empty(t, groups, "nothing legacy is left")
+
+	got, err := ms.ReadFileMetadata(filepath.Join("movies", "A.mkv"))
+	require.NoError(t, err)
+	require.Len(t, got.SegmentData, 2)
+	assert.Equal(t, "s1@n", got.SegmentData[0].Id)
+}
+
+func TestMigrationWorker_RejectsConcurrentRuns(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+	w := NewMigrationWorker(ms, testConfigGetter(t))
+
+	w.mu.Lock()
+	w.running = true
+	w.mu.Unlock()
+
+	err := w.Start(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already running")
+
+	_, dryErr := w.DryRun(context.Background())
+	require.Error(t, dryErr)
+}
+```
+
+`config.ConfigGetter` is `func() *config.Config` (`internal/config/manager.go:1388`), and `Config.Database.Path` / `Config.Metadata.Migration.DefaultGroup` are plain settable fields.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/metadata/ -run TestMigrationWorker -v`
+Expected: FAIL — `undefined: NewMigrationWorker`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/metadata/migration.go`:
+
+```go
+package metadata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+)
+
+// defaultMigrationGroup is used when the config leaves default_group empty.
+// Without a group, nzb.BuildNZB emits an empty <groups> element and most NZB
+// clients reject the result.
+const defaultMigrationGroup = "alt.binaries.misc"
+
+// migrationGroupPause paces the worker so a large library does not saturate
+// disk while streams are being served.
+const migrationGroupPause = 100 * time.Millisecond
+
+// ErrMigrationRunning is returned when a second run is requested.
+var ErrMigrationRunning = errors.New("metadata migration already running")
+
+// MigrationProgress is the live progress of a run.
+type MigrationProgress struct {
+	TotalGroups     int       `json:"total_groups"`
+	ProcessedGroups int       `json:"processed_groups"`
+	TotalFiles      int       `json:"total_files"`
+	ProcessedFiles  int       `json:"processed_files"`
+	CurrentRelease  string    `json:"current_release"`
+	StartTime       time.Time `json:"start_time"`
+}
+
+// MigrationResult summarises a completed run (real or dry).
+type MigrationResult struct {
+	DryRun            bool          `json:"dry_run"`
+	Groups            int           `json:"groups"`
+	FaithfulGroups    int           `json:"faithful_groups"`
+	SynthesizedGroups int           `json:"synthesized_groups"`
+	FilesMigrated     int           `json:"files_migrated"`
+	FilesFailed       int           `json:"files_failed"`
+	BytesBefore       int64         `json:"bytes_before"`
+	BytesAfter        int64         `json:"bytes_after"`
+	BytesSaved        int64         `json:"bytes_saved"`
+	Failures          []string      `json:"failures,omitempty"`
+	Cancelled         bool          `json:"cancelled"`
+	Duration          time.Duration `json:"duration"`
+	CompletedAt       time.Time     `json:"completed_at"`
+}
+
+// MigrationStatus is what the API reports.
+type MigrationStatus struct {
+	IsRunning    bool               `json:"is_running"`
+	LegacyFiles  int                `json:"legacy_files"`
+	LegacyGroups int                `json:"legacy_groups"`
+	Progress     *MigrationProgress `json:"progress,omitempty"`
+	LastResult   *MigrationResult   `json:"last_result,omitempty"`
+	LastDryRun   *MigrationResult   `json:"last_dry_run,omitempty"`
+}
+
+// MigrationWorker converts legacy inline-segment metadata to the v3
+// store-backed format. It is manually triggered; nothing runs on startup.
+type MigrationWorker struct {
+	ms           *MetadataService
+	configGetter config.ConfigGetter
+
+	mu         sync.Mutex
+	running    bool
+	cancelFunc context.CancelFunc
+
+	progressMu sync.RWMutex
+	progress   *MigrationProgress
+	lastResult *MigrationResult
+	lastDryRun *MigrationResult
+}
+
+// NewMigrationWorker creates a migration worker. It does not start anything.
+func NewMigrationWorker(ms *MetadataService, configGetter config.ConfigGetter) *MigrationWorker {
+	return &MigrationWorker{ms: ms, configGetter: configGetter}
+}
+
+// GetStatus reports whether a run is active, its progress, and the last results.
+// The legacy counts come from the live progress when running and are otherwise
+// left at zero; callers wanting a fresh count run a dry run.
+func (w *MigrationWorker) GetStatus() MigrationStatus {
+	w.mu.Lock()
+	running := w.running
+	w.mu.Unlock()
+
+	w.progressMu.RLock()
+	defer w.progressMu.RUnlock()
+
+	status := MigrationStatus{
+		IsRunning:  running,
+		LastResult: w.lastResult,
+		LastDryRun: w.lastDryRun,
+	}
+	if w.progress != nil {
+		p := *w.progress
+		status.Progress = &p
+		status.LegacyFiles = p.TotalFiles
+		status.LegacyGroups = p.TotalGroups
+	}
+	return status
+}
+
+// Cancel stops an in-flight run after the current file.
+func (w *MigrationWorker) Cancel() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.cancelFunc != nil {
+		w.cancelFunc()
+	}
+}
+
+// Start launches a migration in the background and returns immediately.
+// The run is detached from the caller's context so cancelling an HTTP request
+// does not abort a migration; use Cancel for that.
+func (w *MigrationWorker) Start(ctx context.Context) error {
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return ErrMigrationRunning
+	}
+	runCtx, cancel := context.WithCancel(context.Background())
+	w.running = true
+	w.cancelFunc = cancel
+	w.mu.Unlock()
+
+	slog.InfoContext(ctx, "Starting metadata migration to v3 store format")
+
+	go func() {
+		defer func() {
+			w.mu.Lock()
+			w.running = false
+			w.cancelFunc = nil
+			w.mu.Unlock()
+			cancel()
+		}()
+
+		result, err := w.run(runCtx, false)
+		if err != nil {
+			slog.ErrorContext(runCtx, "Metadata migration failed", "error", err)
+			return
+		}
+		w.progressMu.Lock()
+		w.lastResult = result
+		w.progressMu.Unlock()
+		slog.InfoContext(runCtx, "Metadata migration finished",
+			"files_migrated", result.FilesMigrated,
+			"files_failed", result.FilesFailed,
+			"bytes_saved", result.BytesSaved,
+			"cancelled", result.Cancelled)
+	}()
+	return nil
+}
+
+// DryRun performs the real conversion against an isolated temporary metadata
+// root, measures the result, and deletes it. Nothing in the library is touched
+// and no store reference counts move (the temporary service has no counter).
+func (w *MigrationWorker) DryRun(ctx context.Context) (*MigrationResult, error) {
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return nil, ErrMigrationRunning
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	w.running = true
+	w.cancelFunc = cancel
+	w.mu.Unlock()
+
+	defer func() {
+		w.mu.Lock()
+		w.running = false
+		w.cancelFunc = nil
+		w.mu.Unlock()
+		cancel()
+	}()
+
+	result, err := w.run(runCtx, true)
+	if err != nil {
+		return nil, err
+	}
+	w.progressMu.Lock()
+	w.lastDryRun = result
+	w.progressMu.Unlock()
+	return result, nil
+}
+
+// run is the shared body of Start and DryRun.
+func (w *MigrationWorker) run(ctx context.Context, dryRun bool) (*MigrationResult, error) {
+	started := time.Now()
+
+	groups, err := w.ms.ScanLegacyMetas()
+	if err != nil {
+		return nil, fmt.Errorf("scan legacy metadata: %w", err)
+	}
+
+	totalFiles := 0
+	for _, g := range groups {
+		totalFiles += len(g.Files)
+	}
+	w.setProgress(&MigrationProgress{
+		TotalGroups: len(groups),
+		TotalFiles:  totalFiles,
+		StartTime:   started,
+	})
+
+	target := w.ms
+	storeDir := w.storeDir()
+	if dryRun {
+		tmpRoot, tmpErr := os.MkdirTemp("", "altmount-migration-dryrun-")
+		if tmpErr != nil {
+			return nil, fmt.Errorf("create dry-run temp root: %w", tmpErr)
+		}
+		defer func() { _ = os.RemoveAll(tmpRoot) }()
+		target = NewMetadataService(filepath.Join(tmpRoot, "meta"))
+		storeDir = filepath.Join(tmpRoot, "store")
+	}
+
+	result := &MigrationResult{DryRun: dryRun, Groups: len(groups)}
+	defaultGroup := w.defaultGroup()
+
+	for _, g := range groups {
+		if ctx.Err() != nil {
+			result.Cancelled = true
+			break
+		}
+		w.updateProgressGroup(g.Key)
+
+		gr, groupErr := target.MigrateGroup(ctx, g, storeDir, defaultGroup)
+		if groupErr != nil {
+			if ctx.Err() != nil {
+				result.Cancelled = true
+				break
+			}
+			result.FilesFailed += len(g.Files)
+			result.Failures = append(result.Failures, fmt.Sprintf("%s: %v", g.Key, groupErr))
+			slog.WarnContext(ctx, "Skipping release group that failed to migrate",
+				"group", g.Key, "error", groupErr)
+			continue
+		}
+
+		if gr.Faithful {
+			result.FaithfulGroups++
+		} else {
+			result.SynthesizedGroups++
+		}
+		result.FilesMigrated += gr.FilesMigrated
+		result.FilesFailed += gr.FilesFailed
+		result.BytesBefore += gr.BytesBefore
+		result.BytesAfter += gr.BytesAfter
+		result.Failures = append(result.Failures, gr.Failures...)
+
+		w.advanceProgress(len(g.Files))
+		if !dryRun {
+			select {
+			case <-ctx.Done():
+				result.Cancelled = true
+			case <-time.After(migrationGroupPause):
+			}
+		}
+	}
+
+	result.BytesSaved = result.BytesBefore - result.BytesAfter
+	result.Duration = time.Since(started)
+	result.CompletedAt = time.Now()
+	w.setProgress(nil)
+	return result, nil
+}
+
+// storeDir is where migrated .nzbz files live: <configDir>/.nzbs/_migrated,
+// mirroring the importer's layout.
+func (w *MigrationWorker) storeDir() string {
+	cfg := w.configGetter()
+	configDir := filepath.Dir(cfg.Database.Path)
+	if !filepath.IsAbs(configDir) {
+		if abs, err := filepath.Abs(configDir); err == nil {
+			configDir = abs
+		}
+	}
+	return filepath.Join(configDir, ".nzbs", "_migrated")
+}
+
+func (w *MigrationWorker) defaultGroup() string {
+	if g := w.configGetter().Metadata.Migration.DefaultGroup; g != "" {
+		return g
+	}
+	return defaultMigrationGroup
+}
+
+func (w *MigrationWorker) setProgress(p *MigrationProgress) {
+	w.progressMu.Lock()
+	defer w.progressMu.Unlock()
+	w.progress = p
+}
+
+func (w *MigrationWorker) updateProgressGroup(key string) {
+	w.progressMu.Lock()
+	defer w.progressMu.Unlock()
+	if w.progress != nil {
+		w.progress.CurrentRelease = key
+	}
+}
+
+func (w *MigrationWorker) advanceProgress(files int) {
+	w.progressMu.Lock()
+	defer w.progressMu.Unlock()
+	if w.progress != nil {
+		w.progress.ProcessedGroups++
+		w.progress.ProcessedFiles += files
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/metadata/ -run TestMigrationWorker -v`
+Expected: PASS (all three tests)
+
+- [ ] **Step 5: Run the full package and build**
+
+Run: `go build ./... && go test ./internal/metadata/ 2>&1 | tail -20`
+Expected: build succeeds, tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/metadata/migration.go internal/metadata/migration_test.go
+git commit -m "feat(metadata): add manually-triggered v3 migration worker"
+```
+
+---
+
+### Task 8: API endpoints and wiring
+
+**Files:**
+- Create: `internal/api/metadata_migration_handlers.go`
+- Modify: `internal/api/server.go` — add the field near line 56, a setter near line 145, routes near line 296, and the four `Server` methods near line 498
+- Modify: `cmd/altmount/cmd/serve.go` near line 207
+
+**Interfaces:**
+- Consumes: everything from Task 7.
+- Produces: `(*Server).SetMetadataMigrationWorker(w *metadata.MigrationWorker)` and the four routes.
+
+- [ ] **Step 1: Write the handlers**
+
+Create `internal/api/metadata_migration_handlers.go`:
+
+```go
+package api
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/javi11/altmount/internal/metadata"
+)
+
+// MetadataMigrationHandlers holds the legacy-metadata migration handlers.
+type MetadataMigrationHandlers struct {
+	worker *metadata.MigrationWorker
+}
+
+// NewMetadataMigrationHandlers creates a new instance of the migration handlers.
+func NewMetadataMigrationHandlers(worker *metadata.MigrationWorker) *MetadataMigrationHandlers {
+	return &MetadataMigrationHandlers{worker: worker}
+}
+
+// handleGetStatus handles GET /api/metadata/migration/status
+func (h *MetadataMigrationHandlers) handleGetStatus(c *fiber.Ctx) error {
+	return RespondSuccess(c, h.worker.GetStatus())
+}
+
+// handleDryRun handles POST /api/metadata/migration/dry-run
+func (h *MetadataMigrationHandlers) handleDryRun(c *fiber.Ctx) error {
+	result, err := h.worker.DryRun(c.Context())
+	if err != nil {
+		if errors.Is(err, metadata.ErrMigrationRunning) {
+			return RespondConflict(c, "Metadata migration already running", err.Error())
+		}
+		slog.ErrorContext(c.Context(), "Metadata migration dry run failed", "error", err)
+		return RespondInternalError(c, "Failed to perform migration dry run", err.Error())
+	}
+	return RespondSuccess(c, result)
+}
+
+// handleStart handles POST /api/metadata/migration/start
+func (h *MetadataMigrationHandlers) handleStart(c *fiber.Ctx) error {
+	if err := h.worker.Start(c.Context()); err != nil {
+		if errors.Is(err, metadata.ErrMigrationRunning) {
+			return RespondConflict(c, "Metadata migration already running", err.Error())
+		}
+		slog.ErrorContext(c.Context(), "Failed to start metadata migration", "error", err)
+		return RespondInternalError(c, "Failed to start metadata migration", err.Error())
+	}
+	return RespondMessage(c, "Metadata migration started")
+}
+
+// handleCancel handles POST /api/metadata/migration/cancel
+func (h *MetadataMigrationHandlers) handleCancel(c *fiber.Ctx) error {
+	h.worker.Cancel()
+	return RespondMessage(c, "Metadata migration cancelled")
+}
+```
+
+- [ ] **Step 2: Wire the server**
+
+In `internal/api/server.go`, add the field to the `Server` struct next to `librarySyncWorker` (line 56):
+
+```go
+	metadataMigrationWorker *metadata.MigrationWorker
+```
+
+Add the setter after `SetLibrarySyncWorker` (line 147):
+
+```go
+// SetMetadataMigrationWorker sets the metadata migration worker for the server.
+func (s *Server) SetMetadataMigrationWorker(worker *metadata.MigrationWorker) {
+	s.metadataMigrationWorker = worker
+}
+```
+
+Add the routes next to the library-sync routes (after line 296):
+
+```go
+	api.Get("/metadata/migration/status", s.handleGetMetadataMigrationStatus)
+	api.Post("/metadata/migration/dry-run", s.handleDryRunMetadataMigration)
+	api.Post("/metadata/migration/start", s.handleStartMetadataMigration)
+	api.Post("/metadata/migration/cancel", s.handleCancelMetadataMigration)
+```
+
+Add the four `Server` methods near the other library-sync `Server` methods (after line 520):
+
+```go
+// Metadata migration handler methods
+
+// handleGetMetadataMigrationStatus handles GET /api/metadata/migration/status
+//
+//	@Summary		Get metadata migration status
+//	@Description	Returns the status of the legacy metadata → v3 migration worker.
+//	@Tags			Metadata
+//	@Produce		json
+//	@Success		200	{object}	APIResponse
+//	@Failure		503	{object}	APIResponse
+//	@Security		BearerAuth
+//	@Router			/metadata/migration/status [get]
+func (s *Server) handleGetMetadataMigrationStatus(c *fiber.Ctx) error {
+	if s.metadataMigrationWorker == nil {
+		return RespondServiceUnavailable(c, "Metadata migration worker not available", "")
+	}
+	return NewMetadataMigrationHandlers(s.metadataMigrationWorker).handleGetStatus(c)
+}
+
+// handleDryRunMetadataMigration handles POST /api/metadata/migration/dry-run
+//
+//	@Summary		Dry-run the metadata migration
+//	@Description	Converts against an isolated temporary root and reports measured savings without touching the library.
+//	@Tags			Metadata
+//	@Produce		json
+//	@Success		200	{object}	APIResponse
+//	@Failure		409	{object}	APIResponse
+//	@Failure		503	{object}	APIResponse
+//	@Security		BearerAuth
+//	@Router			/metadata/migration/dry-run [post]
+func (s *Server) handleDryRunMetadataMigration(c *fiber.Ctx) error {
+	if s.metadataMigrationWorker == nil {
+		return RespondServiceUnavailable(c, "Metadata migration worker not available", "")
+	}
+	return NewMetadataMigrationHandlers(s.metadataMigrationWorker).handleDryRun(c)
+}
+
+// handleStartMetadataMigration handles POST /api/metadata/migration/start
+//
+//	@Summary		Start the metadata migration
+//	@Description	Rewrites legacy .meta files to the v3 store-backed format in place.
+//	@Tags			Metadata
+//	@Produce		json
+//	@Success		200	{object}	APIResponse
+//	@Failure		409	{object}	APIResponse
+//	@Failure		503	{object}	APIResponse
+//	@Security		BearerAuth
+//	@Router			/metadata/migration/start [post]
+func (s *Server) handleStartMetadataMigration(c *fiber.Ctx) error {
+	if s.metadataMigrationWorker == nil {
+		return RespondServiceUnavailable(c, "Metadata migration worker not available", "")
+	}
+	return NewMetadataMigrationHandlers(s.metadataMigrationWorker).handleStart(c)
+}
+
+// handleCancelMetadataMigration handles POST /api/metadata/migration/cancel
+//
+//	@Summary		Cancel the metadata migration
+//	@Description	Stops an in-flight migration after the current file.
+//	@Tags			Metadata
+//	@Produce		json
+//	@Success		200	{object}	APIResponse
+//	@Failure		503	{object}	APIResponse
+//	@Security		BearerAuth
+//	@Router			/metadata/migration/cancel [post]
+func (s *Server) handleCancelMetadataMigration(c *fiber.Ctx) error {
+	if s.metadataMigrationWorker == nil {
+		return RespondServiceUnavailable(c, "Metadata migration worker not available", "")
+	}
+	return NewMetadataMigrationHandlers(s.metadataMigrationWorker).handleCancel(c)
+}
+```
+
+`internal/api/server.go` already imports `github.com/javi11/altmount/internal/metadata` (it holds `metadataService *metadata.MetadataService`); confirm with `grep -n "internal/metadata" internal/api/server.go` and add the import only if it is missing.
+
+- [ ] **Step 3: Wire it in serve.go**
+
+In `cmd/altmount/cmd/serve.go`, after the `apiServer.SetLibrarySyncWorker(librarySyncWorker)` block (line 205-209), add:
+
+```go
+	apiServer.SetMetadataMigrationWorker(
+		metadata.NewMigrationWorker(metadataService, configManager.GetConfigGetter()),
+	)
+```
+
+`metadataService` is already in scope from line 87. Add `"github.com/javi11/altmount/internal/metadata"` to the imports of `serve.go` if it is not already there — check with `grep -n "internal/metadata" cmd/altmount/cmd/serve.go`.
+
+- [ ] **Step 4: Verify the build and the API package**
+
+Run: `go build ./... && go vet ./internal/api/ ./cmd/... && go test ./internal/api/ 2>&1 | tail -20`
+Expected: build and vet clean, API tests PASS
+
+- [ ] **Step 5: Smoke-test the routes are registered**
+
+Run: `grep -n "metadata/migration" internal/api/server.go`
+Expected: four lines, one per route
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/api/metadata_migration_handlers.go internal/api/server.go cmd/altmount/cmd/serve.go
+git commit -m "feat(api): expose metadata migration status, dry-run, start and cancel"
+```
+
+---
+
+### Task 9: Frontend types, API client, and hook
+
+**Files:**
+- Modify: `frontend/src/types/api.ts` (add next to `LibrarySyncStatus`)
+- Modify: `frontend/src/api/client.ts` (add after `cancelLibrarySync`, around line 508)
+- Create: `frontend/src/hooks/useMetadataMigration.ts`
+
+**Interfaces:**
+- Consumes: the four endpoints from Task 8.
+- Produces: `MetadataMigrationStatus`, `MetadataMigrationResult`, `MetadataMigrationProgress` types; `apiClient.getMetadataMigrationStatus/dryRunMetadataMigration/startMetadataMigration/cancelMetadataMigration`; hooks `useMetadataMigrationStatus`, `useDryRunMetadataMigration`, `useStartMetadataMigration`, `useCancelMetadataMigration`.
+
+- [ ] **Step 1: Add the types**
+
+In `frontend/src/types/api.ts`, next to the existing `LibrarySyncStatus` interface (find it with `grep -n "LibrarySyncStatus" frontend/src/types/api.ts`), add:
+
+```ts
+export interface MetadataMigrationProgress {
+	total_groups: number;
+	processed_groups: number;
+	total_files: number;
+	processed_files: number;
+	current_release: string;
+	start_time: string;
+}
+
+export interface MetadataMigrationResult {
+	dry_run: boolean;
+	groups: number;
+	faithful_groups: number;
+	synthesized_groups: number;
+	files_migrated: number;
+	files_failed: number;
+	bytes_before: number;
+	bytes_after: number;
+	bytes_saved: number;
+	failures?: string[];
+	cancelled: boolean;
+	duration: number;
+	completed_at: string;
+}
+
+export interface MetadataMigrationStatus {
+	is_running: boolean;
+	legacy_files: number;
+	legacy_groups: number;
+	progress?: MetadataMigrationProgress;
+	last_result?: MetadataMigrationResult;
+	last_dry_run?: MetadataMigrationResult;
+}
+```
+
+- [ ] **Step 2: Add the client methods**
+
+In `frontend/src/api/client.ts`, after `cancelLibrarySync()` (ends around line 508), add:
+
+```ts
+	async getMetadataMigrationStatus() {
+		return this.request<MetadataMigrationStatus>("/metadata/migration/status");
+	}
+
+	async dryRunMetadataMigration() {
+		return this.request<MetadataMigrationResult>("/metadata/migration/dry-run", {
+			method: "POST",
+		});
+	}
+
+	async startMetadataMigration() {
+		return this.request<{ message: string }>("/metadata/migration/start", {
+			method: "POST",
+		});
+	}
+
+	async cancelMetadataMigration() {
+		return this.request<{ message: string }>("/metadata/migration/cancel", {
+			method: "POST",
+		});
+	}
+```
+
+Add `MetadataMigrationResult` and `MetadataMigrationStatus` to the existing type import from `../types/api` at the top of `client.ts` (match the file's existing import style, which the `LibrarySyncStatus` import already demonstrates).
+
+- [ ] **Step 3: Write the hook**
+
+Create `frontend/src/hooks/useMetadataMigration.ts`:
+
+```ts
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "../api/client";
+import type { MetadataMigrationResult, MetadataMigrationStatus } from "../types/api";
+
+const MIGRATION_KEY = ["metadata", "migration"];
+
+// Hook to poll migration status: fast while running, slow when idle.
+export function useMetadataMigrationStatus() {
+	return useQuery<MetadataMigrationStatus>({
+		queryKey: [...MIGRATION_KEY, "status"],
+		queryFn: () => apiClient.getMetadataMigrationStatus(),
+		retry: 3,
+		refetchInterval: (query) => {
+			if (query.state.error) return false;
+			if (!query.state.data) return 10000;
+			return query.state.data.is_running ? 2000 : 10000;
+		},
+		refetchIntervalInBackground: true,
+	});
+}
+
+// Hook to run a dry run. Resolves with the measured result.
+export function useDryRunMetadataMigration() {
+	const queryClient = useQueryClient();
+
+	return useMutation<MetadataMigrationResult>({
+		mutationFn: () => apiClient.dryRunMetadataMigration(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: MIGRATION_KEY });
+		},
+		onError: (error) => {
+			console.error("Metadata migration dry run failed:", error);
+		},
+	});
+}
+
+// Hook to start the migration.
+export function useStartMetadataMigration() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: () => apiClient.startMetadataMigration(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: MIGRATION_KEY });
+		},
+		onError: (error) => {
+			console.error("Failed to start metadata migration:", error);
+		},
+	});
+}
+
+// Hook to cancel an in-flight migration.
+export function useCancelMetadataMigration() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: () => apiClient.cancelMetadataMigration(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: MIGRATION_KEY });
+		},
+		onError: (error) => {
+			console.error("Failed to cancel metadata migration:", error);
+		},
+	});
+}
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `cd frontend && bun run check`
+Expected: PASS with no type or lint errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/types/api.ts frontend/src/api/client.ts frontend/src/hooks/useMetadataMigration.ts
+git commit -m "feat(frontend): add metadata migration api client and hooks"
+```
+
+---
+
+### Task 10: The migration card in the metadata config section
+
+**Files:**
+- Create: `frontend/src/components/config/MetadataMigrationCard.tsx`
+- Modify: `frontend/src/components/config/MetadataConfigSection.tsx`
+
+**Interfaces:**
+- Consumes: the hooks from Task 9.
+- Produces: `MetadataMigrationCard` (named export, no props).
+
+- [ ] **Step 1: Write the component**
+
+Create `frontend/src/components/config/MetadataMigrationCard.tsx`:
+
+```tsx
+import { AlertTriangle, Archive, CheckCircle, Play, Search, XCircle } from "lucide-react";
+import { useState } from "react";
+import {
+	useCancelMetadataMigration,
+	useDryRunMetadataMigration,
+	useMetadataMigrationStatus,
+	useStartMetadataMigration,
+} from "../../hooks/useMetadataMigration";
+import { LoadingSpinner } from "../ui/LoadingSpinner";
+
+function formatBytes(bytes: number): string {
+	if (bytes <= 0) return "0 B";
+	const units = ["B", "KB", "MB", "GB", "TB"];
+	const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+	return `${(bytes / 1024 ** exponent).toFixed(exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+}
+
+export function MetadataMigrationCard() {
+	const { data: status, isLoading } = useMetadataMigrationStatus();
+	const dryRun = useDryRunMetadataMigration();
+	const startMigration = useStartMetadataMigration();
+	const cancelMigration = useCancelMetadataMigration();
+	const [showConfirm, setShowConfirm] = useState(false);
+
+	const isRunning = status?.is_running ?? false;
+	const preview = status?.last_dry_run ?? dryRun.data;
+	const lastResult = status?.last_result;
+	const progress = status?.progress;
+	const percent =
+		progress && progress.total_files > 0
+			? Math.round((progress.processed_files / progress.total_files) * 100)
+			: 0;
+
+	const handleConfirmMigrate = async () => {
+		setShowConfirm(false);
+		await startMigration.mutateAsync();
+	};
+
+	return (
+		<div className="card bg-base-100 shadow-lg">
+			<div className="card-body">
+				<h2 className="card-title">
+					<Archive className="h-5 w-5" aria-hidden="true" />
+					Storage Migration
+				</h2>
+				<p className="text-base-content/70 text-sm">
+					Convert legacy metadata files to the shared NZB store format. Segments move out of each
+					<code className="mx-1">.meta</code> file into one compressed
+					<code className="mx-1">.nzbz</code> per release, reclaiming disk space.
+				</p>
+
+				{isLoading ? (
+					<div className="flex justify-center py-6">
+						<LoadingSpinner size="md" />
+					</div>
+				) : (
+					<>
+						{isRunning && progress && (
+							<div className="space-y-2 py-2">
+								<div className="flex justify-between text-sm">
+									<span>
+										Release {progress.processed_groups} of {progress.total_groups}
+									</span>
+									<span>
+										{progress.processed_files} / {progress.total_files} files
+									</span>
+								</div>
+								<progress className="progress progress-primary w-full" value={percent} max={100} />
+								{progress.current_release && (
+									<p className="truncate text-base-content/60 text-xs">
+										{progress.current_release}
+									</p>
+								)}
+							</div>
+						)}
+
+						{!isRunning && preview && (
+							<div className="overflow-x-auto py-2">
+								<table className="table table-sm">
+									<tbody>
+										<tr>
+											<td>Releases</td>
+											<td className="text-right font-mono">{preview.groups}</td>
+										</tr>
+										<tr>
+											<td>Files to convert</td>
+											<td className="text-right font-mono">{preview.files_migrated}</td>
+										</tr>
+										<tr>
+											<td>Current size</td>
+											<td className="text-right font-mono">{formatBytes(preview.bytes_before)}</td>
+										</tr>
+										<tr>
+											<td>Projected size</td>
+											<td className="text-right font-mono">{formatBytes(preview.bytes_after)}</td>
+										</tr>
+										<tr className="font-semibold">
+											<td>Reclaimed</td>
+											<td className="text-right font-mono text-success">
+												{formatBytes(preview.bytes_saved)}
+											</td>
+										</tr>
+										{preview.files_failed > 0 && (
+											<tr>
+												<td>Cannot convert</td>
+												<td className="text-right font-mono text-warning">
+													{preview.files_failed}
+												</td>
+											</tr>
+										)}
+									</tbody>
+								</table>
+							</div>
+						)}
+
+						{!isRunning && preview && preview.groups === 0 && (
+							<div className="alert alert-success">
+								<CheckCircle className="h-6 w-6" aria-hidden="true" />
+								<div>All metadata is already in the shared store format.</div>
+							</div>
+						)}
+
+						{lastResult && !isRunning && (
+							<div className={`alert ${lastResult.files_failed > 0 ? "alert-warning" : "alert-success"}`}>
+								{lastResult.files_failed > 0 ? (
+									<AlertTriangle className="h-6 w-6" aria-hidden="true" />
+								) : (
+									<CheckCircle className="h-6 w-6" aria-hidden="true" />
+								)}
+								<div>
+									<div className="font-bold">
+										{lastResult.cancelled ? "Migration cancelled" : "Migration complete"}
+									</div>
+									<div className="text-sm">
+										{lastResult.files_migrated} files migrated,{" "}
+										{formatBytes(lastResult.bytes_saved)} reclaimed
+										{lastResult.files_failed > 0 && `, ${lastResult.files_failed} skipped`}
+									</div>
+								</div>
+							</div>
+						)}
+
+						{dryRun.isError && (
+							<div className="alert alert-error">
+								<XCircle className="h-6 w-6" aria-hidden="true" />
+								<div>Dry run failed. Check the logs for details.</div>
+							</div>
+						)}
+
+						<div className="card-actions justify-end pt-2">
+							{isRunning ? (
+								<button
+									type="button"
+									className="btn btn-error btn-outline"
+									onClick={() => cancelMigration.mutate()}
+									disabled={cancelMigration.isPending}
+								>
+									<XCircle className="h-4 w-4" aria-hidden="true" />
+									Cancel
+								</button>
+							) : (
+								<>
+									<button
+										type="button"
+										className="btn btn-outline"
+										onClick={() => dryRun.mutate()}
+										disabled={dryRun.isPending}
+									>
+										{dryRun.isPending ? (
+											<LoadingSpinner size="sm" />
+										) : (
+											<Search className="h-4 w-4" aria-hidden="true" />
+										)}
+										{dryRun.isPending ? "Scanning..." : "Dry Run"}
+									</button>
+									<button
+										type="button"
+										className="btn btn-primary"
+										onClick={() => setShowConfirm(true)}
+										disabled={!preview || preview.groups === 0 || startMigration.isPending}
+									>
+										<Play className="h-4 w-4" aria-hidden="true" />
+										Migrate
+									</button>
+								</>
+							)}
+						</div>
+					</>
+				)}
+			</div>
+
+			{showConfirm && (
+				<dialog className="modal modal-open">
+					<div className="modal-box">
+						<h3 className="font-bold text-lg">Migrate metadata?</h3>
+						<p className="py-4">
+							This rewrites every legacy <code>.meta</code> file in place and moves its segments into
+							a shared <code>.nzbz</code> store per release. The change is one-way. Streaming keeps
+							working throughout, and you can cancel at any point.
+						</p>
+						<div className="modal-action">
+							<button type="button" className="btn" onClick={() => setShowConfirm(false)}>
+								Cancel
+							</button>
+							<button type="button" className="btn btn-primary" onClick={handleConfirmMigrate}>
+								Migrate
+							</button>
+						</div>
+					</div>
+				</dialog>
+			)}
+		</div>
+	);
+}
+```
+
+- [ ] **Step 2: Render it in the metadata section**
+
+In `frontend/src/components/config/MetadataConfigSection.tsx`, add the import next to the existing component imports:
+
+```tsx
+import { MetadataMigrationCard } from "./MetadataMigrationCard";
+```
+
+Then render it just above the `{/* Save Button */}` block at the end of the returned JSX:
+
+```tsx
+			<MetadataMigrationCard />
+
+			{/* Save Button */}
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `cd frontend && bun run check && bun run build`
+Expected: both PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/config/MetadataMigrationCard.tsx frontend/src/components/config/MetadataConfigSection.tsx
+git commit -m "feat(frontend): add storage migration card to metadata settings"
+```
+
+---
+
+### Task 11: Full verification
+
+**Files:** none created; this validates the whole change.
+
+**Interfaces:**
+- Consumes: everything.
+- Produces: a green build.
+
+- [ ] **Step 1: Run the full Go test suite**
+
+Run: `go build ./... && go test ./... 2>&1 | grep -v "^ok\|no test files" | head -30`
+Expected: no FAIL lines
+
+- [ ] **Step 2: Run the full project build**
+
+Run: `make`
+Expected: succeeds (Go backend + frontend, all validations)
+
+- [ ] **Step 3: Confirm the migration round-trips on a realistic tree**
+
+Run: `go test ./internal/metadata/ -run 'TestMigrate|TestScanLegacy|TestSynthesize|TestBuildGroupStore|TestMigrationWorker' -v 2>&1 | tail -30`
+Expected: all PASS
+
+- [ ] **Step 4: Commit any formatting fixes the build produced**
+
+```bash
+git status --short
+git add -A
+git commit -m "chore: formatting and generated output after metadata migration feature"
+```
+
+Skip this commit if `git status --short` is empty.

--- a/docs/superpowers/plans/2026-08-21-metadata-v3-migration.md
+++ b/docs/superpowers/plans/2026-08-21-metadata-v3-migration.md
@@ -282,7 +282,8 @@ git commit -m "feat(config): add metadata.migration.default_group"
 - Produces:
   - `type LegacyMeta struct { MetaPath, VirtualPath string; SizeBytes int64; Meta *metapb.FileMetadata }`
   - `type LegacyGroup struct { Key string; Files []LegacyMeta }`
-  - `func (ms *MetadataService) ScanLegacyMetas() ([]LegacyGroup, error)`
+  - `func (ms *MetadataService) ScanLegacyMetas() ([]LegacyGroup, error)` — `LegacyMeta.Meta` is nil in the result
+  - `func (ms *MetadataService) LoadGroupMetas(g LegacyGroup) (LegacyGroup, error)` — returns a copy with `Meta` populated
 
 - [ ] **Step 1: Write the failing test**
 
@@ -340,7 +341,34 @@ func TestScanLegacyMetas_GroupsBySourceNzbPath(t *testing.T) {
 	dirKey := filepath.Join(root, "other")
 	require.Len(t, byKey[dirKey], 1, "empty source_nzb_path falls back to the parent directory")
 	assert.Positive(t, byKey[dirKey][0].SizeBytes)
-	require.Len(t, byKey[dirKey][0].Meta.SegmentData, 1)
+
+	// The scan must not retain full protos: that is the whole-library
+	// allocation pattern ReadFileMetadataLite was introduced to avoid.
+	for _, g := range groups {
+		for _, lm := range g.Files {
+			assert.Nil(t, lm.Meta, "scan must not retain segment data for %s", lm.VirtualPath)
+		}
+	}
+}
+
+func TestLoadGroupMetas_HydratesOneGroup(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	writeLegacyMeta(t, ms, filepath.Join("movies", "A.mkv"), "/nzbs/rel.nzb", "a1@n", "a2@n")
+	writeLegacyMeta(t, ms, filepath.Join("movies", "B.mkv"), "/nzbs/rel.nzb", "b1@n")
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+
+	loaded, err := ms.LoadGroupMetas(groups[0])
+	require.NoError(t, err)
+	require.Len(t, loaded.Files, 2)
+	require.NotNil(t, loaded.Files[0].Meta)
+	assert.Len(t, loaded.Files[0].Meta.SegmentData, 2)
+	assert.Len(t, loaded.Files[1].Meta.SegmentData, 1)
+	assert.Equal(t, groups[0].Key, loaded.Key)
 }
 
 func TestScanLegacyMetas_SkipsV3Metas(t *testing.T) {
@@ -398,6 +426,12 @@ import (
 )
 
 // LegacyMeta is one v1 (inline-segment) metadata file discovered by a scan.
+//
+// Meta is deliberately nil after a scan: a legacy meta carries its segments
+// inline, so retaining every one of them across a whole-library walk is the
+// allocation pattern that ReadFileMetadataLite exists to avoid (see the 7.94 GB
+// spike documented at service.go:405). LoadGroupMetas fills it in for one
+// release at a time, just before that release is migrated.
 type LegacyMeta struct {
 	MetaPath    string
 	VirtualPath string
@@ -416,6 +450,10 @@ type LegacyGroup struct {
 // meta, grouped by release. The group key is source_nzb_path when set, and the
 // meta's parent directory otherwise. Unreadable files are skipped rather than
 // failing the whole scan: a migration should convert what it can.
+//
+// Each meta is read to obtain its group key and then released, so the walk
+// retains only paths and sizes — peak memory is one meta, not the library.
+// Call LoadGroupMetas to hydrate a single group before migrating it.
 func (ms *MetadataService) ScanLegacyMetas() ([]LegacyGroup, error) {
 	byKey := make(map[string][]LegacyMeta)
 
@@ -443,11 +481,11 @@ func (ms *MetadataService) ScanLegacyMetas() ([]LegacyGroup, error) {
 		if key == "" {
 			key = filepath.Dir(path)
 		}
+		// meta goes out of scope here on purpose — see the LegacyMeta doc.
 		byKey[key] = append(byKey[key], LegacyMeta{
 			MetaPath:    path,
 			VirtualPath: virtualPath,
 			SizeBytes:   int64(len(data)),
-			Meta:        meta,
 		})
 		return nil
 	})
@@ -463,18 +501,37 @@ func (ms *MetadataService) ScanLegacyMetas() ([]LegacyGroup, error) {
 	sort.Slice(groups, func(a, b int) bool { return groups[a].Key < groups[b].Key })
 	return groups, nil
 }
+
+// LoadGroupMetas returns a copy of g with every LegacyMeta.Meta populated.
+// Files that can no longer be read (deleted or migrated since the scan) are
+// dropped, so a stale scan degrades to a smaller group rather than an error.
+func (ms *MetadataService) LoadGroupMetas(g LegacyGroup) (LegacyGroup, error) {
+	loaded := LegacyGroup{Key: g.Key, Files: make([]LegacyMeta, 0, len(g.Files))}
+	for _, lm := range g.Files {
+		meta, err := ms.ReadFileMetadata(lm.VirtualPath)
+		if err != nil || meta == nil {
+			continue
+		}
+		lm.Meta = meta
+		loaded.Files = append(loaded.Files, lm)
+	}
+	if len(loaded.Files) == 0 {
+		return loaded, fmt.Errorf("no readable metadata left in group %q", g.Key)
+	}
+	return loaded, nil
+}
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `go test ./internal/metadata/ -run TestScanLegacyMetas -v`
-Expected: PASS (both subtests)
+Run: `go test ./internal/metadata/ -run 'TestScanLegacyMetas|TestLoadGroupMetas' -v`
+Expected: PASS (all three tests)
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add internal/metadata/migration_scan.go internal/metadata/migration_scan_test.go
-git commit -m "feat(metadata): scan and group legacy metas by release"
+git commit -m "feat(metadata): scan and group legacy metas without retaining segments"
 ```
 
 ---
@@ -935,7 +992,7 @@ This task carries the core invariant: after migration, `ReadFileMetadata` must r
 - Create: `internal/metadata/migration_convert_test.go`
 
 **Interfaces:**
-- Consumes: `buildGroupStore` (Task 5), `LegacyGroup`/`LegacyMeta` (Task 3), `MetadataService.Store()`, `MetadataService.WriteFileMetadataV3(ctx, virtualPath, metadata, index, storeRef)`.
+- Consumes: `buildGroupStore` (Task 5), `LegacyGroup`/`LegacyMeta`/`LoadGroupMetas` (Task 3), `MetadataService.Store()`, `MetadataService.WriteFileMetadataV3(ctx, virtualPath, metadata, index, storeRef)`.
 - Produces:
   - `type GroupResult struct { Key, StoreRef string; Faithful bool; FilesMigrated, FilesFailed int; BytesBefore, BytesAfter int64; Failures []string }`
   - `func (ms *MetadataService) MigrateGroup(ctx context.Context, g LegacyGroup, storeDir, defaultGroup string) (GroupResult, error)`
@@ -1251,10 +1308,25 @@ type GroupResult struct {
 // A per-file failure leaves that file as v1 and is recorded; the rest of the
 // group still migrates. If every file fails, the freshly written store is
 // removed so no orphan is left behind.
+//
+// The group's metas are loaded here rather than at scan time: legacy metas
+// carry their segments inline, so hydrating the whole library at once is the
+// allocation pattern documented at service.go:405.
 func (ms *MetadataService) MigrateGroup(ctx context.Context, g LegacyGroup, storeDir, defaultGroup string) (GroupResult, error) {
 	res := GroupResult{Key: g.Key}
 	for _, lm := range g.Files {
 		res.BytesBefore += lm.SizeBytes
+	}
+
+	// Hydrate this group's metas now and let them fall out of scope when the
+	// call returns, so peak memory is one release rather than the whole library.
+	// A group hydrated by the caller (tests, or a re-used group) is left alone.
+	if len(g.Files) > 0 && g.Files[0].Meta == nil {
+		loaded, err := ms.LoadGroupMetas(g)
+		if err != nil {
+			return res, err
+		}
+		g = loaded
 	}
 
 	store, index, faithful, err := buildGroupStore(g, defaultGroup)

--- a/docs/superpowers/specs/2026-08-21-metadata-v1-to-v3-migration-design.md
+++ b/docs/superpowers/specs/2026-08-21-metadata-v1-to-v3-migration-design.md
@@ -1,0 +1,181 @@
+# Legacy metadata → v3 store-backed migration
+
+**Date:** 2026-08-21
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+Libraries imported before the v3 shared-`NzbStore` format (commit `c7f73182`) have
+`.meta` files carrying inline `segment_data`: one `SegmentData` message per segment,
+per file. For a RAR release every virtual file repeats the same outer-volume
+segments, so the on-disk cost is O(files × segments).
+
+v3 stores the segments once per release in a zstd-compressed `.nzbz` sidecar and
+leaves each `.meta` holding only `segment_refs`/`segment_runs` into that store's flat
+segment index. New imports already write v3 (`processor.go:582` →
+`WriteFileMetadataAuto`). Existing libraries never convert.
+
+**Goal:** migrate every legacy `.meta` to v3, merging all files of a release onto one
+shared `.nzbz`, to reclaim disk space. Triggered manually from the AltMount panel,
+with a dry run first.
+
+Explicitly out of scope: there is no distinct "v2" on-disk format (the only magic is
+`{0x00,'A','M','3',0x01}`); metas carrying `shared_outer_sources` are just legacy
+metas with a dedup layer and are handled by the same path.
+
+## Existing machinery reused
+
+- `MetadataService.WriteFileMetadataV3` (`service.go:263`) already *is* the
+  converter: given an inline-segment `FileMetadata`, a `messageID → flatIndex` map and
+  a store ref, it converts main + PAR2 + nested segments to refs/runs, sets
+  `store_ref`/`source_nzb_path`, writes atomically, and calls `IncStoreRef` once.
+- `segDataToRefs` + `splitRefs` (`store.go`) do the ref conversion and run compaction.
+- `ExpandSharedOuterSources` (`expand.go`) dissolves the multi-extent dedup.
+- `StoreService.WriteStore` / `ReadStore` (`store.go`) persist and verify `.nzbz`.
+- `parser.BuildStore` + `nzbparser.Parse` build a faithful store from a real `.nzb`,
+  with no `Parser` instance and no NNTP.
+- `LibrarySyncWorker` (`internal/health/library_sync.go:65`) is the structural model
+  for the worker; `internal/api/server.go:292` for the routes; `useLibrarySync.ts`
+  for the hook.
+
+Two facts that make in-place rewriting safe:
+
+- `truncateFilename` is idempotent, so a walked `.meta` path maps back to a
+  `virtualPath` that re-derives to the same file — no orphaning.
+- `segDataToRefs` writes `decoded_bytes` from each `SegmentData.SegmentSize`, and the
+  read path prefers `decoded_bytes` over `NzbSeg.Bytes`, so a synthesized store
+  carrying decoded sizes is self-consistent and loses no size information.
+
+## Architecture
+
+New file `internal/metadata/migration.go` defines `MigrationWorker`, modeled on
+`LibrarySyncWorker`: `mu`/`running` guard, `cancelFunc`, `progressMu`/`progress`,
+`lastResult`. Methods: `Scan`, `DryRun`, `Start`, `Cancel`, `Status`.
+
+### Pass 1 — discover and group
+
+Walk `ms.rootPath` for `*.meta`. Read the first 5 bytes and skip anything with the v3
+magic — this is what makes the migration idempotent and resumable. Unmarshal each
+legacy meta and derive a group key:
+
+1. primary: `source_nzb_path`
+2. fallback when empty/missing: the meta file's parent directory
+
+Yields `map[groupKey][]legacyMeta{metaPath, virtualPath, meta}`.
+
+### Pass 2 — per group, convert
+
+Groups are processed in a stable order (sorted meta path).
+
+**Store provenance chain:**
+
+1. **Faithful store** — if `source_nzb_path` still exists on disk: `nzbparser.Parse`
+   it, then `parser.BuildStore(n)`. Real subjects, posters, dates, groups, segment
+   numbers and raw byte counts. Before writing anything, pre-check that *every*
+   segment id in *every* meta of the group resolves in that index; if any is missing
+   (edited or mismatched NZB), abandon the faithful path for this group and fall
+   through. The faithful store carries every segment in the original NZB, including
+   files no meta references — slightly larger than a synthesized store, still vastly
+   smaller than inline segments.
+2. **Synthesized store** — otherwise. Walk each meta's segments in order (main
+   `segment_data`, then each `par2_files[].segment_data`, then
+   `nested_sources[].segments` after `ExpandSharedOuterSources`), appending every
+   not-yet-seen message-id and recording `id → flatIndex`. Emit
+   `NzbSeg{Id, Number: ordinal, Bytes: SegmentData.SegmentSize}`, one `NzbFileEntry`
+   per contributing meta, with `subject` = virtual filename and `groups` =
+   `[metadata.migration.default_group]`. One entry per meta keeps each file's segments
+   on a contiguous increasing index range, so `splitRefs` collapses them into
+   `segment_runs` — where the space win comes from, on top of zstd.
+
+**Then, per group:**
+
+1. Write the store to a fresh path under `<configDir>/.nzbs/_migrated/`, named
+   `<sanitized-group-base>-<shortHash>.nzbz`, where `shortHash` is the first 8 hex
+   characters of the SHA-256 of the store's segment ids joined in flat order. Read it back to verify (same write-then-verify as `processor.go:582`). On
+   either failure, skip the whole group and leave it as v1.
+2. Repoint each meta with `WriteFileMetadataV3(ctx, virtualPath, meta, index, storeRef)`.
+   Refcounts land at exactly the number of migrated metas, so existing
+   deletion/refcount logic needs no changes.
+
+Everything else on the meta is preserved untouched: `known_holes`, `status`,
+`clip_boundaries`, AES keys, `release_date`, `nzbdav_id`, `password`/`salt`.
+
+### Why store paths are content-hashed and never overwritten
+
+If a run is cancelled or a file fails mid-group, some metas are v3 and some remain v1.
+On re-run the v3 metas are skipped, so a rebuilt store for that group would contain
+only the *remaining* segments — a different flat index. Overwriting the original
+`.nzbz` would silently corrupt every already-migrated meta pointing at it. A fresh
+hashed path per run means a partially-migrated group simply gets a second, smaller
+store. Marginally less compact in that rare case, never wrong.
+
+## Correctness and safety
+
+**Core invariant:** for every migrated file, `ReadFileMetadata` after migration returns
+`segment_data` byte-identical to before — same ids, `segment_size`, `start_offset`,
+`end_offset`, order — and likewise for each PAR2 file and nested source. If that holds,
+streaming behaviour cannot change.
+
+**Live-server safety** (the worker runs while serving):
+
+- Store before metas, always: a meta only names a `.nzbz` already written and verified.
+- Meta rewrites use `WriteFileMetadata`'s existing atomic tmp+rename, so a reader sees
+  either the whole old file or the whole new one.
+- An in-flight stream has already resolved its segments into memory; rewriting its meta
+  underneath it changes nothing. The next open reads v3 and resolves through the store.
+- Cancellation is checked between files and between groups, never mid-file.
+- One migration at a time, guarded by the `running` flag.
+- A per-file failure (empty segment id, unreadable meta) leaves that file as v1 and is
+  counted in the result. Nothing is ever deleted: inline data disappears only because
+  the meta is rewritten, and the equivalent data lives in the verified store.
+- Pacing: a fixed 100ms sleep between groups so a large library does not saturate disk
+  while streams are being served.
+
+## Config
+
+One new field: `metadata.migration.default_group`, default `alt.binaries.misc`. Used
+only for synthesized stores. Without it, `nzb.BuildNZB` would render an empty
+`<groups>` element and most external clients reject such an NZB. Faithful stores carry
+the real groups. Streaming, health checks and PAR2 repair are unaffected either way —
+they resolve by message-id.
+
+## API
+
+New `internal/api/metadata_migration_handlers.go`, routes alongside the library-sync
+ones:
+
+- `GET  /api/metadata/migration/status` → `{is_running, progress, last_result}`
+- `POST /api/metadata/migration/dry-run` → scans and converts *in memory*, writing
+  nothing to disk, so numbers are measured rather than estimated: legacy file count, group
+  count, faithful-vs-synthesized split, current bytes, projected bytes, savings, and
+  the files that would fail
+- `POST /api/metadata/migration/start`
+- `POST /api/metadata/migration/cancel`
+
+## UI
+
+A "Storage migration" card in the existing `MetadataConfigSection.tsx`, driven by a
+`useMetadataMigration` hook modeled on `useLibrarySync.ts`:
+
+- **Idle:** one-line summary ("142 legacy files across 18 releases") + **Dry run**
+- **After dry run:** result table (releases, files, current size, projected size,
+  savings, files that cannot convert) + **Migrate**
+- **Migrate:** confirmation modal stating plainly that `.meta` files are rewritten in
+  place and the change is one-way
+- **Running:** progress bar (group n of m, current release) + **Cancel**
+- **Done:** last-result panel with counts, bytes reclaimed, failures
+
+## Testing
+
+- Round-trip invariant over fixtures for each shape: single file, multi-file, RAR with
+  sliced seams, nested RAR, `shared_outer_sources` Blu-ray, PAR2-bearing. Fixture style
+  follows `format_v3_test.go` / `segrefs_test.go`.
+- Grouping: `source_nzb_path` primary, parent-directory fallback.
+- Run compaction actually happens: a plain file collapses to `segment_runs`, not N refs.
+- Faithful path: with the source `.nzb` present, groups survive into the store and
+  `RegenerateNZB` round-trips through `nzbparser`.
+- Faithful pre-check rejects a mismatched NZB and falls back to synthesis.
+- Re-run safety: cancel mid-group, re-run, confirm already-v3 metas are skipped, the
+  surviving v1 metas get a fresh store, and the first store is untouched.
+- Refcounts equal the number of metas pointing at each store.
+- Idempotence: a second full run is a no-op.

--- a/docs/superpowers/specs/2026-08-21-metadata-v1-to-v3-migration-design.md
+++ b/docs/superpowers/specs/2026-08-21-metadata-v1-to-v3-migration-design.md
@@ -145,8 +145,9 @@ New `internal/api/metadata_migration_handlers.go`, routes alongside the library-
 ones:
 
 - `GET  /api/metadata/migration/status` → `{is_running, progress, last_result}`
-- `POST /api/metadata/migration/dry-run` → scans and converts *in memory*, writing
-  nothing to disk, so numbers are measured rather than estimated: legacy file count, group
+- `POST /api/metadata/migration/dry-run` → runs the real conversion against an
+  isolated temporary metadata root that is deleted afterwards, so nothing in the
+  library is touched and no refcounts move, so numbers are measured rather than estimated: legacy file count, group
   count, faithful-vs-synthesized split, current bytes, projected bytes, savings, and
   the files that would fail
 - `POST /api/metadata/migration/start`

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -16,6 +16,8 @@ import type {
 	ImportStatusResponse,
 	LibrarySyncStatus,
 	ManualScanRequest,
+	MetadataMigrationResult,
+	MetadataMigrationStatus,
 	NzbdavMigrateSymlinksRequest,
 	NzbdavMigrateSymlinksResponse,
 	PoolMetrics,
@@ -503,6 +505,28 @@ class APIClient {
 
 	async cancelLibrarySync() {
 		return this.request<{ message: string }>("/health/library-sync/cancel", {
+			method: "POST",
+		});
+	}
+
+	async getMetadataMigrationStatus() {
+		return this.request<MetadataMigrationStatus>("/metadata/migration/status");
+	}
+
+	async dryRunMetadataMigration() {
+		return this.request<MetadataMigrationResult>("/metadata/migration/dry-run", {
+			method: "POST",
+		});
+	}
+
+	async startMetadataMigration() {
+		return this.request<{ message: string }>("/metadata/migration/start", {
+			method: "POST",
+		});
+	}
+
+	async cancelMetadataMigration() {
+		return this.request<{ message: string }>("/metadata/migration/cancel", {
 			method: "POST",
 		});
 	}

--- a/frontend/src/components/config/MetadataConfigSection.tsx
+++ b/frontend/src/components/config/MetadataConfigSection.tsx
@@ -11,6 +11,7 @@ import {
 	type ScheduleType,
 } from "../../utils/cronSchedule";
 import { LoadingSpinner } from "../ui/LoadingSpinner";
+import { MetadataMigrationCard } from "./MetadataMigrationCard";
 
 interface MetadataConfigSectionProps {
 	config: ConfigResponse;
@@ -348,6 +349,8 @@ export function MetadataConfigSection({
 					</div>
 				</div>
 			</div>
+
+			<MetadataMigrationCard />
 
 			{/* Save Button */}
 			{!isReadOnly && (

--- a/frontend/src/components/config/MetadataMigrationCard.tsx
+++ b/frontend/src/components/config/MetadataMigrationCard.tsx
@@ -1,0 +1,216 @@
+import { AlertTriangle, Archive, CheckCircle, Play, Search, XCircle } from "lucide-react";
+import { useState } from "react";
+import {
+	useCancelMetadataMigration,
+	useDryRunMetadataMigration,
+	useMetadataMigrationStatus,
+	useStartMetadataMigration,
+} from "../../hooks/useMetadataMigration";
+import { LoadingSpinner } from "../ui/LoadingSpinner";
+
+function formatBytes(bytes: number): string {
+	if (bytes <= 0) return "0 B";
+	const units = ["B", "KB", "MB", "GB", "TB"];
+	const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+	return `${(bytes / 1024 ** exponent).toFixed(exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+}
+
+export function MetadataMigrationCard() {
+	const { data: status, isLoading } = useMetadataMigrationStatus();
+	const dryRun = useDryRunMetadataMigration();
+	const startMigration = useStartMetadataMigration();
+	const cancelMigration = useCancelMetadataMigration();
+	const [showConfirm, setShowConfirm] = useState(false);
+
+	const isRunning = status?.is_running ?? false;
+	const preview = status?.last_dry_run ?? dryRun.data;
+	const lastResult = status?.last_result;
+	const progress = status?.progress;
+	const percent =
+		progress && progress.total_files > 0
+			? Math.round((progress.processed_files / progress.total_files) * 100)
+			: 0;
+
+	const handleConfirmMigrate = async () => {
+		setShowConfirm(false);
+		await startMigration.mutateAsync();
+	};
+
+	return (
+		<div className="card bg-base-100 shadow-lg">
+			<div className="card-body">
+				<h2 className="card-title">
+					<Archive className="h-5 w-5" aria-hidden="true" />
+					Storage Migration
+				</h2>
+				<p className="text-base-content/70 text-sm">
+					Convert legacy metadata files to the shared NZB store format. Segments move out of each
+					<code className="mx-1">.meta</code> file into one compressed
+					<code className="mx-1">.nzbz</code> per release, reclaiming disk space.
+				</p>
+
+				{isLoading ? (
+					<div className="flex justify-center py-6">
+						<LoadingSpinner size="md" />
+					</div>
+				) : (
+					<>
+						{isRunning && progress && (
+							<div className="space-y-2 py-2">
+								<div className="flex justify-between text-sm">
+									<span>
+										Release {progress.processed_groups} of {progress.total_groups}
+									</span>
+									<span>
+										{progress.processed_files} / {progress.total_files} files
+									</span>
+								</div>
+								<progress className="progress progress-primary w-full" value={percent} max={100} />
+								{progress.current_release && (
+									<p className="truncate text-base-content/60 text-xs">
+										{progress.current_release}
+									</p>
+								)}
+							</div>
+						)}
+
+						{!isRunning && preview && preview.groups > 0 && (
+							<div className="overflow-x-auto py-2">
+								<table className="table-sm table">
+									<tbody>
+										<tr>
+											<td>Releases</td>
+											<td className="text-right font-mono">{preview.groups}</td>
+										</tr>
+										<tr>
+											<td>Files to convert</td>
+											<td className="text-right font-mono">{preview.files_migrated}</td>
+										</tr>
+										<tr>
+											<td>Current size</td>
+											<td className="text-right font-mono">{formatBytes(preview.bytes_before)}</td>
+										</tr>
+										<tr>
+											<td>Projected size</td>
+											<td className="text-right font-mono">{formatBytes(preview.bytes_after)}</td>
+										</tr>
+										<tr className="font-semibold">
+											<td>Reclaimed</td>
+											<td className="text-right font-mono text-success">
+												{formatBytes(preview.bytes_saved)}
+											</td>
+										</tr>
+										{preview.files_failed > 0 && (
+											<tr>
+												<td>Cannot convert</td>
+												<td className="text-right font-mono text-warning">
+													{preview.files_failed}
+												</td>
+											</tr>
+										)}
+									</tbody>
+								</table>
+							</div>
+						)}
+
+						{!isRunning && preview && preview.groups === 0 && (
+							<div className="alert alert-success">
+								<CheckCircle className="h-6 w-6" aria-hidden="true" />
+								<div>All metadata is already in the shared store format.</div>
+							</div>
+						)}
+
+						{lastResult && !isRunning && (
+							<div
+								className={`alert ${lastResult.files_failed > 0 ? "alert-warning" : "alert-success"}`}
+							>
+								{lastResult.files_failed > 0 ? (
+									<AlertTriangle className="h-6 w-6" aria-hidden="true" />
+								) : (
+									<CheckCircle className="h-6 w-6" aria-hidden="true" />
+								)}
+								<div>
+									<div className="font-bold">
+										{lastResult.cancelled ? "Migration cancelled" : "Migration complete"}
+									</div>
+									<div className="text-sm">
+										{lastResult.files_migrated} files migrated,{" "}
+										{formatBytes(lastResult.bytes_saved)} reclaimed
+										{lastResult.files_failed > 0 && `, ${lastResult.files_failed} skipped`}
+									</div>
+								</div>
+							</div>
+						)}
+
+						{dryRun.isError && (
+							<div className="alert alert-error">
+								<XCircle className="h-6 w-6" aria-hidden="true" />
+								<div>Dry run failed. Check the logs for details.</div>
+							</div>
+						)}
+
+						<div className="card-actions justify-end pt-2">
+							{isRunning ? (
+								<button
+									type="button"
+									className="btn btn-error btn-outline"
+									onClick={() => cancelMigration.mutate()}
+									disabled={cancelMigration.isPending}
+								>
+									<XCircle className="h-4 w-4" aria-hidden="true" />
+									Cancel
+								</button>
+							) : (
+								<>
+									<button
+										type="button"
+										className="btn btn-outline"
+										onClick={() => dryRun.mutate()}
+										disabled={dryRun.isPending}
+									>
+										{dryRun.isPending ? (
+											<LoadingSpinner size="sm" />
+										) : (
+											<Search className="h-4 w-4" aria-hidden="true" />
+										)}
+										{dryRun.isPending ? "Scanning..." : "Dry Run"}
+									</button>
+									<button
+										type="button"
+										className="btn btn-primary"
+										onClick={() => setShowConfirm(true)}
+										disabled={!preview || preview.groups === 0 || startMigration.isPending}
+									>
+										<Play className="h-4 w-4" aria-hidden="true" />
+										Migrate
+									</button>
+								</>
+							)}
+						</div>
+					</>
+				)}
+			</div>
+
+			{showConfirm && (
+				<dialog className="modal modal-open">
+					<div className="modal-box">
+						<h3 className="font-bold text-lg">Migrate metadata?</h3>
+						<p className="py-4">
+							This rewrites every legacy <code>.meta</code> file in place and moves its segments
+							into a shared <code>.nzbz</code> store per release. The change is one-way. Streaming
+							keeps working throughout, and you can cancel at any point.
+						</p>
+						<div className="modal-action">
+							<button type="button" className="btn" onClick={() => setShowConfirm(false)}>
+								Cancel
+							</button>
+							<button type="button" className="btn btn-primary" onClick={handleConfirmMigrate}>
+								Migrate
+							</button>
+						</div>
+					</div>
+				</dialog>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/components/config/MetadataMigrationCard.tsx
+++ b/frontend/src/components/config/MetadataMigrationCard.tsx
@@ -136,8 +136,23 @@ export function MetadataMigrationCard() {
 									<div className="text-sm">
 										{lastResult.files_migrated} files migrated,{" "}
 										{formatBytes(lastResult.bytes_saved)} reclaimed
-										{lastResult.files_failed > 0 && `, ${lastResult.files_failed} skipped`}
+										{lastResult.files_failed > 0 && `, ${lastResult.files_failed} left unchanged`}
 									</div>
+									{lastResult.failures && lastResult.failures.length > 0 && (
+										<details className="mt-2">
+											<summary className="cursor-pointer text-sm">
+												Show {lastResult.failures.length} file
+												{lastResult.failures.length === 1 ? "" : "s"} left in the old format
+											</summary>
+											<ul className="mt-2 max-h-48 space-y-1 overflow-y-auto font-mono text-xs">
+												{lastResult.failures.map((failure) => (
+													<li key={failure} className="break-all">
+														{failure}
+													</li>
+												))}
+											</ul>
+										</details>
+									)}
 								</div>
 							</div>
 						)}

--- a/frontend/src/hooks/useMetadataMigration.ts
+++ b/frontend/src/hooks/useMetadataMigration.ts
@@ -1,0 +1,65 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "../api/client";
+import type { MetadataMigrationResult, MetadataMigrationStatus } from "../types/api";
+
+const MIGRATION_KEY = ["metadata", "migration"];
+
+// Hook to poll migration status: fast while running, slow when idle.
+export function useMetadataMigrationStatus() {
+	return useQuery<MetadataMigrationStatus>({
+		queryKey: [...MIGRATION_KEY, "status"],
+		queryFn: () => apiClient.getMetadataMigrationStatus(),
+		retry: 3,
+		refetchInterval: (query) => {
+			if (query.state.error) return false;
+			if (!query.state.data) return 10000;
+			return query.state.data.is_running ? 2000 : 10000;
+		},
+		refetchIntervalInBackground: true,
+	});
+}
+
+// Hook to run a dry run. Resolves with the measured result.
+export function useDryRunMetadataMigration() {
+	const queryClient = useQueryClient();
+
+	return useMutation<MetadataMigrationResult>({
+		mutationFn: () => apiClient.dryRunMetadataMigration(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: MIGRATION_KEY });
+		},
+		onError: (error) => {
+			console.error("Metadata migration dry run failed:", error);
+		},
+	});
+}
+
+// Hook to start the migration.
+export function useStartMetadataMigration() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: () => apiClient.startMetadataMigration(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: MIGRATION_KEY });
+		},
+		onError: (error) => {
+			console.error("Failed to start metadata migration:", error);
+		},
+	});
+}
+
+// Hook to cancel an in-flight migration.
+export function useCancelMetadataMigration() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: () => apiClient.cancelMetadataMigration(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: MIGRATION_KEY });
+		},
+		onError: (error) => {
+			console.error("Failed to cancel metadata migration:", error);
+		},
+	});
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -365,6 +365,41 @@ export interface LibrarySyncStatus {
 	last_sync_result?: LibrarySyncResult;
 }
 
+// Metadata migration types (legacy inline-segment .meta → v3 shared NZB store)
+export interface MetadataMigrationProgress {
+	total_groups: number;
+	processed_groups: number;
+	total_files: number;
+	processed_files: number;
+	current_release: string;
+	start_time: string;
+}
+
+export interface MetadataMigrationResult {
+	dry_run: boolean;
+	groups: number;
+	faithful_groups: number;
+	synthesized_groups: number;
+	files_migrated: number;
+	files_failed: number;
+	bytes_before: number;
+	bytes_after: number;
+	bytes_saved: number;
+	failures?: string[];
+	cancelled: boolean;
+	duration: number;
+	completed_at: string;
+}
+
+export interface MetadataMigrationStatus {
+	is_running: boolean;
+	legacy_files: number;
+	legacy_groups: number;
+	progress?: MetadataMigrationProgress;
+	last_result?: MetadataMigrationResult;
+	last_dry_run?: MetadataMigrationResult;
+}
+
 // Pool Metrics types
 export interface ProviderStatus {
 	id: string;

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -71,6 +71,11 @@ export interface MetadataConfig {
 	root_path: string;
 	delete_source_nzb_on_removal?: boolean;
 	backup: MetadataBackupConfig;
+	migration?: MetadataMigrationConfig;
+}
+
+export interface MetadataMigrationConfig {
+	default_group: string;
 }
 
 export interface MetadataBackupConfig {

--- a/internal/api/metadata_migration_handlers.go
+++ b/internal/api/metadata_migration_handlers.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/javi11/altmount/internal/metadata"
+)
+
+// MetadataMigrationHandlers holds the legacy-metadata migration handlers.
+type MetadataMigrationHandlers struct {
+	worker *metadata.MigrationWorker
+}
+
+// NewMetadataMigrationHandlers creates a new instance of the migration handlers.
+func NewMetadataMigrationHandlers(worker *metadata.MigrationWorker) *MetadataMigrationHandlers {
+	return &MetadataMigrationHandlers{worker: worker}
+}
+
+// handleGetStatus handles GET /api/metadata/migration/status
+func (h *MetadataMigrationHandlers) handleGetStatus(c *fiber.Ctx) error {
+	return RespondSuccess(c, h.worker.GetStatus())
+}
+
+// handleDryRun handles POST /api/metadata/migration/dry-run
+func (h *MetadataMigrationHandlers) handleDryRun(c *fiber.Ctx) error {
+	result, err := h.worker.DryRun(c.Context())
+	if err != nil {
+		if errors.Is(err, metadata.ErrMigrationRunning) {
+			return RespondConflict(c, "Metadata migration already running", err.Error())
+		}
+		slog.ErrorContext(c.Context(), "Metadata migration dry run failed", "error", err)
+		return RespondInternalError(c, "Failed to perform migration dry run", err.Error())
+	}
+	return RespondSuccess(c, result)
+}
+
+// handleStart handles POST /api/metadata/migration/start
+func (h *MetadataMigrationHandlers) handleStart(c *fiber.Ctx) error {
+	if err := h.worker.Start(c.Context()); err != nil {
+		if errors.Is(err, metadata.ErrMigrationRunning) {
+			return RespondConflict(c, "Metadata migration already running", err.Error())
+		}
+		slog.ErrorContext(c.Context(), "Failed to start metadata migration", "error", err)
+		return RespondInternalError(c, "Failed to start metadata migration", err.Error())
+	}
+	return RespondMessage(c, "Metadata migration started")
+}
+
+// handleCancel handles POST /api/metadata/migration/cancel
+func (h *MetadataMigrationHandlers) handleCancel(c *fiber.Ctx) error {
+	h.worker.Cancel()
+	return RespondMessage(c, "Metadata migration cancelled")
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -43,30 +43,32 @@ func DefaultConfig() *Config {
 
 // Server represents the API server
 type Server struct {
-	config              *Config
-	queueRepo           *database.Repository
-	healthRepo          *database.HealthRepository
-	authService         *auth.Service
-	userRepo            *database.UserRepository
-	configManager       ConfigManager
-	metadataReader      *metadata.MetadataReader
-	metadataService     *metadata.MetadataService
-	nzbFilesystem       *nzbfilesystem.NzbFilesystem
-	healthWorker        *health.HealthWorker
-	librarySyncWorker   *health.LibrarySyncWorker
-	importerService     *importer.Service
-	poolManager         pool.Manager
-	arrsService         *arrs.Service
-	mountService        *rclone.MountService
-	startTime           time.Time
-	progressBroadcaster *progress.ProgressBroadcaster
-	streamTracker       *StreamTracker
-	fuseManager         *FuseManager
-	cacheSource         *segcache.Source
-	logFilePath         string
-	migrationRepo       *database.ImportMigrationRepository
-	updater             updater.Updater
-	ready               atomic.Bool
+	config            *Config
+	queueRepo         *database.Repository
+	healthRepo        *database.HealthRepository
+	authService       *auth.Service
+	userRepo          *database.UserRepository
+	configManager     ConfigManager
+	metadataReader    *metadata.MetadataReader
+	metadataService   *metadata.MetadataService
+	nzbFilesystem     *nzbfilesystem.NzbFilesystem
+	healthWorker      *health.HealthWorker
+	librarySyncWorker *health.LibrarySyncWorker
+
+	metadataMigrationWorker *metadata.MigrationWorker
+	importerService         *importer.Service
+	poolManager             pool.Manager
+	arrsService             *arrs.Service
+	mountService            *rclone.MountService
+	startTime               time.Time
+	progressBroadcaster     *progress.ProgressBroadcaster
+	streamTracker           *StreamTracker
+	fuseManager             *FuseManager
+	cacheSource             *segcache.Source
+	logFilePath             string
+	migrationRepo           *database.ImportMigrationRepository
+	updater                 updater.Updater
+	ready                   atomic.Bool
 
 	speedtest     *speedtestCoordinator
 	speedtestOnce sync.Once
@@ -144,6 +146,11 @@ func (s *Server) SetHealthWorker(healthWorker *health.HealthWorker) {
 // SetLibrarySyncWorker sets the library sync worker reference for the server
 func (s *Server) SetLibrarySyncWorker(librarySyncWorker *health.LibrarySyncWorker) {
 	s.librarySyncWorker = librarySyncWorker
+}
+
+// SetMetadataMigrationWorker sets the metadata migration worker for the server.
+func (s *Server) SetMetadataMigrationWorker(worker *metadata.MigrationWorker) {
+	s.metadataMigrationWorker = worker
 }
 
 // SetLogFilePath sets the path to the JSON log file used by the logs endpoints.
@@ -294,6 +301,11 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	api.Post("/health/library-sync/start", s.handleStartLibrarySync)
 	api.Post("/health/library-sync/cancel", s.handleCancelLibrarySync)
 	api.Post("/health/library-sync/dry-run", s.handleDryRunLibrarySync)
+
+	api.Get("/metadata/migration/status", s.handleGetMetadataMigrationStatus)
+	api.Post("/metadata/migration/dry-run", s.handleDryRunMetadataMigration)
+	api.Post("/metadata/migration/start", s.handleStartMetadataMigration)
+	api.Post("/metadata/migration/cancel", s.handleCancelMetadataMigration)
 
 	api.Get("/files/info", s.handleGetFileMetadata)
 	api.Get("/files/active-streams", s.handleGetActiveStreams)
@@ -647,4 +659,76 @@ func (s *Server) handleGetStreamHistory(c *fiber.Ctx) error {
 		"success": true,
 		"data":    s.streamTracker.GetHistory(),
 	})
+}
+
+// Metadata migration handler methods
+
+// handleGetMetadataMigrationStatus handles GET /api/metadata/migration/status
+//
+//	@Summary		Get metadata migration status
+//	@Description	Returns the status of the legacy metadata → v3 migration worker.
+//	@Tags			Metadata
+//	@Produce		json
+//	@Success		200	{object}	APIResponse
+//	@Failure		503	{object}	APIResponse
+//	@Security		BearerAuth
+//	@Router			/metadata/migration/status [get]
+func (s *Server) handleGetMetadataMigrationStatus(c *fiber.Ctx) error {
+	if s.metadataMigrationWorker == nil {
+		return RespondServiceUnavailable(c, "Metadata migration worker not available", "")
+	}
+	return NewMetadataMigrationHandlers(s.metadataMigrationWorker).handleGetStatus(c)
+}
+
+// handleDryRunMetadataMigration handles POST /api/metadata/migration/dry-run
+//
+//	@Summary		Dry-run the metadata migration
+//	@Description	Converts against an isolated temporary root and reports measured savings without touching the library.
+//	@Tags			Metadata
+//	@Produce		json
+//	@Success		200	{object}	APIResponse
+//	@Failure		409	{object}	APIResponse
+//	@Failure		503	{object}	APIResponse
+//	@Security		BearerAuth
+//	@Router			/metadata/migration/dry-run [post]
+func (s *Server) handleDryRunMetadataMigration(c *fiber.Ctx) error {
+	if s.metadataMigrationWorker == nil {
+		return RespondServiceUnavailable(c, "Metadata migration worker not available", "")
+	}
+	return NewMetadataMigrationHandlers(s.metadataMigrationWorker).handleDryRun(c)
+}
+
+// handleStartMetadataMigration handles POST /api/metadata/migration/start
+//
+//	@Summary		Start the metadata migration
+//	@Description	Rewrites legacy .meta files to the v3 store-backed format in place.
+//	@Tags			Metadata
+//	@Produce		json
+//	@Success		200	{object}	APIResponse
+//	@Failure		409	{object}	APIResponse
+//	@Failure		503	{object}	APIResponse
+//	@Security		BearerAuth
+//	@Router			/metadata/migration/start [post]
+func (s *Server) handleStartMetadataMigration(c *fiber.Ctx) error {
+	if s.metadataMigrationWorker == nil {
+		return RespondServiceUnavailable(c, "Metadata migration worker not available", "")
+	}
+	return NewMetadataMigrationHandlers(s.metadataMigrationWorker).handleStart(c)
+}
+
+// handleCancelMetadataMigration handles POST /api/metadata/migration/cancel
+//
+//	@Summary		Cancel the metadata migration
+//	@Description	Stops an in-flight migration after the current file.
+//	@Tags			Metadata
+//	@Produce		json
+//	@Success		200	{object}	APIResponse
+//	@Failure		503	{object}	APIResponse
+//	@Security		BearerAuth
+//	@Router			/metadata/migration/cancel [post]
+func (s *Server) handleCancelMetadataMigration(c *fiber.Ctx) error {
+	if s.metadataMigrationWorker == nil {
+		return RespondServiceUnavailable(c, "Metadata migration worker not available", "")
+	}
+	return NewMetadataMigrationHandlers(s.metadataMigrationWorker).handleCancel(c)
 }

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -324,9 +324,18 @@ type DatabaseConfig struct {
 
 // MetadataConfig represents metadata filesystem configuration
 type MetadataConfig struct {
-	RootPath                 string               `yaml:"root_path" mapstructure:"root_path" json:"root_path"`
-	DeleteSourceNzbOnRemoval *bool                `yaml:"delete_source_nzb_on_removal" mapstructure:"delete_source_nzb_on_removal" json:"delete_source_nzb_on_removal,omitempty"`
-	Backup                   MetadataBackupConfig `yaml:"backup" mapstructure:"backup" json:"backup"`
+	RootPath                 string                  `yaml:"root_path" mapstructure:"root_path" json:"root_path"`
+	DeleteSourceNzbOnRemoval *bool                   `yaml:"delete_source_nzb_on_removal" mapstructure:"delete_source_nzb_on_removal" json:"delete_source_nzb_on_removal,omitempty"`
+	Backup                   MetadataBackupConfig    `yaml:"backup" mapstructure:"backup" json:"backup"`
+	Migration                MetadataMigrationConfig `yaml:"migration" mapstructure:"migration" json:"migration"`
+}
+
+// MetadataMigrationConfig configures the legacy-metadata → v3 migration.
+type MetadataMigrationConfig struct {
+	// DefaultGroup is the newsgroup written into synthesized NzbStore entries.
+	// Legacy metas do not retain the original groups, and nzb.BuildNZB renders an
+	// empty <groups> element without this, which most NZB clients reject.
+	DefaultGroup string `yaml:"default_group" mapstructure:"default_group" json:"default_group"`
 }
 
 // ShouldDeleteSourceNzb returns whether source NZB files should be deleted on removal.
@@ -1688,6 +1697,9 @@ func DefaultConfig(configDir ...string) *Config {
 				Schedule:    "0 3 * * *", // daily at 3 AM UTC
 				KeepBackups: 10,
 				Path:        backupPath,
+			},
+			Migration: MetadataMigrationConfig{
+				DefaultGroup: "alt.binaries.misc",
 			},
 		},
 		Streaming: StreamingConfig{

--- a/internal/config/metadata_migration_test.go
+++ b/internal/config/metadata_migration_test.go
@@ -1,0 +1,10 @@
+package config
+
+import "testing"
+
+func TestDefaultConfig_MetadataMigrationDefaultGroup(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Metadata.Migration.DefaultGroup != "alt.binaries.misc" {
+		t.Fatalf("expected default group alt.binaries.misc, got %q", cfg.Metadata.Migration.DefaultGroup)
+	}
+}

--- a/internal/importer/parser/parser.go
+++ b/internal/importer/parser/parser.go
@@ -25,6 +25,7 @@ import (
 	"github.com/javi11/altmount/internal/importer/parser/par2"
 	"github.com/javi11/altmount/internal/importer/rarname"
 	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
+	"github.com/javi11/altmount/internal/metadata"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/pool"
 	"github.com/javi11/altmount/internal/progress"
@@ -135,7 +136,7 @@ func (p *Parser) ParseNzb(ctx context.Context, n *nzbparser.Nzb, nzbPath string,
 	// Build the shared NzbStore and segment index for v3 format.
 	// Must be built from the raw *nzbparser.Nzb BEFORE any per-file processing
 	// (which may filter/reorder files). The index maps message-id → flat store index.
-	parsed.Store, parsed.SegmentIndex = BuildStore(n)
+	parsed.Store, parsed.SegmentIndex = metadata.BuildStore(n)
 
 	// Determine segment size from meta chunk_size or fallback to first segment size
 	if n.Meta != nil {
@@ -1474,37 +1475,6 @@ func (p *Parser) propagateArchiveType(parsed *ParsedNzb) {
 			}
 		}
 	}
-}
-
-// BuildStore converts a parsed NZB into a NzbStore (for persistence) plus a
-// message-id → flat-store-index lookup used to emit SegmentRefs.
-// Segments are stored in their natural NzbSegments order (by Number after sort).
-func BuildStore(n *nzbparser.Nzb) (*metapb.NzbStore, map[string]int64) {
-	store := &metapb.NzbStore{Files: make([]*metapb.NzbFileEntry, 0, len(n.Files))}
-	index := make(map[string]int64)
-	var flat int64
-	for _, f := range n.Files {
-		fe := &metapb.NzbFileEntry{
-			Subject: f.Subject,
-			Poster:  f.Poster,
-			Date:    int64(f.Date),
-			Groups:  f.Groups,
-		}
-		segs := make(nzbparser.NzbSegments, len(f.Segments))
-		copy(segs, f.Segments)
-		sort.Sort(segs)
-		for _, s := range segs {
-			fe.Segments = append(fe.Segments, &metapb.NzbSeg{
-				Id:     s.ID,
-				Number: int32(s.Number),
-				Bytes:  int64(s.Bytes),
-			})
-			index[s.ID] = flat
-			flat++
-		}
-		store.Files = append(store.Files, fe)
-	}
-	return store, index
 }
 
 // GetMetadata extracts metadata from the NZB head section

--- a/internal/metadata/build_store.go
+++ b/internal/metadata/build_store.go
@@ -1,0 +1,39 @@
+package metadata
+
+import (
+	"sort"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/javi11/nzbparser"
+)
+
+// BuildStore converts a parsed NZB into a NzbStore (for persistence) plus a
+// message-id → flat-store-index lookup used to emit SegmentRefs.
+// Segments are stored in their natural NzbSegments order (by Number after sort).
+func BuildStore(n *nzbparser.Nzb) (*metapb.NzbStore, map[string]int64) {
+	store := &metapb.NzbStore{Files: make([]*metapb.NzbFileEntry, 0, len(n.Files))}
+	index := make(map[string]int64)
+	var flat int64
+	for _, f := range n.Files {
+		fe := &metapb.NzbFileEntry{
+			Subject: f.Subject,
+			Poster:  f.Poster,
+			Date:    int64(f.Date),
+			Groups:  f.Groups,
+		}
+		segs := make(nzbparser.NzbSegments, len(f.Segments))
+		copy(segs, f.Segments)
+		sort.Sort(segs)
+		for _, s := range segs {
+			fe.Segments = append(fe.Segments, &metapb.NzbSeg{
+				Id:     s.ID,
+				Number: int32(s.Number),
+				Bytes:  int64(s.Bytes),
+			})
+			index[s.ID] = flat
+			flat++
+		}
+		store.Files = append(store.Files, fe)
+	}
+	return store, index
+}

--- a/internal/metadata/build_store_test.go
+++ b/internal/metadata/build_store_test.go
@@ -1,4 +1,4 @@
-package parser
+package metadata
 
 import (
 	"sort"
@@ -18,7 +18,6 @@ func TestBuildStore(t *testing.T) {
 				Segments: nzbparser.NzbSegments{{ID: "p1@x", Number: 1, Bytes: 4096}}},
 		},
 	}
-	// Sort segments as the parser would
 	for i := range nzb.Files {
 		sort.Sort(nzb.Files[i].Segments)
 	}
@@ -34,7 +33,6 @@ func TestBuildStore(t *testing.T) {
 	assert.Equal(t, "m1@x", store.Files[0].Segments[0].Id)
 	assert.EqualValues(t, 700000, store.Files[0].Segments[0].Bytes)
 
-	// Flat index: file0 seg0=0, file0 seg1=1, file1 seg0=2
 	assert.EqualValues(t, 0, index["m1@x"])
 	assert.EqualValues(t, 1, index["m2@x"])
 	assert.EqualValues(t, 2, index["p1@x"])

--- a/internal/metadata/migration.go
+++ b/internal/metadata/migration.go
@@ -1,0 +1,329 @@
+package metadata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+)
+
+// defaultMigrationGroup is used when the config leaves default_group empty.
+// Without a group, nzb.BuildNZB emits an empty <groups> element and most NZB
+// clients reject the result.
+const defaultMigrationGroup = "alt.binaries.misc"
+
+// migrationGroupPause paces the worker so a large library does not saturate
+// disk while streams are being served.
+const migrationGroupPause = 100 * time.Millisecond
+
+// ErrMigrationRunning is returned when a second run is requested.
+var ErrMigrationRunning = errors.New("metadata migration already running")
+
+// MigrationProgress is the live progress of a run.
+type MigrationProgress struct {
+	TotalGroups     int       `json:"total_groups"`
+	ProcessedGroups int       `json:"processed_groups"`
+	TotalFiles      int       `json:"total_files"`
+	ProcessedFiles  int       `json:"processed_files"`
+	CurrentRelease  string    `json:"current_release"`
+	StartTime       time.Time `json:"start_time"`
+}
+
+// MigrationResult summarises a completed run (real or dry).
+type MigrationResult struct {
+	DryRun            bool          `json:"dry_run"`
+	Groups            int           `json:"groups"`
+	FaithfulGroups    int           `json:"faithful_groups"`
+	SynthesizedGroups int           `json:"synthesized_groups"`
+	FilesMigrated     int           `json:"files_migrated"`
+	FilesFailed       int           `json:"files_failed"`
+	BytesBefore       int64         `json:"bytes_before"`
+	BytesAfter        int64         `json:"bytes_after"`
+	BytesSaved        int64         `json:"bytes_saved"`
+	Failures          []string      `json:"failures,omitempty"`
+	Cancelled         bool          `json:"cancelled"`
+	Duration          time.Duration `json:"duration"`
+	CompletedAt       time.Time     `json:"completed_at"`
+}
+
+// MigrationStatus is what the API reports.
+type MigrationStatus struct {
+	IsRunning    bool               `json:"is_running"`
+	LegacyFiles  int                `json:"legacy_files"`
+	LegacyGroups int                `json:"legacy_groups"`
+	Progress     *MigrationProgress `json:"progress,omitempty"`
+	LastResult   *MigrationResult   `json:"last_result,omitempty"`
+	LastDryRun   *MigrationResult   `json:"last_dry_run,omitempty"`
+}
+
+// MigrationWorker converts legacy inline-segment metadata to the v3
+// store-backed format. It is manually triggered; nothing runs on startup.
+type MigrationWorker struct {
+	ms           *MetadataService
+	configGetter config.ConfigGetter
+
+	mu         sync.Mutex
+	running    bool
+	cancelFunc context.CancelFunc
+
+	progressMu sync.RWMutex
+	progress   *MigrationProgress
+	lastResult *MigrationResult
+	lastDryRun *MigrationResult
+}
+
+// NewMigrationWorker creates a migration worker. It does not start anything.
+func NewMigrationWorker(ms *MetadataService, configGetter config.ConfigGetter) *MigrationWorker {
+	return &MigrationWorker{ms: ms, configGetter: configGetter}
+}
+
+// GetStatus reports whether a run is active, its progress, and the last results.
+// The legacy counts come from the live progress when running and are otherwise
+// left at zero; callers wanting a fresh count run a dry run.
+func (w *MigrationWorker) GetStatus() MigrationStatus {
+	w.mu.Lock()
+	running := w.running
+	w.mu.Unlock()
+
+	w.progressMu.RLock()
+	defer w.progressMu.RUnlock()
+
+	status := MigrationStatus{
+		IsRunning:  running,
+		LastResult: w.lastResult,
+		LastDryRun: w.lastDryRun,
+	}
+	if w.progress != nil {
+		p := *w.progress
+		status.Progress = &p
+		status.LegacyFiles = p.TotalFiles
+		status.LegacyGroups = p.TotalGroups
+	}
+	return status
+}
+
+// Cancel stops an in-flight run after the current file.
+func (w *MigrationWorker) Cancel() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.cancelFunc != nil {
+		w.cancelFunc()
+	}
+}
+
+// Start launches a migration in the background and returns immediately.
+// The run is detached from the caller's context so cancelling an HTTP request
+// does not abort a migration; use Cancel for that.
+func (w *MigrationWorker) Start(ctx context.Context) error {
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return ErrMigrationRunning
+	}
+	runCtx, cancel := context.WithCancel(context.Background())
+	w.running = true
+	w.cancelFunc = cancel
+	w.mu.Unlock()
+
+	slog.InfoContext(ctx, "Starting metadata migration to v3 store format")
+
+	go func() {
+		defer func() {
+			w.mu.Lock()
+			w.running = false
+			w.cancelFunc = nil
+			w.mu.Unlock()
+			cancel()
+		}()
+
+		result, err := w.run(runCtx, false)
+		if err != nil {
+			slog.ErrorContext(runCtx, "Metadata migration failed", "error", err)
+			return
+		}
+		w.progressMu.Lock()
+		w.lastResult = result
+		w.progressMu.Unlock()
+		slog.InfoContext(runCtx, "Metadata migration finished",
+			"files_migrated", result.FilesMigrated,
+			"files_failed", result.FilesFailed,
+			"bytes_saved", result.BytesSaved,
+			"cancelled", result.Cancelled)
+	}()
+	return nil
+}
+
+// DryRun performs the real conversion against an isolated temporary metadata
+// root, measures the result, and deletes it. Nothing in the library is touched
+// and no store reference counts move (the temporary service has no counter).
+func (w *MigrationWorker) DryRun(ctx context.Context) (*MigrationResult, error) {
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return nil, ErrMigrationRunning
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	w.running = true
+	w.cancelFunc = cancel
+	w.mu.Unlock()
+
+	defer func() {
+		w.mu.Lock()
+		w.running = false
+		w.cancelFunc = nil
+		w.mu.Unlock()
+		cancel()
+	}()
+
+	result, err := w.run(runCtx, true)
+	if err != nil {
+		return nil, err
+	}
+	w.progressMu.Lock()
+	w.lastDryRun = result
+	w.progressMu.Unlock()
+	return result, nil
+}
+
+// run is the shared body of Start and DryRun.
+func (w *MigrationWorker) run(ctx context.Context, dryRun bool) (*MigrationResult, error) {
+	started := time.Now()
+
+	groups, err := w.ms.ScanLegacyMetas()
+	if err != nil {
+		return nil, fmt.Errorf("scan legacy metadata: %w", err)
+	}
+
+	totalFiles := 0
+	for _, g := range groups {
+		totalFiles += len(g.Files)
+	}
+	w.setProgress(&MigrationProgress{
+		TotalGroups: len(groups),
+		TotalFiles:  totalFiles,
+		StartTime:   started,
+	})
+
+	target := w.ms
+	storeDir := w.storeDir()
+	if dryRun {
+		tmpRoot, tmpErr := os.MkdirTemp("", "altmount-migration-dryrun-")
+		if tmpErr != nil {
+			return nil, fmt.Errorf("create dry-run temp root: %w", tmpErr)
+		}
+		defer func() { _ = os.RemoveAll(tmpRoot) }()
+		target = NewMetadataService(filepath.Join(tmpRoot, "meta"))
+		storeDir = filepath.Join(tmpRoot, "store")
+	}
+
+	result := &MigrationResult{DryRun: dryRun, Groups: len(groups)}
+	defaultGroup := w.defaultGroup()
+
+	for _, g := range groups {
+		if ctx.Err() != nil {
+			result.Cancelled = true
+			break
+		}
+		w.updateProgressGroup(g.Key)
+
+		// A dry run converts into a throwaway root, so it must hydrate the
+		// group from the real service: the temporary one has no .meta files.
+		hydrated := g
+		if dryRun {
+			loaded, loadErr := w.ms.LoadGroupMetas(g)
+			if loadErr != nil {
+				result.Failures = append(result.Failures, fmt.Sprintf("%s: %v", g.Key, loadErr))
+				continue
+			}
+			hydrated = loaded
+		}
+
+		gr, groupErr := target.MigrateGroup(ctx, hydrated, storeDir, defaultGroup)
+		if groupErr != nil {
+			if ctx.Err() != nil {
+				result.Cancelled = true
+				break
+			}
+			result.FilesFailed += len(g.Files)
+			result.Failures = append(result.Failures, fmt.Sprintf("%s: %v", g.Key, groupErr))
+			slog.WarnContext(ctx, "Skipping release group that failed to migrate",
+				"group", g.Key, "error", groupErr)
+			continue
+		}
+
+		if gr.Faithful {
+			result.FaithfulGroups++
+		} else {
+			result.SynthesizedGroups++
+		}
+		result.FilesMigrated += gr.FilesMigrated
+		result.FilesFailed += gr.FilesFailed
+		result.BytesBefore += gr.BytesBefore
+		result.BytesAfter += gr.BytesAfter
+		result.Failures = append(result.Failures, gr.Failures...)
+
+		w.advanceProgress(len(g.Files))
+		if !dryRun {
+			select {
+			case <-ctx.Done():
+				result.Cancelled = true
+			case <-time.After(migrationGroupPause):
+			}
+		}
+	}
+
+	result.BytesSaved = result.BytesBefore - result.BytesAfter
+	result.Duration = time.Since(started)
+	result.CompletedAt = time.Now()
+	w.setProgress(nil)
+	return result, nil
+}
+
+// storeDir is where migrated .nzbz files live: <configDir>/.nzbs/_migrated,
+// mirroring the importer's layout.
+func (w *MigrationWorker) storeDir() string {
+	cfg := w.configGetter()
+	configDir := filepath.Dir(cfg.Database.Path)
+	if !filepath.IsAbs(configDir) {
+		if abs, err := filepath.Abs(configDir); err == nil {
+			configDir = abs
+		}
+	}
+	return filepath.Join(configDir, ".nzbs", "_migrated")
+}
+
+func (w *MigrationWorker) defaultGroup() string {
+	if g := w.configGetter().Metadata.Migration.DefaultGroup; g != "" {
+		return g
+	}
+	return defaultMigrationGroup
+}
+
+func (w *MigrationWorker) setProgress(p *MigrationProgress) {
+	w.progressMu.Lock()
+	defer w.progressMu.Unlock()
+	w.progress = p
+}
+
+func (w *MigrationWorker) updateProgressGroup(key string) {
+	w.progressMu.Lock()
+	defer w.progressMu.Unlock()
+	if w.progress != nil {
+		w.progress.CurrentRelease = key
+	}
+}
+
+func (w *MigrationWorker) advanceProgress(files int) {
+	w.progressMu.Lock()
+	defer w.progressMu.Unlock()
+	if w.progress != nil {
+		w.progress.ProcessedGroups++
+		w.progress.ProcessedFiles += files
+	}
+}

--- a/internal/metadata/migration_convert.go
+++ b/internal/metadata/migration_convert.go
@@ -64,7 +64,9 @@ func (ms *MetadataService) MigrateGroup(ctx context.Context, g LegacyGroup, stor
 	if err := ms.store.WriteStore(storeRef, store); err != nil {
 		return res, fmt.Errorf("write store %q: %w", storeRef, err)
 	}
-	if _, err := ms.store.ReadStore(storeRef); err != nil {
+	// Read back from disk, bypassing the cache WriteStore just populated, so
+	// this proves the bytes really landed and decompress.
+	if _, err := ms.store.ReadStoreUncached(storeRef); err != nil {
 		_ = os.Remove(storeRef)
 		return res, fmt.Errorf("store integrity check failed for %q: %w", storeRef, err)
 	}

--- a/internal/metadata/migration_convert.go
+++ b/internal/metadata/migration_convert.go
@@ -74,6 +74,18 @@ func (ms *MetadataService) MigrateGroup(ctx context.Context, g LegacyGroup, stor
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return res, ctxErr
 		}
+
+		// Keep the exact legacy bytes so a file that fails conversion or
+		// verification can be put back precisely as it was.
+		originalBytes, readErr := os.ReadFile(lm.MetaPath)
+		if readErr != nil {
+			res.FilesFailed++
+			res.Failures = append(res.Failures, fmt.Sprintf("%s: read original: %v", lm.VirtualPath, readErr))
+			slog.WarnContext(ctx, "Failed to read legacy metadata before migrating; skipping file",
+				"virtual_path", lm.VirtualPath, "error", readErr)
+			continue
+		}
+
 		if err := ms.WriteFileMetadataV3(ctx, lm.VirtualPath, lm.Meta, index, storeRef); err != nil {
 			res.FilesFailed++
 			res.Failures = append(res.Failures, fmt.Sprintf("%s: %v", lm.VirtualPath, err))
@@ -81,6 +93,28 @@ func (ms *MetadataService) MigrateGroup(ctx context.Context, g LegacyGroup, stor
 				"virtual_path", lm.VirtualPath, "error", err)
 			continue
 		}
+
+		// Prove this specific file still resolves to exactly the segments it
+		// had before, and undo it if not. This is what makes the migration
+		// trustworthy on metadata shapes no test anticipated.
+		if verifyErr := verifyMigratedFile(ms, lm.VirtualPath, lm.Meta); verifyErr != nil {
+			res.FilesFailed++
+			res.Failures = append(res.Failures,
+				fmt.Sprintf("%s: verification failed, restored legacy metadata: %v", lm.VirtualPath, verifyErr))
+			slog.ErrorContext(ctx, "Migrated metadata did not verify; restoring the legacy file",
+				"virtual_path", lm.VirtualPath, "error", verifyErr)
+			if restoreErr := restoreLegacyMeta(lm.MetaPath, originalBytes); restoreErr != nil {
+				slog.ErrorContext(ctx, "Failed to restore legacy metadata after a failed verification",
+					"virtual_path", lm.VirtualPath, "error", restoreErr)
+				res.Failures = append(res.Failures,
+					fmt.Sprintf("%s: RESTORE FAILED: %v", lm.VirtualPath, restoreErr))
+			}
+			// The failed v3 write already refreshed the lite cache; drop that
+			// entry so readers see the restored legacy file.
+			ms.liteCache.Remove(lm.VirtualPath)
+			continue
+		}
+
 		res.FilesMigrated++
 		if info, statErr := os.Stat(lm.MetaPath); statErr == nil {
 			res.BytesAfter += info.Size()

--- a/internal/metadata/migration_convert.go
+++ b/internal/metadata/migration_convert.go
@@ -1,0 +1,103 @@
+package metadata
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+// GroupResult reports what happened to one release group.
+type GroupResult struct {
+	Key           string   `json:"key"`
+	StoreRef      string   `json:"store_ref"`
+	Faithful      bool     `json:"faithful"`
+	FilesMigrated int      `json:"files_migrated"`
+	FilesFailed   int      `json:"files_failed"`
+	BytesBefore   int64    `json:"bytes_before"`
+	BytesAfter    int64    `json:"bytes_after"`
+	Failures      []string `json:"failures,omitempty"`
+}
+
+// MigrateGroup converts one release group to the v3 store-backed format.
+//
+// Ordering is load-bearing: the .nzbz is written and read back before any meta
+// is repointed at it, so a meta never names a store that is missing or corrupt.
+// Each meta is then rewritten atomically by WriteFileMetadataV3, which also
+// increments the store's reference count exactly once, leaving the count equal
+// to the number of migrated metas.
+//
+// A per-file failure leaves that file as v1 and is recorded; the rest of the
+// group still migrates. If every file fails, the freshly written store is
+// removed so no orphan is left behind.
+//
+// The group's metas are loaded here rather than at scan time: legacy metas
+// carry their segments inline, so hydrating the whole library at once is the
+// allocation pattern documented at service.go:405.
+func (ms *MetadataService) MigrateGroup(ctx context.Context, g LegacyGroup, storeDir, defaultGroup string) (GroupResult, error) {
+	res := GroupResult{Key: g.Key}
+	for _, lm := range g.Files {
+		res.BytesBefore += lm.SizeBytes
+	}
+
+	// Hydrate this group's metas now and let them fall out of scope when the
+	// call returns, so peak memory is one release rather than the whole library.
+	// A group hydrated by the caller (tests, or a re-used group) is left alone.
+	if len(g.Files) > 0 && g.Files[0].Meta == nil {
+		loaded, err := ms.LoadGroupMetas(g)
+		if err != nil {
+			return res, err
+		}
+		g = loaded
+	}
+
+	store, index, faithful, err := buildGroupStore(g, defaultGroup)
+	if err != nil {
+		return res, fmt.Errorf("build store for %q: %w", g.Key, err)
+	}
+	res.Faithful = faithful
+
+	if err := os.MkdirAll(storeDir, 0755); err != nil {
+		return res, fmt.Errorf("create store dir %q: %w", storeDir, err)
+	}
+	storeRef := storeHashPath(storeDir, g.Key, store)
+	if err := ms.store.WriteStore(storeRef, store); err != nil {
+		return res, fmt.Errorf("write store %q: %w", storeRef, err)
+	}
+	if _, err := ms.store.ReadStore(storeRef); err != nil {
+		_ = os.Remove(storeRef)
+		return res, fmt.Errorf("store integrity check failed for %q: %w", storeRef, err)
+	}
+	res.StoreRef = storeRef
+
+	for _, lm := range g.Files {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return res, ctxErr
+		}
+		if err := ms.WriteFileMetadataV3(ctx, lm.VirtualPath, lm.Meta, index, storeRef); err != nil {
+			res.FilesFailed++
+			res.Failures = append(res.Failures, fmt.Sprintf("%s: %v", lm.VirtualPath, err))
+			slog.WarnContext(ctx, "Failed to migrate metadata file; leaving it in the legacy format",
+				"virtual_path", lm.VirtualPath, "error", err)
+			continue
+		}
+		res.FilesMigrated++
+		if info, statErr := os.Stat(lm.MetaPath); statErr == nil {
+			res.BytesAfter += info.Size()
+		}
+	}
+
+	if res.FilesMigrated == 0 {
+		if removeErr := os.Remove(storeRef); removeErr != nil && !os.IsNotExist(removeErr) {
+			slog.WarnContext(ctx, "Failed to remove orphaned store after a fully failed group",
+				"store_ref", storeRef, "error", removeErr)
+		}
+		res.StoreRef = ""
+		return res, nil
+	}
+
+	if info, statErr := os.Stat(storeRef); statErr == nil {
+		res.BytesAfter += info.Size()
+	}
+	return res, nil
+}

--- a/internal/metadata/migration_convert_test.go
+++ b/internal/metadata/migration_convert_test.go
@@ -1,0 +1,251 @@
+package metadata
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// readResolved returns the SegmentData a consumer would see for a virtual path.
+func readResolved(t *testing.T, ms *MetadataService, virtualPath string) *metapb.FileMetadata {
+	t.Helper()
+	got, err := ms.ReadFileMetadata(virtualPath)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	return got
+}
+
+func TestMigrateGroup_PreservesResolvedSegments(t *testing.T) {
+	root := t.TempDir()
+	storeDir := t.TempDir()
+	ms := NewMetadataService(root)
+
+	pathA := filepath.Join("movies", "A.mkv")
+	pathB := filepath.Join("movies", "B.mkv")
+	metaA := &metapb.FileMetadata{
+		FileSize:      300,
+		Status:        metapb.FileStatus_FILE_STATUS_HEALTHY,
+		SourceNzbPath: "/nzbs/rel.nzb",
+		CreatedAt:     10,
+		ModifiedAt:    20,
+		ReleaseDate:   30,
+		KnownHoles:    []*metapb.HoleRun{{StartSegment: 1, Count: 1}},
+		SegmentData: []*metapb.SegmentData{
+			{Id: "s1@n", SegmentSize: 100, StartOffset: 0, EndOffset: 99},
+			{Id: "s2@n", SegmentSize: 100, StartOffset: 0, EndOffset: 99},
+			{Id: "s3@n", SegmentSize: 100, StartOffset: 0, EndOffset: 99},
+		},
+		Par2Files: []*metapb.Par2FileReference{
+			{Filename: "rel.par2", FileSize: 50, SegmentData: []*metapb.SegmentData{
+				{Id: "p1@n", SegmentSize: 50, StartOffset: 0, EndOffset: 49},
+			}},
+		},
+	}
+	metaB := &metapb.FileMetadata{
+		FileSize:      120,
+		Status:        metapb.FileStatus_FILE_STATUS_HEALTHY,
+		SourceNzbPath: "/nzbs/rel.nzb",
+		SegmentData: []*metapb.SegmentData{
+			{Id: "s2@n", SegmentSize: 100, StartOffset: 40, EndOffset: 99},
+			{Id: "s3@n", SegmentSize: 100, StartOffset: 0, EndOffset: 59},
+		},
+	}
+	require.NoError(t, ms.WriteFileMetadata(pathA, metaA))
+	require.NoError(t, ms.WriteFileMetadata(pathB, metaB))
+
+	beforeA := proto.Clone(readResolved(t, ms, pathA)).(*metapb.FileMetadata)
+	beforeB := proto.Clone(readResolved(t, ms, pathB)).(*metapb.FileMetadata)
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+
+	res, err := ms.MigrateGroup(context.Background(), groups[0], storeDir, "alt.binaries.misc")
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.FilesMigrated)
+	assert.Equal(t, 0, res.FilesFailed)
+	assert.False(t, res.Faithful, "no source nzb on disk")
+	assert.FileExists(t, res.StoreRef)
+
+	afterA := readResolved(t, ms, pathA)
+	afterB := readResolved(t, ms, pathB)
+
+	assert.Equal(t, res.StoreRef, afterA.StoreRef, "meta now points at the shared store")
+	require.Len(t, afterA.SegmentData, len(beforeA.SegmentData))
+	for i := range beforeA.SegmentData {
+		assert.Equal(t, beforeA.SegmentData[i].Id, afterA.SegmentData[i].Id)
+		assert.Equal(t, beforeA.SegmentData[i].SegmentSize, afterA.SegmentData[i].SegmentSize)
+		assert.Equal(t, beforeA.SegmentData[i].StartOffset, afterA.SegmentData[i].StartOffset)
+		assert.Equal(t, beforeA.SegmentData[i].EndOffset, afterA.SegmentData[i].EndOffset)
+	}
+	require.Len(t, afterA.Par2Files, 1)
+	require.Len(t, afterA.Par2Files[0].SegmentData, 1)
+	assert.Equal(t, "p1@n", afterA.Par2Files[0].SegmentData[0].Id)
+
+	require.Len(t, afterB.SegmentData, 2)
+	assert.EqualValues(t, 40, afterB.SegmentData[0].StartOffset, "archive slicing offsets survive")
+	assert.EqualValues(t, 59, afterB.SegmentData[1].EndOffset)
+	assert.Equal(t, beforeB.FileSize, afterB.FileSize)
+
+	assert.Equal(t, beforeA.FileSize, afterA.FileSize)
+	assert.Equal(t, beforeA.ReleaseDate, afterA.ReleaseDate)
+	assert.Equal(t, metapb.FileStatus_FILE_STATUS_HEALTHY, afterA.Status)
+	require.Len(t, afterA.KnownHoles, 1)
+	assert.EqualValues(t, 1, afterA.KnownHoles[0].StartSegment)
+}
+
+func TestMigrateGroup_CompactsIntoSegmentRuns(t *testing.T) {
+	root := t.TempDir()
+	storeDir := t.TempDir()
+	ms := NewMetadataService(root)
+
+	segs := make([]*metapb.SegmentData, 0, 10)
+	for i := 0; i < 10; i++ {
+		segs = append(segs, &metapb.SegmentData{
+			Id: string(rune('a'+i)) + "@n", SegmentSize: 100, StartOffset: 0, EndOffset: 99,
+		})
+	}
+	vpath := filepath.Join("movies", "Plain.mkv")
+	require.NoError(t, ms.WriteFileMetadata(vpath, &metapb.FileMetadata{
+		FileSize: 1000, SourceNzbPath: "/nzbs/plain.nzb", SegmentData: segs,
+	}))
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	_, err = ms.MigrateGroup(context.Background(), groups[0], storeDir, "alt.binaries.misc")
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(filepath.Join(root, "movies", "Plain.mkv.meta"))
+	require.NoError(t, err)
+	require.True(t, isV3Meta(raw))
+	var stored metapb.FileMetadata
+	require.NoError(t, proto.Unmarshal(raw[5:], &stored))
+	assert.Len(t, stored.SegmentRefs, 0, "no explicit refs for a uniform file")
+	require.Len(t, stored.SegmentRuns, 1)
+	assert.EqualValues(t, 10, stored.SegmentRuns[0].Count)
+	assert.Empty(t, stored.SegmentData, "inline segments are gone")
+}
+
+func TestMigrateGroup_IsIdempotentAndSkipsMigratedFiles(t *testing.T) {
+	root := t.TempDir()
+	storeDir := t.TempDir()
+	ms := NewMetadataService(root)
+
+	vpath := filepath.Join("movies", "A.mkv")
+	require.NoError(t, ms.WriteFileMetadata(vpath, &metapb.FileMetadata{
+		FileSize: 100, SourceNzbPath: "/nzbs/rel.nzb",
+		SegmentData: []*metapb.SegmentData{{Id: "s1@n", SegmentSize: 100, EndOffset: 99}},
+	}))
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	first, err := ms.MigrateGroup(context.Background(), groups[0], storeDir, "alt.binaries.misc")
+	require.NoError(t, err)
+
+	groups, err = ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	assert.Empty(t, groups, "migrated metas are not rescanned")
+	assert.FileExists(t, first.StoreRef)
+}
+
+// countingRefCounter records IncStoreRef calls per store path.
+type countingRefCounter struct {
+	mu   sync.Mutex
+	inc  map[string]int
+	decs map[string]int
+}
+
+func newCountingRefCounter() *countingRefCounter {
+	return &countingRefCounter{inc: map[string]int{}, decs: map[string]int{}}
+}
+
+func (c *countingRefCounter) IncStoreRef(_ context.Context, storePath string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.inc[storePath]++
+	return nil
+}
+
+func (c *countingRefCounter) DecStoreRef(_ context.Context, storePath string) (int64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.decs[storePath]++
+	return int64(c.inc[storePath] - c.decs[storePath]), nil
+}
+
+func TestMigrateGroup_RefCountMatchesMigratedFiles(t *testing.T) {
+	root := t.TempDir()
+	storeDir := t.TempDir()
+	ms := NewMetadataService(root)
+	counter := newCountingRefCounter()
+	ms.SetStoreRefCounter(counter)
+
+	for _, name := range []string{"A.mkv", "B.mkv", "C.mkv"} {
+		require.NoError(t, ms.WriteFileMetadata(filepath.Join("movies", name), &metapb.FileMetadata{
+			FileSize: 100, SourceNzbPath: "/nzbs/rel.nzb",
+			SegmentData: []*metapb.SegmentData{{Id: name + "@n", SegmentSize: 100, EndOffset: 99}},
+		}))
+	}
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+
+	res, err := ms.MigrateGroup(context.Background(), groups[0], storeDir, "alt.binaries.misc")
+	require.NoError(t, err)
+	assert.Equal(t, 3, res.FilesMigrated)
+
+	counter.mu.Lock()
+	defer counter.mu.Unlock()
+	assert.Equal(t, 3, counter.inc[res.StoreRef], "one reference per migrated meta")
+}
+
+func TestMigrateGroup_PartialRunLeavesFirstStoreIntact(t *testing.T) {
+	root := t.TempDir()
+	storeDir := t.TempDir()
+	ms := NewMetadataService(root)
+
+	pathA := filepath.Join("movies", "A.mkv")
+	pathB := filepath.Join("movies", "B.mkv")
+	for _, p := range []struct{ path, id string }{{pathA, "a@n"}, {pathB, "b@n"}} {
+		require.NoError(t, ms.WriteFileMetadata(p.path, &metapb.FileMetadata{
+			FileSize: 100, SourceNzbPath: "/nzbs/rel.nzb",
+			SegmentData: []*metapb.SegmentData{{Id: p.id, SegmentSize: 100, EndOffset: 99}},
+		}))
+	}
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups[0].Files, 2)
+
+	firstOnly := LegacyGroup{Key: groups[0].Key, Files: groups[0].Files[:1]}
+	firstRes, err := ms.MigrateGroup(context.Background(), firstOnly, storeDir, "alt.binaries.misc")
+	require.NoError(t, err)
+	require.Equal(t, 1, firstRes.FilesMigrated)
+
+	remaining, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	require.Len(t, remaining[0].Files, 1, "only B is left")
+
+	secondRes, err := ms.MigrateGroup(context.Background(), remaining[0], storeDir, "alt.binaries.misc")
+	require.NoError(t, err)
+	assert.Equal(t, 1, secondRes.FilesMigrated)
+	assert.NotEqual(t, firstRes.StoreRef, secondRes.StoreRef,
+		"a different segment set must not reuse the first store path")
+	assert.FileExists(t, firstRes.StoreRef, "the first store is untouched")
+
+	gotA := readResolved(t, ms, pathA)
+	gotB := readResolved(t, ms, pathB)
+	require.Len(t, gotA.SegmentData, 1)
+	require.Len(t, gotB.SegmentData, 1)
+	assert.Equal(t, "a@n", gotA.SegmentData[0].Id)
+	assert.Equal(t, "b@n", gotB.SegmentData[0].Id)
+}

--- a/internal/metadata/migration_property_test.go
+++ b/internal/metadata/migration_property_test.go
@@ -1,0 +1,287 @@
+package metadata
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// migration_property_test.go answers "are all cases covered?" by not enumerating
+// cases at all. It generates randomized legacy metadata across every
+// segment-bearing and preserved field — partial offsets, PAR2 sets, nested
+// sources with and without the shared-outer dedup, all four encryption modes,
+// clip boundaries, known holes, nzbdav ids, duplicate and shared segment ids,
+// multi-file groups, empty files — migrates it, and asserts the invariant.
+//
+// The assertions here are deliberately independent of verifyMigratedFile: if the
+// migration's own checker had a blind spot, comparing against it would inherit
+// that blind spot. The expected values are recomputed from a pristine clone.
+
+const idPoolSize = 24
+
+// idPool returns message ids drawn from a small pool so that generated files
+// collide with each other, exercising cross-file dedup and the non-increasing
+// store-index path in splitRefs.
+func idPool() []string {
+	pool := make([]string, idPoolSize)
+	for i := range pool {
+		pool[i] = fmt.Sprintf("prop-%03d@news.example.com", i)
+	}
+	return pool
+}
+
+func randSegments(rng *rand.Rand, pool []string, n int) []*metapb.SegmentData {
+	if n == 0 {
+		return nil
+	}
+	segs := make([]*metapb.SegmentData, n)
+	for i := range segs {
+		size := int64(1 + rng.Intn(1000))
+		start, end := int64(0), size-1
+		// Sometimes slice the segment the way an archive extent does.
+		if rng.Intn(3) == 0 && size > 2 {
+			start = int64(rng.Intn(int(size - 1)))
+			end = start + int64(rng.Intn(int(size-start)))
+		}
+		segs[i] = &metapb.SegmentData{
+			Id:          pool[rng.Intn(len(pool))],
+			SegmentSize: size,
+			StartOffset: start,
+			EndOffset:   end,
+		}
+	}
+	return segs
+}
+
+func randNestedSource(rng *rand.Rand, pool []string) *metapb.NestedSegmentSource {
+	ns := &metapb.NestedSegmentSource{
+		Segments:        randSegments(rng, pool, 1+rng.Intn(4)),
+		InnerOffset:     int64(rng.Intn(5000)),
+		InnerLength:     int64(1 + rng.Intn(5000)),
+		InnerVolumeSize: int64(1 + rng.Intn(100000)),
+	}
+	if rng.Intn(2) == 0 {
+		ns.AesKey = []byte("0123456789abcdef")
+		ns.AesIv = []byte("fedcba9876543210")
+	}
+	return ns
+}
+
+// randomLegacyMeta builds a v1 FileMetadata exercising a random combination of
+// every field the migration touches or must preserve.
+func randomLegacyMeta(rng *rand.Rand, pool []string) *metapb.FileMetadata {
+	m := &metapb.FileMetadata{
+		FileSize:    int64(rng.Intn(1 << 30)),
+		Status:      []metapb.FileStatus{metapb.FileStatus_FILE_STATUS_HEALTHY, metapb.FileStatus_FILE_STATUS_CORRUPTED, metapb.FileStatus_FILE_STATUS_DEGRADED}[rng.Intn(3)],
+		CreatedAt:   int64(rng.Intn(1 << 31)),
+		ModifiedAt:  int64(rng.Intn(1 << 31)),
+		ReleaseDate: int64(rng.Intn(1 << 31)),
+		SegmentData: randSegments(rng, pool, rng.Intn(12)),
+	}
+
+	switch rng.Intn(4) {
+	case 0: // NONE
+	case 1: // RCLONE — password/salt must survive
+		m.Encryption = metapb.Encryption_RCLONE
+		m.Password = fmt.Sprintf("pw-%d", rng.Int())
+		m.Salt = fmt.Sprintf("salt-%d", rng.Int())
+	case 2: // HEADERS
+		m.Encryption = metapb.Encryption_HEADERS
+	case 3: // AES — key material must survive
+		m.Encryption = metapb.Encryption_AES
+		m.AesKey = []byte("0123456789abcdef")
+		m.AesIv = []byte("fedcba9876543210")
+	}
+
+	for i := 0; i < rng.Intn(3); i++ {
+		m.Par2Files = append(m.Par2Files, &metapb.Par2FileReference{
+			Filename:    fmt.Sprintf("rel.vol%02d.par2", i),
+			FileSize:    int64(rng.Intn(1 << 20)),
+			SegmentData: randSegments(rng, pool, 1+rng.Intn(4)),
+		})
+	}
+
+	// Nested sources: either self-contained, or sharing outer sources through
+	// the dedup that migration dissolves.
+	switch nested := rng.Intn(3); nested {
+	case 1:
+		for i := 0; i < 1+rng.Intn(3); i++ {
+			m.NestedSources = append(m.NestedSources, randNestedSource(rng, pool))
+		}
+	case 2:
+		shared := 1 + rng.Intn(2)
+		for i := 0; i < shared; i++ {
+			m.SharedOuterSources = append(m.SharedOuterSources, randNestedSource(rng, pool))
+		}
+		for i := 0; i < 1+rng.Intn(4); i++ {
+			m.NestedSources = append(m.NestedSources, &metapb.NestedSegmentSource{
+				SharedOuterSourceIndex: int32(1 + rng.Intn(shared)),
+				InnerOffset:            int64(rng.Intn(5000)),
+				InnerLength:            int64(1 + rng.Intn(5000)),
+			})
+		}
+	}
+
+	for i := 0; i < rng.Intn(3); i++ {
+		m.ClipBoundaries = append(m.ClipBoundaries, &metapb.ClipBoundary{
+			ByteLen:   int64(1 + rng.Intn(1<<20)),
+			Delta_90K: int64(rng.Intn(1 << 20)),
+		})
+	}
+	for i := 0; i < rng.Intn(2); i++ {
+		m.KnownHoles = append(m.KnownHoles, &metapb.HoleRun{
+			StartSegment: int64(rng.Intn(100)),
+			Count:        int64(1 + rng.Intn(5)),
+		})
+	}
+	if rng.Intn(3) == 0 {
+		m.NzbdavId = fmt.Sprintf("nzbdav-%d", rng.Int())
+	}
+	return m
+}
+
+// assertPreserved compares a migrated file against the pristine expectation,
+// recomputed independently of the migration's own verifier.
+func assertPreserved(t *testing.T, label string, want, got *metapb.FileMetadata) {
+	t.Helper()
+
+	require.NoError(t, sameResolvedSegments(label+" main", want.SegmentData, got.SegmentData))
+
+	require.Len(t, got.Par2Files, len(want.Par2Files), "%s par2 count", label)
+	for i := range want.Par2Files {
+		require.NoError(t, sameResolvedSegments(
+			fmt.Sprintf("%s par2[%d]", label, i),
+			want.Par2Files[i].SegmentData, got.Par2Files[i].SegmentData))
+		assert.Equal(t, want.Par2Files[i].Filename, got.Par2Files[i].Filename)
+		assert.Equal(t, want.Par2Files[i].FileSize, got.Par2Files[i].FileSize)
+	}
+
+	require.Len(t, got.NestedSources, len(want.NestedSources), "%s nested count", label)
+	for i := range want.NestedSources {
+		w, g := want.NestedSources[i], got.NestedSources[i]
+		require.NoError(t, sameResolvedSegments(
+			fmt.Sprintf("%s nested[%d]", label, i), w.Segments, g.Segments))
+		assert.Equal(t, w.InnerOffset, g.InnerOffset, "%s nested[%d] inner offset", label, i)
+		assert.Equal(t, w.InnerLength, g.InnerLength, "%s nested[%d] inner length", label, i)
+		assert.Equal(t, w.InnerVolumeSize, g.InnerVolumeSize, "%s nested[%d] inner volume size", label, i)
+		assert.Equal(t, w.AesKey, g.AesKey, "%s nested[%d] aes key", label, i)
+		assert.Equal(t, w.AesIv, g.AesIv, "%s nested[%d] aes iv", label, i)
+	}
+
+	assert.Equal(t, want.FileSize, got.FileSize, "%s file size", label)
+	assert.Equal(t, want.Status, got.Status, "%s status", label)
+	assert.Equal(t, want.Encryption, got.Encryption, "%s encryption", label)
+	assert.Equal(t, want.Password, got.Password, "%s rclone password", label)
+	assert.Equal(t, want.Salt, got.Salt, "%s rclone salt", label)
+	assert.Equal(t, want.AesKey, got.AesKey, "%s aes key", label)
+	assert.Equal(t, want.AesIv, got.AesIv, "%s aes iv", label)
+	assert.Equal(t, want.ReleaseDate, got.ReleaseDate, "%s release date", label)
+	assert.Equal(t, want.NzbdavId, got.NzbdavId, "%s nzbdav id (.id sidecar)", label)
+
+	require.Len(t, got.ClipBoundaries, len(want.ClipBoundaries), "%s clip boundary count", label)
+	for i := range want.ClipBoundaries {
+		assert.Equal(t, want.ClipBoundaries[i].ByteLen, got.ClipBoundaries[i].ByteLen)
+		assert.Equal(t, want.ClipBoundaries[i].Delta_90K, got.ClipBoundaries[i].Delta_90K)
+	}
+	require.Len(t, got.KnownHoles, len(want.KnownHoles), "%s known hole count", label)
+	for i := range want.KnownHoles {
+		assert.Equal(t, want.KnownHoles[i].StartSegment, got.KnownHoles[i].StartSegment)
+		assert.Equal(t, want.KnownHoles[i].Count, got.KnownHoles[i].Count)
+	}
+}
+
+// migrateRandomGroup generates a group of random legacy files, migrates it, and
+// asserts every file survived unchanged. Returns the number of files generated.
+func migrateRandomGroup(t *testing.T, rng *rand.Rand) int {
+	t.Helper()
+	root := t.TempDir()
+	storeDir := t.TempDir()
+	ms := NewMetadataService(root)
+	pool := idPool()
+
+	fileCount := 1 + rng.Intn(4)
+	paths := make([]string, fileCount)
+	expected := make([]*metapb.FileMetadata, fileCount)
+
+	for i := 0; i < fileCount; i++ {
+		m := randomLegacyMeta(rng, pool)
+		m.SourceNzbPath = "/nzbs/prop.nzb"
+		paths[i] = filepath.Join("movies", fmt.Sprintf("F%02d.mkv", i))
+		require.NoError(t, ms.WriteFileMetadata(paths[i], m))
+
+		// nzbdav ids live in a .id sidecar written outside this package (an
+		// imported nzbdav library); WriteFileMetadata deliberately never
+		// persists the proto field. Create the sidecar the way production does
+		// so the assertion below tests the real invariant: migration must not
+		// disturb it.
+		if m.NzbdavId != "" {
+			require.NoError(t, os.WriteFile(
+				filepath.Join(root, paths[i]+".meta.id"), []byte(m.NzbdavId), 0644))
+		}
+
+		// Expectation: the pristine shape with the dedup expanded, since
+		// migration legitimately dissolves shared_outer_sources.
+		want := proto.Clone(m).(*metapb.FileMetadata)
+		require.NoError(t, ExpandSharedOuterSources(want))
+		expected[i] = want
+	}
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+
+	res, err := ms.MigrateGroup(context.Background(), groups[0], storeDir, "alt.binaries.misc")
+	require.NoError(t, err)
+	require.Equal(t, 0, res.FilesFailed, "no file may fail: %v", res.Failures)
+	require.Equal(t, fileCount, res.FilesMigrated)
+
+	for i, p := range paths {
+		raw, readErr := os.ReadFile(filepath.Join(root, p+".meta"))
+		require.NoError(t, readErr)
+		require.True(t, isV3Meta(raw), "%s must be v3 on disk", p)
+
+		got, readErr := ms.ReadFileMetadata(p)
+		require.NoError(t, readErr)
+		require.NotNil(t, got)
+		assertPreserved(t, p, expected[i], got)
+	}
+	return fileCount
+}
+
+func TestMigration_PropertyRandomShapes(t *testing.T) {
+	const iterations = 300
+	totalFiles := 0
+	for i := 0; i < iterations; i++ {
+		rng := rand.New(rand.NewSource(int64(i)))
+		t.Run(fmt.Sprintf("seed%03d", i), func(t *testing.T) {
+			totalFiles += migrateRandomGroup(t, rng)
+		})
+	}
+	t.Logf("migrated %d randomly generated files across %d groups", totalFiles, iterations)
+}
+
+// FuzzMigrationPreservesSegments lets the fuzzer explore the shape space beyond
+// the fixed seeds. Run longer with:
+//
+//	go test ./internal/metadata/ -run=Fuzz -fuzz=FuzzMigrationPreservesSegments -fuzztime=5m
+func FuzzMigrationPreservesSegments(f *testing.F) {
+	f.Add([]byte("seed"))
+	f.Add([]byte(""))
+	f.Add([]byte{0x00, 0xff, 0x7f})
+	f.Add([]byte("archive-nested-encrypted"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		h := fnv.New64a()
+		_, _ = h.Write(data)
+		migrateRandomGroup(t, rand.New(rand.NewSource(int64(h.Sum64()))))
+	})
+}

--- a/internal/metadata/migration_scan.go
+++ b/internal/metadata/migration_scan.go
@@ -1,0 +1,108 @@
+package metadata
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+)
+
+// LegacyMeta is one v1 (inline-segment) metadata file discovered by a scan.
+//
+// Meta is deliberately nil after a scan: a legacy meta carries its segments
+// inline, so retaining every one of them across a whole-library walk is the
+// allocation pattern that ReadFileMetadataLite exists to avoid (see the 7.94 GB
+// spike documented at service.go:405). LoadGroupMetas fills it in for one
+// release at a time, just before that release is migrated.
+type LegacyMeta struct {
+	MetaPath    string
+	VirtualPath string
+	SizeBytes   int64
+	Meta        *metapb.FileMetadata
+}
+
+// LegacyGroup is the set of legacy metas belonging to one release. Files are
+// sorted by meta path so a migration run is deterministic.
+type LegacyGroup struct {
+	Key   string
+	Files []LegacyMeta
+}
+
+// ScanLegacyMetas walks the metadata root and returns every legacy (non-v3)
+// meta, grouped by release. The group key is source_nzb_path when set, and the
+// meta's parent directory otherwise. Unreadable files are skipped rather than
+// failing the whole scan: a migration should convert what it can.
+//
+// Each meta is read to obtain its group key and then released, so the walk
+// retains only paths and sizes — peak memory is one meta, not the library.
+// Call LoadGroupMetas to hydrate a single group before migrating it.
+func (ms *MetadataService) ScanLegacyMetas() ([]LegacyGroup, error) {
+	byKey := make(map[string][]LegacyMeta)
+
+	err := filepath.WalkDir(ms.rootPath, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() || !strings.HasSuffix(path, ".meta") {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil || isV3Meta(data) {
+			return nil
+		}
+		rel, relErr := filepath.Rel(ms.rootPath, path)
+		if relErr != nil {
+			return nil
+		}
+		virtualPath := strings.TrimSuffix(rel, ".meta")
+
+		// Read through the service so the .id sidecar populates NzbdavId.
+		meta, metaErr := ms.ReadFileMetadata(virtualPath)
+		if metaErr != nil || meta == nil {
+			return nil
+		}
+
+		key := meta.SourceNzbPath
+		if key == "" {
+			key = filepath.Dir(path)
+		}
+		// meta goes out of scope here on purpose — see the LegacyMeta doc.
+		byKey[key] = append(byKey[key], LegacyMeta{
+			MetaPath:    path,
+			VirtualPath: virtualPath,
+			SizeBytes:   int64(len(data)),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk metadata root: %w", err)
+	}
+
+	groups := make([]LegacyGroup, 0, len(byKey))
+	for key, files := range byKey {
+		sort.Slice(files, func(a, b int) bool { return files[a].MetaPath < files[b].MetaPath })
+		groups = append(groups, LegacyGroup{Key: key, Files: files})
+	}
+	sort.Slice(groups, func(a, b int) bool { return groups[a].Key < groups[b].Key })
+	return groups, nil
+}
+
+// LoadGroupMetas returns a copy of g with every LegacyMeta.Meta populated.
+// Files that can no longer be read (deleted or migrated since the scan) are
+// dropped, so a stale scan degrades to a smaller group rather than an error.
+func (ms *MetadataService) LoadGroupMetas(g LegacyGroup) (LegacyGroup, error) {
+	loaded := LegacyGroup{Key: g.Key, Files: make([]LegacyMeta, 0, len(g.Files))}
+	for _, lm := range g.Files {
+		meta, err := ms.ReadFileMetadata(lm.VirtualPath)
+		if err != nil || meta == nil {
+			continue
+		}
+		lm.Meta = meta
+		loaded.Files = append(loaded.Files, lm)
+	}
+	if len(loaded.Files) == 0 {
+		return loaded, fmt.Errorf("no readable metadata left in group %q", g.Key)
+	}
+	return loaded, nil
+}

--- a/internal/metadata/migration_scan_test.go
+++ b/internal/metadata/migration_scan_test.go
@@ -1,0 +1,110 @@
+package metadata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeLegacyMeta writes a v1 (inline-segment, no magic) meta at virtualPath.
+func writeLegacyMeta(t *testing.T, ms *MetadataService, virtualPath, sourceNzb string, ids ...string) {
+	t.Helper()
+	segs := make([]*metapb.SegmentData, 0, len(ids))
+	for _, id := range ids {
+		segs = append(segs, &metapb.SegmentData{Id: id, SegmentSize: 100, StartOffset: 0, EndOffset: 99})
+	}
+	meta := &metapb.FileMetadata{
+		FileSize:      int64(100 * len(ids)),
+		Status:        metapb.FileStatus_FILE_STATUS_HEALTHY,
+		SourceNzbPath: sourceNzb,
+		SegmentData:   segs,
+	}
+	require.NoError(t, ms.WriteFileMetadata(virtualPath, meta))
+}
+
+func TestScanLegacyMetas_GroupsBySourceNzbPath(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	writeLegacyMeta(t, ms, filepath.Join("movies", "A.mkv"), "/nzbs/rel.nzb", "a1@n", "a2@n")
+	writeLegacyMeta(t, ms, filepath.Join("movies", "B.mkv"), "/nzbs/rel.nzb", "b1@n")
+	writeLegacyMeta(t, ms, filepath.Join("other", "C.mkv"), "", "c1@n")
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 2, "two releases: one keyed by source nzb, one by parent dir")
+
+	byKey := map[string][]LegacyMeta{}
+	for _, g := range groups {
+		byKey[g.Key] = g.Files
+	}
+	require.Len(t, byKey["/nzbs/rel.nzb"], 2)
+	assert.Equal(t, filepath.Join("movies", "A.mkv"), byKey["/nzbs/rel.nzb"][0].VirtualPath)
+	assert.Equal(t, filepath.Join("movies", "B.mkv"), byKey["/nzbs/rel.nzb"][1].VirtualPath)
+
+	dirKey := filepath.Join(root, "other")
+	require.Len(t, byKey[dirKey], 1, "empty source_nzb_path falls back to the parent directory")
+	assert.Positive(t, byKey[dirKey][0].SizeBytes)
+
+	// The scan must not retain full protos: that is the whole-library
+	// allocation pattern ReadFileMetadataLite was introduced to avoid.
+	for _, g := range groups {
+		for _, lm := range g.Files {
+			assert.Nil(t, lm.Meta, "scan must not retain segment data for %s", lm.VirtualPath)
+		}
+	}
+}
+
+func TestLoadGroupMetas_HydratesOneGroup(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	writeLegacyMeta(t, ms, filepath.Join("movies", "A.mkv"), "/nzbs/rel.nzb", "a1@n", "a2@n")
+	writeLegacyMeta(t, ms, filepath.Join("movies", "B.mkv"), "/nzbs/rel.nzb", "b1@n")
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+
+	loaded, err := ms.LoadGroupMetas(groups[0])
+	require.NoError(t, err)
+	require.Len(t, loaded.Files, 2)
+	require.NotNil(t, loaded.Files[0].Meta)
+	assert.Len(t, loaded.Files[0].Meta.SegmentData, 2)
+	assert.Len(t, loaded.Files[1].Meta.SegmentData, 1)
+	assert.Equal(t, groups[0].Key, loaded.Key)
+}
+
+func TestScanLegacyMetas_SkipsV3Metas(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+	storeRef := filepath.Join(t.TempDir(), "rel.nzbz")
+
+	store := &metapb.NzbStore{Files: []*metapb.NzbFileEntry{
+		{Subject: "V3.mkv", Segments: []*metapb.NzbSeg{{Id: "v1@n", Number: 1, Bytes: 100}}},
+	}}
+	require.NoError(t, ms.Store().WriteStore(storeRef, store))
+	require.NoError(t, ms.WriteFileMetadata(filepath.Join("movies", "V3.mkv"), &metapb.FileMetadata{
+		FileSize: 100,
+		StoreRef: storeRef,
+		SegmentRefs: []*metapb.SegmentRef{
+			{StoreIndex: 0, StartOffset: 0, EndOffset: 99, DecodedBytes: 100},
+		},
+	}))
+	writeLegacyMeta(t, ms, filepath.Join("movies", "Old.mkv"), "/nzbs/old.nzb", "o1@n")
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 1, "already-migrated metas are skipped")
+	assert.Equal(t, "/nzbs/old.nzb", groups[0].Key)
+
+	// Sanity: a non-.meta file in the tree is ignored.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "movies", "stray.txt"), []byte("x"), 0644))
+	groups, err = ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+}

--- a/internal/metadata/migration_store.go
+++ b/internal/metadata/migration_store.go
@@ -1,0 +1,120 @@
+package metadata
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+)
+
+// allSegmentLists returns every inline SegmentData slice a metadata carries:
+// the main file, each PAR2 file, and each nested source. Call
+// ExpandSharedOuterSources first so nested sources carry their segments.
+func allSegmentLists(m *metapb.FileMetadata) [][]*metapb.SegmentData {
+	lists := make([][]*metapb.SegmentData, 0, 1+len(m.Par2Files)+len(m.NestedSources))
+	lists = append(lists, m.SegmentData)
+	for _, p := range m.Par2Files {
+		lists = append(lists, p.SegmentData)
+	}
+	for _, ns := range m.NestedSources {
+		lists = append(lists, ns.Segments)
+	}
+	return lists
+}
+
+// synthesizeStore builds an NzbStore from the inline segments of a legacy
+// release group, plus the message-id → flat-index map used to emit SegmentRefs.
+//
+// Subject/poster/groups are not retained by legacy metas, so entries carry the
+// virtual filename as subject and defaultGroup as the single group — enough for
+// nzb.BuildNZB to emit a structurally valid NZB. Segment sizes are the decoded
+// sizes from SegmentData, which is what segDataToRefs records in decoded_bytes
+// and what the read path prefers, so no size information is lost.
+//
+// One NzbFileEntry per contributing meta keeps each file's segments on a
+// contiguous, increasing index range, which is what lets splitRefs collapse
+// them into compact SegmentRuns.
+func synthesizeStore(files []LegacyMeta, defaultGroup string) (*metapb.NzbStore, map[string]int64, error) {
+	store := &metapb.NzbStore{Files: make([]*metapb.NzbFileEntry, 0, len(files))}
+	index := make(map[string]int64)
+	var flat int64
+
+	var groups []string
+	if defaultGroup != "" {
+		groups = []string{defaultGroup}
+	}
+
+	for _, lm := range files {
+		if err := ExpandSharedOuterSources(lm.Meta); err != nil {
+			return nil, nil, fmt.Errorf("expand shared outer sources for %s: %w", lm.VirtualPath, err)
+		}
+		entry := &metapb.NzbFileEntry{
+			Subject: filepath.Base(lm.VirtualPath),
+			Date:    lm.Meta.CreatedAt,
+			Groups:  groups,
+		}
+		for _, segs := range allSegmentLists(lm.Meta) {
+			for _, s := range segs {
+				if s.Id == "" {
+					return nil, nil, fmt.Errorf("empty segment id in %s", lm.VirtualPath)
+				}
+				if _, seen := index[s.Id]; seen {
+					continue
+				}
+				index[s.Id] = flat
+				flat++
+				entry.Segments = append(entry.Segments, &metapb.NzbSeg{
+					Id:     s.Id,
+					Number: int32(len(entry.Segments) + 1),
+					Bytes:  s.SegmentSize,
+				})
+			}
+		}
+		store.Files = append(store.Files, entry)
+	}
+	return store, index, nil
+}
+
+// storeHashPath returns the .nzbz path for a group's store. The name embeds the
+// first 8 hex characters of the SHA-256 over the store's segment ids in flat
+// order, so a store is never overwritten by one holding a different segment set
+// — which would silently invalidate the refs of already-migrated metas.
+func storeHashPath(dir, groupKey string, store *metapb.NzbStore) string {
+	h := sha256.New()
+	for _, f := range store.Files {
+		for _, s := range f.Segments {
+			_, _ = h.Write([]byte(s.Id))
+			_, _ = h.Write([]byte{'\n'})
+		}
+	}
+	sum := hex.EncodeToString(h.Sum(nil))[:8]
+	return filepath.Join(dir, fmt.Sprintf("%s-%s.nzbz", sanitizeStoreBase(groupKey), sum))
+}
+
+// sanitizeStoreBase turns a group key (an nzb path or a directory) into a safe,
+// bounded filename component.
+func sanitizeStoreBase(groupKey string) string {
+	base := filepath.Base(filepath.FromSlash(strings.ReplaceAll(groupKey, `\`, "/")))
+	base = strings.TrimSuffix(base, ".nzb")
+
+	var b strings.Builder
+	for _, r := range base {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	out := b.String()
+	if len(out) > 80 {
+		out = out[:80]
+	}
+	if out == "" || out == "." || out == ".." {
+		out = "release"
+	}
+	return out
+}

--- a/internal/metadata/migration_store.go
+++ b/internal/metadata/migration_store.go
@@ -4,10 +4,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/javi11/nzbparser"
 )
 
 // allSegmentLists returns every inline SegmentData slice a metadata carries:
@@ -117,4 +119,55 @@ func sanitizeStoreBase(groupKey string) string {
 		out = "release"
 	}
 	return out
+}
+
+// buildGroupStore returns the store and flat index for a release group. It
+// prefers a faithful store parsed from the surviving source .nzb (real
+// subjects, posters, groups and segment numbers) and falls back to synthesis
+// from the inline segments. The bool reports which path was taken.
+func buildGroupStore(g LegacyGroup, defaultGroup string) (*metapb.NzbStore, map[string]int64, bool, error) {
+	if store, index, ok := tryFaithfulStore(g); ok {
+		return store, index, true, nil
+	}
+	store, index, err := synthesizeStore(g.Files, defaultGroup)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	return store, index, false, nil
+}
+
+// tryFaithfulStore parses the group's source .nzb, if it still exists, and
+// returns the resulting store only when it covers every segment referenced by
+// every meta in the group. A partial or mismatched NZB (edited, replaced, or
+// belonging to a different release) is rejected outright: half a faithful index
+// is worse than an honest synthesized one.
+func tryFaithfulStore(g LegacyGroup) (*metapb.NzbStore, map[string]int64, bool) {
+	if g.Key == "" {
+		return nil, nil, false
+	}
+	f, err := os.Open(g.Key)
+	if err != nil {
+		return nil, nil, false
+	}
+	defer func() { _ = f.Close() }()
+
+	parsed, err := nzbparser.Parse(f)
+	if err != nil || parsed == nil || len(parsed.Files) == 0 {
+		return nil, nil, false
+	}
+	store, index := BuildStore(parsed)
+
+	for _, lm := range g.Files {
+		if expandErr := ExpandSharedOuterSources(lm.Meta); expandErr != nil {
+			return nil, nil, false
+		}
+		for _, segs := range allSegmentLists(lm.Meta) {
+			for _, s := range segs {
+				if _, ok := index[s.Id]; !ok {
+					return nil, nil, false
+				}
+			}
+		}
+	}
+	return store, index, true
 }

--- a/internal/metadata/migration_store_test.go
+++ b/internal/metadata/migration_store_test.go
@@ -1,11 +1,15 @@
 package metadata
 
 import (
+	"bytes"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/javi11/altmount/internal/nzb"
+	"github.com/javi11/nzbparser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -103,4 +107,78 @@ func TestStoreHashPath_StableAndContentAddressed(t *testing.T) {
 	assert.True(t, strings.HasSuffix(base, ".nzbz"))
 	assert.True(t, strings.HasPrefix(base, "My_Release__2024_-"), "unsafe characters are replaced, got %q", base)
 	assert.NotContains(t, base, "/")
+}
+
+const testNZB = `<?xml version="1.0" encoding="UTF-8"?>
+<nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+  <file poster="poster@example.com" date="1700000000" subject="[1/1] &quot;A.mkv&quot; yEnc (1/2)">
+    <groups><group>alt.binaries.real</group></groups>
+    <segments>
+      <segment bytes="140" number="1">s1@n</segment>
+      <segment bytes="140" number="2">s2@n</segment>
+    </segments>
+  </file>
+</nzb>
+`
+
+func TestBuildGroupStore_FaithfulWhenSourceNzbExists(t *testing.T) {
+	dir := t.TempDir()
+	nzbPath := filepath.Join(dir, "rel.nzb")
+	require.NoError(t, os.WriteFile(nzbPath, []byte(testNZB), 0644))
+
+	g := LegacyGroup{Key: nzbPath, Files: []LegacyMeta{legacyMeta("movies/A.mkv", &metapb.FileMetadata{
+		SegmentData: []*metapb.SegmentData{
+			{Id: "s1@n", SegmentSize: 100, EndOffset: 99},
+			{Id: "s2@n", SegmentSize: 100, EndOffset: 99},
+		},
+	})}}
+
+	store, index, faithful, err := buildGroupStore(g, "alt.binaries.misc")
+	require.NoError(t, err)
+	assert.True(t, faithful)
+	require.Len(t, store.Files, 1)
+	assert.Equal(t, []string{"alt.binaries.real"}, store.Files[0].Groups, "real groups survive")
+	assert.Equal(t, "poster@example.com", store.Files[0].Poster)
+	assert.EqualValues(t, 0, index["s1@n"])
+	assert.EqualValues(t, 1, index["s2@n"])
+
+	// A faithful store regenerates an NZB that parses back with its group intact.
+	regenerated := nzb.BuildNZB(store)
+	reparsed, parseErr := nzbparser.Parse(bytes.NewReader(regenerated))
+	require.NoError(t, parseErr)
+	require.Len(t, reparsed.Files, 1)
+	assert.Equal(t, []string{"alt.binaries.real"}, reparsed.Files[0].Groups)
+	require.Len(t, reparsed.Files[0].Segments, 2)
+}
+
+func TestBuildGroupStore_FallsBackWhenNzbMissing(t *testing.T) {
+	g := LegacyGroup{Key: "/nzbs/gone.nzb", Files: []LegacyMeta{legacyMeta("movies/A.mkv", &metapb.FileMetadata{
+		SegmentData: []*metapb.SegmentData{{Id: "s1@n", SegmentSize: 100, EndOffset: 99}},
+	})}}
+
+	store, index, faithful, err := buildGroupStore(g, "alt.binaries.misc")
+	require.NoError(t, err)
+	assert.False(t, faithful)
+	require.Len(t, store.Files, 1)
+	assert.Equal(t, []string{"alt.binaries.misc"}, store.Files[0].Groups)
+	assert.EqualValues(t, 0, index["s1@n"])
+}
+
+func TestBuildGroupStore_FallsBackWhenNzbDoesNotCoverSegments(t *testing.T) {
+	dir := t.TempDir()
+	nzbPath := filepath.Join(dir, "rel.nzb")
+	require.NoError(t, os.WriteFile(nzbPath, []byte(testNZB), 0644))
+
+	g := LegacyGroup{Key: nzbPath, Files: []LegacyMeta{legacyMeta("movies/A.mkv", &metapb.FileMetadata{
+		SegmentData: []*metapb.SegmentData{
+			{Id: "s1@n", SegmentSize: 100, EndOffset: 99},
+			{Id: "unknown@n", SegmentSize: 100, EndOffset: 99},
+		},
+	})}}
+
+	store, index, faithful, err := buildGroupStore(g, "alt.binaries.misc")
+	require.NoError(t, err)
+	assert.False(t, faithful, "a mismatched NZB must not be trusted")
+	assert.Equal(t, []string{"alt.binaries.misc"}, store.Files[0].Groups)
+	assert.Contains(t, index, "unknown@n")
 }

--- a/internal/metadata/migration_store_test.go
+++ b/internal/metadata/migration_store_test.go
@@ -1,0 +1,106 @@
+package metadata
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func legacyMeta(virtualPath string, meta *metapb.FileMetadata) LegacyMeta {
+	return LegacyMeta{
+		MetaPath:    virtualPath + ".meta",
+		VirtualPath: virtualPath,
+		SizeBytes:   1,
+		Meta:        meta,
+	}
+}
+
+func TestSynthesizeStore_FlatIndexAndDedup(t *testing.T) {
+	a := &metapb.FileMetadata{
+		CreatedAt: 111,
+		SegmentData: []*metapb.SegmentData{
+			{Id: "s1@n", SegmentSize: 100, EndOffset: 99},
+			{Id: "s2@n", SegmentSize: 100, EndOffset: 99},
+		},
+		Par2Files: []*metapb.Par2FileReference{
+			{Filename: "rel.par2", SegmentData: []*metapb.SegmentData{{Id: "p1@n", SegmentSize: 50, EndOffset: 49}}},
+		},
+	}
+	b := &metapb.FileMetadata{
+		CreatedAt: 222,
+		SegmentData: []*metapb.SegmentData{
+			{Id: "s2@n", SegmentSize: 100, EndOffset: 99},
+			{Id: "s3@n", SegmentSize: 70, EndOffset: 69},
+		},
+	}
+
+	store, index, err := synthesizeStore(
+		[]LegacyMeta{legacyMeta("movies/A.mkv", a), legacyMeta("movies/B.mkv", b)},
+		"alt.binaries.misc",
+	)
+	require.NoError(t, err)
+	require.Len(t, store.Files, 2, "one NzbFileEntry per contributing meta")
+
+	assert.Equal(t, "A.mkv", store.Files[0].Subject)
+	assert.Equal(t, []string{"alt.binaries.misc"}, store.Files[0].Groups)
+	assert.EqualValues(t, 111, store.Files[0].Date)
+
+	assert.EqualValues(t, 0, index["s1@n"])
+	assert.EqualValues(t, 1, index["s2@n"])
+	assert.EqualValues(t, 2, index["p1@n"])
+	assert.EqualValues(t, 3, index["s3@n"])
+	require.Len(t, store.Files[1].Segments, 1, "duplicate ids are not stored twice")
+	assert.Equal(t, "s3@n", store.Files[1].Segments[0].Id)
+
+	assert.EqualValues(t, 100, store.Files[0].Segments[0].Bytes)
+	assert.EqualValues(t, 70, store.Files[1].Segments[0].Bytes)
+
+	assert.EqualValues(t, 1, store.Files[0].Segments[0].Number)
+	assert.EqualValues(t, 2, store.Files[0].Segments[1].Number)
+}
+
+func TestSynthesizeStore_ExpandsSharedOuterSources(t *testing.T) {
+	m := &metapb.FileMetadata{
+		SharedOuterSources: []*metapb.NestedSegmentSource{
+			{Segments: []*metapb.SegmentData{{Id: "outer@n", SegmentSize: 500, EndOffset: 499}}, InnerVolumeSize: 500},
+		},
+		NestedSources: []*metapb.NestedSegmentSource{
+			{SharedOuterSourceIndex: 1, InnerOffset: 0, InnerLength: 250},
+			{SharedOuterSourceIndex: 1, InnerOffset: 250, InnerLength: 250},
+		},
+	}
+
+	_, index, err := synthesizeStore([]LegacyMeta{legacyMeta("movies/BD.m2ts", m)}, "alt.binaries.misc")
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, index["outer@n"], "shared outer segments are expanded and indexed")
+	assert.Len(t, index, 1)
+}
+
+func TestSynthesizeStore_RejectsEmptySegmentID(t *testing.T) {
+	m := &metapb.FileMetadata{SegmentData: []*metapb.SegmentData{{Id: "", SegmentSize: 10, EndOffset: 9}}}
+	_, _, err := synthesizeStore([]LegacyMeta{legacyMeta("movies/Bad.mkv", m)}, "alt.binaries.misc")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty segment id")
+}
+
+func TestStoreHashPath_StableAndContentAddressed(t *testing.T) {
+	s1 := &metapb.NzbStore{Files: []*metapb.NzbFileEntry{
+		{Segments: []*metapb.NzbSeg{{Id: "x@n"}, {Id: "y@n"}}},
+	}}
+	s2 := &metapb.NzbStore{Files: []*metapb.NzbFileEntry{
+		{Segments: []*metapb.NzbSeg{{Id: "x@n"}}},
+	}}
+
+	p1 := storeHashPath("/store", "/nzbs/My Release [2024].nzb", s1)
+	assert.Equal(t, p1, storeHashPath("/store", "/nzbs/My Release [2024].nzb", s1), "stable across calls")
+	assert.NotEqual(t, p1, storeHashPath("/store", "/nzbs/My Release [2024].nzb", s2), "different segments, different path")
+
+	base := filepath.Base(p1)
+	assert.True(t, strings.HasSuffix(base, ".nzbz"))
+	assert.True(t, strings.HasPrefix(base, "My_Release__2024_-"), "unsafe characters are replaced, got %q", base)
+	assert.NotContains(t, base, "/")
+}

--- a/internal/metadata/migration_test.go
+++ b/internal/metadata/migration_test.go
@@ -1,0 +1,112 @@
+package metadata
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testConfigGetter(t *testing.T) config.ConfigGetter {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "altmount.db")
+	cfg := &config.Config{}
+	cfg.Database.Path = dbPath
+	cfg.Metadata.Migration.DefaultGroup = "alt.binaries.misc"
+	return func() *config.Config { return cfg }
+}
+
+func seedLegacyRelease(t *testing.T, ms *MetadataService) {
+	t.Helper()
+	require.NoError(t, ms.WriteFileMetadata(filepath.Join("movies", "A.mkv"), &metapb.FileMetadata{
+		FileSize: 200, SourceNzbPath: "/nzbs/rel.nzb",
+		SegmentData: []*metapb.SegmentData{
+			{Id: "s1@n", SegmentSize: 100, EndOffset: 99},
+			{Id: "s2@n", SegmentSize: 100, EndOffset: 99},
+		},
+	}))
+	require.NoError(t, ms.WriteFileMetadata(filepath.Join("movies", "B.mkv"), &metapb.FileMetadata{
+		FileSize: 100, SourceNzbPath: "/nzbs/rel.nzb",
+		SegmentData: []*metapb.SegmentData{{Id: "s3@n", SegmentSize: 100, EndOffset: 99}},
+	}))
+}
+
+func TestMigrationWorker_DryRunLeavesLibraryUntouched(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+	seedLegacyRelease(t, ms)
+
+	w := NewMigrationWorker(ms, testConfigGetter(t))
+	res, err := w.DryRun(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	assert.True(t, res.DryRun)
+	assert.Equal(t, 1, res.Groups)
+	assert.Equal(t, 2, res.FilesMigrated)
+	assert.Equal(t, 0, res.FilesFailed)
+	assert.Positive(t, res.BytesBefore)
+	assert.Positive(t, res.BytesAfter)
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Len(t, groups[0].Files, 2)
+
+	status := w.GetStatus()
+	assert.False(t, status.IsRunning)
+	require.NotNil(t, status.LastDryRun)
+	assert.Nil(t, status.LastResult, "a dry run is not a migration")
+}
+
+func TestMigrationWorker_StartMigratesEverything(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+	seedLegacyRelease(t, ms)
+
+	w := NewMigrationWorker(ms, testConfigGetter(t))
+	require.NoError(t, w.Start(context.Background()))
+
+	require.Eventually(t, func() bool {
+		return !w.GetStatus().IsRunning && w.GetStatus().LastResult != nil
+	}, 10*time.Second, 20*time.Millisecond)
+
+	res := w.GetStatus().LastResult
+	require.NotNil(t, res)
+	assert.False(t, res.DryRun)
+	assert.Equal(t, 2, res.FilesMigrated)
+	assert.Equal(t, 0, res.FilesFailed)
+	assert.Equal(t, 1, res.SynthesizedGroups)
+	assert.Equal(t, 0, res.FaithfulGroups)
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	assert.Empty(t, groups, "nothing legacy is left")
+
+	got, err := ms.ReadFileMetadata(filepath.Join("movies", "A.mkv"))
+	require.NoError(t, err)
+	require.Len(t, got.SegmentData, 2)
+	assert.Equal(t, "s1@n", got.SegmentData[0].Id)
+}
+
+func TestMigrationWorker_RejectsConcurrentRuns(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+	w := NewMigrationWorker(ms, testConfigGetter(t))
+
+	w.mu.Lock()
+	w.running = true
+	w.mu.Unlock()
+
+	err := w.Start(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already running")
+
+	_, dryErr := w.DryRun(context.Background())
+	require.Error(t, dryErr)
+}

--- a/internal/metadata/migration_verify.go
+++ b/internal/metadata/migration_verify.go
@@ -1,0 +1,140 @@
+package metadata
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+)
+
+// sameResolvedSegments reports whether two resolved segment lists are
+// equivalent for streaming purposes: same ids, same decoded sizes, same byte
+// ranges, in the same order. label names the list in the error so a failure
+// says which part of the file disagreed.
+func sameResolvedSegments(label string, want, got []*metapb.SegmentData) error {
+	if len(want) != len(got) {
+		return fmt.Errorf("%s segment count changed: was %d, now %d", label, len(want), len(got))
+	}
+	for i := range want {
+		w, g := want[i], got[i]
+		if w.Id != g.Id || w.SegmentSize != g.SegmentSize ||
+			w.StartOffset != g.StartOffset || w.EndOffset != g.EndOffset {
+			return fmt.Errorf(
+				"%s segment %d changed: was {id=%s size=%d start=%d end=%d}, now {id=%s size=%d start=%d end=%d}",
+				label, i,
+				w.Id, w.SegmentSize, w.StartOffset, w.EndOffset,
+				g.Id, g.SegmentSize, g.StartOffset, g.EndOffset,
+			)
+		}
+	}
+	return nil
+}
+
+// verifyMigratedFile re-reads a just-migrated .meta from disk and confirms it
+// resolves, through the shared store, to exactly the segments the legacy file
+// carried inline — main file, every PAR2 file, and every nested source.
+//
+// This is the migration's own proof of correctness. Rather than relying on test
+// coverage to have anticipated every metadata shape in the wild, each file is
+// checked individually against itself, and MigrateGroup restores any file whose
+// check fails. It is a package-level var so tests can force the failure path.
+var verifyMigratedFile = func(ms *MetadataService, virtualPath string, original *metapb.FileMetadata) error {
+	reread, err := ms.ReadFileMetadata(virtualPath)
+	if err != nil {
+		return fmt.Errorf("re-read after migration: %w", err)
+	}
+	if reread == nil {
+		return fmt.Errorf("re-read after migration returned no metadata")
+	}
+
+	if err := sameResolvedSegments("main", original.SegmentData, reread.SegmentData); err != nil {
+		return err
+	}
+
+	if len(original.Par2Files) != len(reread.Par2Files) {
+		return fmt.Errorf("par2 file count changed: was %d, now %d",
+			len(original.Par2Files), len(reread.Par2Files))
+	}
+	for i := range original.Par2Files {
+		label := fmt.Sprintf("par2[%d] (%s)", i, original.Par2Files[i].Filename)
+		if err := sameResolvedSegments(label, original.Par2Files[i].SegmentData, reread.Par2Files[i].SegmentData); err != nil {
+			return err
+		}
+	}
+
+	if len(original.NestedSources) != len(reread.NestedSources) {
+		return fmt.Errorf("nested source count changed: was %d, now %d",
+			len(original.NestedSources), len(reread.NestedSources))
+	}
+	for i := range original.NestedSources {
+		o, r := original.NestedSources[i], reread.NestedSources[i]
+		if err := sameResolvedSegments(fmt.Sprintf("nested[%d]", i), o.Segments, r.Segments); err != nil {
+			return err
+		}
+		// The cipher and extent geometry matter as much as the segments: a
+		// wrong inner volume size silently corrupts an encrypted read.
+		if o.InnerOffset != r.InnerOffset || o.InnerLength != r.InnerLength {
+			return fmt.Errorf("nested[%d] extent changed: was offset=%d len=%d, now offset=%d len=%d",
+				i, o.InnerOffset, o.InnerLength, r.InnerOffset, r.InnerLength)
+		}
+		if o.InnerVolumeSize != r.InnerVolumeSize {
+			return fmt.Errorf("nested[%d] inner volume size changed: was %d, now %d",
+				i, o.InnerVolumeSize, r.InnerVolumeSize)
+		}
+		if string(o.AesKey) != string(r.AesKey) || string(o.AesIv) != string(r.AesIv) {
+			return fmt.Errorf("nested[%d] AES key material changed", i)
+		}
+	}
+
+	// File-level crypto and geometry must be untouched by a format change.
+	if original.FileSize != reread.FileSize {
+		return fmt.Errorf("file size changed: was %d, now %d", original.FileSize, reread.FileSize)
+	}
+	if original.Encryption != reread.Encryption {
+		return fmt.Errorf("encryption changed: was %v, now %v", original.Encryption, reread.Encryption)
+	}
+	if string(original.AesKey) != string(reread.AesKey) || string(original.AesIv) != string(reread.AesIv) {
+		return fmt.Errorf("AES key material changed")
+	}
+	if original.Password != reread.Password || original.Salt != reread.Salt {
+		return fmt.Errorf("rclone password/salt changed")
+	}
+	if len(original.ClipBoundaries) != len(reread.ClipBoundaries) {
+		return fmt.Errorf("clip boundary count changed: was %d, now %d",
+			len(original.ClipBoundaries), len(reread.ClipBoundaries))
+	}
+	for i := range original.ClipBoundaries {
+		if original.ClipBoundaries[i].ByteLen != reread.ClipBoundaries[i].ByteLen ||
+			original.ClipBoundaries[i].Delta_90K != reread.ClipBoundaries[i].Delta_90K {
+			return fmt.Errorf("clip boundary %d changed", i)
+		}
+	}
+	return nil
+}
+
+// restoreLegacyMeta writes raw bytes back to a .meta path atomically, undoing a
+// migration for one file. Used when verification fails: the legacy format still
+// works, so leaving the file untouched is always the safe outcome.
+func restoreLegacyMeta(metaPath string, original []byte) error {
+	dir := filepath.Dir(metaPath)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(metaPath)+".restore.*.tmp")
+	if err != nil {
+		return fmt.Errorf("create restore temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(original); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write restore temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close restore temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, metaPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename restored metadata: %w", err)
+	}
+	return nil
+}

--- a/internal/metadata/migration_verify_test.go
+++ b/internal/metadata/migration_verify_test.go
@@ -1,0 +1,160 @@
+package metadata
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestSameResolvedSegments(t *testing.T) {
+	base := []*metapb.SegmentData{
+		{Id: "a@n", SegmentSize: 100, StartOffset: 0, EndOffset: 99},
+		{Id: "b@n", SegmentSize: 100, StartOffset: 10, EndOffset: 89},
+	}
+	clone := func() []*metapb.SegmentData {
+		out := make([]*metapb.SegmentData, len(base))
+		for i, s := range base {
+			out[i] = proto.Clone(s).(*metapb.SegmentData)
+		}
+		return out
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func([]*metapb.SegmentData) []*metapb.SegmentData
+		wantErr string
+	}{
+		{"identical", func(s []*metapb.SegmentData) []*metapb.SegmentData { return s }, ""},
+		{"count differs", func(s []*metapb.SegmentData) []*metapb.SegmentData { return s[:1] }, "segment count"},
+		{"id differs", func(s []*metapb.SegmentData) []*metapb.SegmentData {
+			s[1].Id = "other@n"
+			return s
+		}, "segment 1"},
+		{"size differs", func(s []*metapb.SegmentData) []*metapb.SegmentData {
+			s[0].SegmentSize = 99
+			return s
+		}, "segment 0"},
+		{"start offset differs", func(s []*metapb.SegmentData) []*metapb.SegmentData {
+			s[1].StartOffset = 11
+			return s
+		}, "segment 1"},
+		{"end offset differs", func(s []*metapb.SegmentData) []*metapb.SegmentData {
+			s[1].EndOffset = 88
+			return s
+		}, "segment 1"},
+		{"order differs", func(s []*metapb.SegmentData) []*metapb.SegmentData {
+			s[0], s[1] = s[1], s[0]
+			return s
+		}, "segment 0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := sameResolvedSegments("main", base, tt.mutate(clone()))
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestMigrateGroup_RollsBackWhenVerificationFails proves the safety net: if the
+// post-write check ever disagrees with the pre-migration segments, the file is
+// restored byte-for-byte to its legacy form rather than left converted.
+func TestMigrateGroup_RollsBackWhenVerificationFails(t *testing.T) {
+	root := t.TempDir()
+	storeDir := t.TempDir()
+	ms := NewMetadataService(root)
+
+	vpath := filepath.Join("movies", "A.mkv")
+	require.NoError(t, ms.WriteFileMetadata(vpath, &metapb.FileMetadata{
+		FileSize: 200, SourceNzbPath: "/nzbs/rel.nzb",
+		SegmentData: []*metapb.SegmentData{
+			{Id: "s1@n", SegmentSize: 100, EndOffset: 99},
+			{Id: "s2@n", SegmentSize: 100, EndOffset: 99},
+		},
+	}))
+
+	metaPath := filepath.Join(root, "movies", "A.mkv.meta")
+	originalBytes, err := os.ReadFile(metaPath)
+	require.NoError(t, err)
+	require.False(t, isV3Meta(originalBytes))
+
+	// Force every verification to fail.
+	restore := verifyMigratedFile
+	verifyMigratedFile = func(_ *MetadataService, _ string, _ *metapb.FileMetadata) error {
+		return assert.AnError
+	}
+	t.Cleanup(func() { verifyMigratedFile = restore })
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+
+	res, err := ms.MigrateGroup(context.Background(), groups[0], storeDir, "alt.binaries.misc")
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, res.FilesMigrated, "a file failing verification must not count as migrated")
+	assert.Equal(t, 1, res.FilesFailed)
+	require.Len(t, res.Failures, 1)
+	assert.Contains(t, res.Failures[0], "verification")
+
+	// The .meta on disk is byte-identical to before the attempt.
+	afterBytes, err := os.ReadFile(metaPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalBytes, afterBytes, "failed file must be restored byte-for-byte")
+
+	// And it still reads as a working legacy file.
+	got, err := ms.ReadFileMetadata(vpath)
+	require.NoError(t, err)
+	require.Len(t, got.SegmentData, 2)
+	assert.Equal(t, "s1@n", got.SegmentData[0].Id)
+	assert.Empty(t, got.StoreRef)
+
+	// No orphan store is left behind when nothing migrated.
+	assert.Empty(t, res.StoreRef)
+	entries, readErr := os.ReadDir(storeDir)
+	if readErr == nil {
+		assert.Empty(t, entries, "orphaned store must be removed")
+	}
+}
+
+// TestMigrateGroup_VerificationRunsOnEveryFile guards against the check being
+// silently skipped: every migrated file must have been verified.
+func TestMigrateGroup_VerificationRunsOnEveryFile(t *testing.T) {
+	root := t.TempDir()
+	storeDir := t.TempDir()
+	ms := NewMetadataService(root)
+
+	for _, name := range []string{"A.mkv", "B.mkv", "C.mkv"} {
+		require.NoError(t, ms.WriteFileMetadata(filepath.Join("movies", name), &metapb.FileMetadata{
+			FileSize: 100, SourceNzbPath: "/nzbs/rel.nzb",
+			SegmentData: []*metapb.SegmentData{{Id: name + "@n", SegmentSize: 100, EndOffset: 99}},
+		}))
+	}
+
+	var verified []string
+	restore := verifyMigratedFile
+	verifyMigratedFile = func(svc *MetadataService, virtualPath string, original *metapb.FileMetadata) error {
+		verified = append(verified, virtualPath)
+		return restore(svc, virtualPath, original)
+	}
+	t.Cleanup(func() { verifyMigratedFile = restore })
+
+	groups, err := ms.ScanLegacyMetas()
+	require.NoError(t, err)
+	res, err := ms.MigrateGroup(context.Background(), groups[0], storeDir, "alt.binaries.misc")
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, res.FilesMigrated)
+	assert.Len(t, verified, 3, "every migrated file must be verified against its pre-migration segments")
+}

--- a/internal/metadata/store.go
+++ b/internal/metadata/store.go
@@ -218,6 +218,29 @@ func (ss *StoreService) ReadStore(ref string) (*metapb.NzbStore, error) {
 	return store, nil
 }
 
+// ReadStoreUncached reads and decompresses a store straight from disk, ignoring
+// the cache and without populating it.
+//
+// WriteStore adds the written store to the cache, and ReadStore consults the
+// cache first, so a read-back immediately after a write is served from memory
+// and proves nothing about what actually landed on disk. Post-write integrity
+// checks must use this instead.
+func (ss *StoreService) ReadStoreUncached(ref string) (*metapb.NzbStore, error) {
+	compressed, err := os.ReadFile(ref)
+	if err != nil {
+		return nil, fmt.Errorf("read store %q: %w", ref, err)
+	}
+	raw, err := ss.decoder.DecodeAll(compressed, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decompress store: %w", err)
+	}
+	store := &metapb.NzbStore{}
+	if err := proto.Unmarshal(raw, store); err != nil {
+		return nil, fmt.Errorf("unmarshal store: %w", err)
+	}
+	return store, nil
+}
+
 // FlatSegments returns all segments in flat order: files in order, each file's
 // segments in the order they appear (sorted by number at import time).
 func FlatSegments(store *metapb.NzbStore) []*metapb.NzbSeg {

--- a/internal/metadata/store_uncached_test.go
+++ b/internal/metadata/store_uncached_test.go
@@ -1,0 +1,56 @@
+package metadata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReadStoreUncached_ActuallyHitsDisk guards the post-write integrity check.
+// WriteStore populates the cache and ReadStore consults it first, so a cached
+// read proves only that the in-memory object still exists — it would happily
+// pass even if the bytes on disk were truncated or never landed.
+func TestReadStoreUncached_ActuallyHitsDisk(t *testing.T) {
+	ss := NewStoreService(t.TempDir())
+	ref := filepath.Join(t.TempDir(), "rel.nzbz")
+
+	store := &metapb.NzbStore{Files: []*metapb.NzbFileEntry{
+		{Subject: "A.mkv", Segments: []*metapb.NzbSeg{{Id: "a@n", Number: 1, Bytes: 100}}},
+	}}
+	require.NoError(t, ss.WriteStore(ref, store))
+
+	// Corrupt the file on disk. The cache still holds the good object.
+	require.NoError(t, os.WriteFile(ref, []byte("not zstd"), 0644))
+
+	cached, err := ss.ReadStore(ref)
+	require.NoError(t, err, "cached read succeeds and therefore proves nothing about disk")
+	require.Len(t, cached.Files, 1)
+
+	_, err = ss.ReadStoreUncached(ref)
+	require.Error(t, err, "an uncached read must surface the corruption")
+	assert.Contains(t, err.Error(), "decompress")
+}
+
+// TestReadStoreUncached_DoesNotPolluteCache keeps the verification read from
+// evicting live entries or masking a later corruption.
+func TestReadStoreUncached_DoesNotPolluteCache(t *testing.T) {
+	ss := NewStoreService(t.TempDir())
+	ref := filepath.Join(t.TempDir(), "rel.nzbz")
+
+	store := &metapb.NzbStore{Files: []*metapb.NzbFileEntry{
+		{Subject: "A.mkv", Segments: []*metapb.NzbSeg{{Id: "a@n", Number: 1, Bytes: 100}}},
+	}}
+	require.NoError(t, ss.WriteStore(ref, store))
+	ss.purgeCache()
+
+	got, err := ss.ReadStoreUncached(ref)
+	require.NoError(t, err)
+	require.Len(t, got.Files, 1)
+
+	_, cached := ss.cacheGet(ref)
+	assert.False(t, cached, "an uncached read must not populate the cache")
+}

--- a/internal/nzbfilesystem/migration_encrypted_nested_test.go
+++ b/internal/nzbfilesystem/migration_encrypted_nested_test.go
@@ -1,0 +1,247 @@
+package nzbfilesystem
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"path/filepath"
+	"testing"
+
+	aescipher "github.com/javi11/altmount/internal/encryption/aes"
+	"github.com/javi11/altmount/internal/metadata"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/altmount/internal/testsupport/segments"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// migration_encrypted_nested_test.go extends the streaming migration coverage to
+// the two shapes that carry the most migration risk:
+//
+//   - AES-encrypted files, where aes_key / aes_iv must survive the rewrite and
+//     the decrypting reader must still see byte-identical ciphertext.
+//   - Nested-RAR files, where nested_sources[].segments become segment_refs and
+//     — the interesting part — a legacy shared_outer_sources dedup is *dissolved*
+//     by the migration, so each nested source becomes self-contained. That is a
+//     structural change to the metadata, not just a re-encoding, which makes it
+//     the case most likely to break silently.
+//
+// Every test streams real bytes through MetadataVirtualFile before and after the
+// real MigrationWorker runs, and compares them.
+
+var (
+	testAESKey = []byte("0123456789abcdef") // AES-128
+	testAESIV  = []byte("fedcba9876543210")
+)
+
+// encryptCBC returns AES-CBC ciphertext for block-aligned plaintext.
+func encryptCBC(t testing.TB, plaintext []byte) []byte {
+	t.Helper()
+	require.Zero(t, len(plaintext)%aescipher.BlockSize, "fixture plaintext must be block aligned")
+	block, err := aes.NewCipher(testAESKey)
+	require.NoError(t, err)
+	out := make([]byte, len(plaintext))
+	cipher.NewCBCEncrypter(block, testAESIV).CryptBlocks(out, plaintext)
+	return out
+}
+
+// plainPattern builds deterministic, non-repeating plaintext of size n.
+func plainPattern(n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = byte((i*7 + 13) % 251)
+	}
+	return out
+}
+
+// serveBytes splits payload across n segments of segSize and teaches the
+// fakepool to serve each one under its canonical message-ID.
+func serveBytes(fp *fakepool.Client, payload []byte, segSize int) []*metapb.SegmentData {
+	var segs []*metapb.SegmentData
+	for i := 0; i*segSize < len(payload); i++ {
+		end := (i + 1) * segSize
+		if end > len(payload) {
+			end = len(payload)
+		}
+		chunk := payload[i*segSize : end]
+		id := segments.MessageID(i)
+		fp.SetBehavior(id, fakepool.SegmentBehavior{Bytes: chunk})
+		segs = append(segs, &metapb.SegmentData{
+			Id:          id,
+			SegmentSize: int64(len(chunk)),
+			StartOffset: 0,
+			EndOffset:   int64(len(chunk) - 1),
+		})
+	}
+	return segs
+}
+
+// mvfWithCipher is mvfFromMeta plus a real AES cipher, needed by any file whose
+// metadata (or nested source) carries an AES key.
+func mvfWithCipher(t testing.TB, ctx context.Context, fp *fakepool.Client, name string, m *metapb.FileMetadata) *MetadataVirtualFile {
+	t.Helper()
+	mvf := mvfFromMeta(t, ctx, fp, name, m)
+	mvf.aesCipher = aescipher.NewAesCipher()
+	return mvf
+}
+
+func TestMigration_AESEncryptedFileStillDecryptsAfterMigration(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	configDir := t.TempDir()
+	ms := metadata.NewMetadataService(root)
+
+	// 256 bytes of plaintext, encrypted, served as two 128-byte segments.
+	plaintext := plainPattern(256)
+	fp := fakepool.New()
+	segs := serveBytes(fp, encryptCBC(t, plaintext), 128)
+	require.Len(t, segs, 2)
+
+	vpath := filepath.Join("movies", "Encrypted.mkv")
+	require.NoError(t, ms.WriteFileMetadata(vpath, &metapb.FileMetadata{
+		FileSize:      int64(len(plaintext)),
+		Status:        metapb.FileStatus_FILE_STATUS_HEALTHY,
+		SourceNzbPath: filepath.Join(configDir, "encrypted.nzb"),
+		Encryption:    metapb.Encryption_AES,
+		AesKey:        testAESKey,
+		AesIv:         testAESIV,
+		SegmentData:   segs,
+	}))
+
+	preMeta, err := ms.ReadFileMetadata(vpath)
+	require.NoError(t, err)
+	pre := streamAll(t, mvfWithCipher(t, ctx, fp, "aes-pre", preMeta), preMeta.FileSize)
+	require.Equal(t, plaintext, pre, "pre-migration AES file must decrypt to the plaintext")
+
+	_ = runMigration(t, ctx, ms, configDir)
+
+	postMeta, err := ms.ReadFileMetadata(vpath)
+	require.NoError(t, err)
+	require.NotEmpty(t, postMeta.StoreRef)
+	// The key material must survive the rewrite untouched.
+	assert.Equal(t, testAESKey, postMeta.AesKey, "aes_key must survive migration")
+	assert.Equal(t, testAESIV, postMeta.AesIv, "aes_iv must survive migration")
+	assert.Equal(t, metapb.Encryption_AES, postMeta.Encryption)
+
+	post := streamAll(t, mvfWithCipher(t, ctx, fp, "aes-post", postMeta), postMeta.FileSize)
+	assert.Equal(t, pre, post, "AES file must stream identically after migration")
+	assert.Equal(t, plaintext, post, "AES file must still decrypt to the plaintext")
+}
+
+func TestMigration_NestedSharedOuterSourcesStillStreams(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	configDir := t.TempDir()
+	ms := metadata.NewMetadataService(root)
+
+	// One outer "RAR volume" of 512 bytes served as four 128-byte segments. The
+	// virtual file is two extents of that volume, both reading through a single
+	// shared_outer_sources entry — the layout the Blu-ray dedup produces.
+	volume := plainPattern(512)
+	fp := fakepool.New()
+	outerSegs := serveBytes(fp, volume, 128)
+	require.Len(t, outerSegs, 4)
+
+	// Extent 1: volume[64:192]. Extent 2: volume[320:448]. Concatenated = file.
+	expected := append(append([]byte{}, volume[64:192]...), volume[320:448]...)
+
+	vpath := filepath.Join("movies", "Nested.m2ts")
+	require.NoError(t, ms.WriteFileMetadata(vpath, &metapb.FileMetadata{
+		FileSize:      int64(len(expected)),
+		Status:        metapb.FileStatus_FILE_STATUS_HEALTHY,
+		SourceNzbPath: filepath.Join(configDir, "nested.nzb"),
+		SharedOuterSources: []*metapb.NestedSegmentSource{
+			{Segments: outerSegs, InnerVolumeSize: int64(len(volume))},
+		},
+		NestedSources: []*metapb.NestedSegmentSource{
+			{SharedOuterSourceIndex: 1, InnerOffset: 64, InnerLength: 128},
+			{SharedOuterSourceIndex: 1, InnerOffset: 320, InnerLength: 128},
+		},
+	}))
+
+	preMeta, err := ms.ReadFileMetadata(vpath)
+	require.NoError(t, err)
+	// The read path expects nested sources hydrated; production does this too.
+	require.NoError(t, metadata.ExpandSharedOuterSources(preMeta))
+	pre := streamAll(t, mvfFromMeta(t, ctx, fp, "nested-pre", preMeta), preMeta.FileSize)
+	require.Equal(t, expected, pre, "pre-migration nested file must stream both extents")
+
+	_ = runMigration(t, ctx, ms, configDir)
+
+	postMeta, err := ms.ReadFileMetadata(vpath)
+	require.NoError(t, err)
+	require.NotEmpty(t, postMeta.StoreRef)
+
+	// Migration dissolves the dedup: each nested source is self-contained, and
+	// shared_outer_sources is gone from disk.
+	assert.Empty(t, postMeta.SharedOuterSources, "the dedup must be dissolved by migration")
+	require.Len(t, postMeta.NestedSources, 2)
+	for i, ns := range postMeta.NestedSources {
+		assert.Zero(t, ns.SharedOuterSourceIndex, "nested source %d must no longer reference a shared entry", i)
+		assert.Len(t, ns.Segments, len(outerSegs), "nested source %d must carry its own resolved segments", i)
+	}
+
+	post := streamAll(t, mvfFromMeta(t, ctx, fp, "nested-post", postMeta), postMeta.FileSize)
+	assert.Equal(t, pre, post, "nested file must stream identically after migration")
+	assert.Equal(t, expected, post)
+}
+
+func TestMigration_NestedEncryptedSourceStillDecryptsAfterMigration(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	configDir := t.TempDir()
+	ms := metadata.NewMetadataService(root)
+
+	// An encrypted inner volume: 512 bytes of plaintext, AES-CBC encrypted and
+	// served as four 128-byte segments. The file is one extent, volume[128:384].
+	volumePlain := plainPattern(512)
+	fp := fakepool.New()
+	outerSegs := serveBytes(fp, encryptCBC(t, volumePlain), 128)
+	require.Len(t, outerSegs, 4)
+
+	expected := volumePlain[128:384]
+
+	vpath := filepath.Join("movies", "NestedEnc.mkv")
+	require.NoError(t, ms.WriteFileMetadata(vpath, &metapb.FileMetadata{
+		FileSize:      int64(len(expected)),
+		Status:        metapb.FileStatus_FILE_STATUS_HEALTHY,
+		SourceNzbPath: filepath.Join(configDir, "nestedenc.nzb"),
+		NestedSources: []*metapb.NestedSegmentSource{
+			{
+				Segments:        outerSegs,
+				AesKey:          testAESKey,
+				AesIv:           testAESIV,
+				InnerOffset:     128,
+				InnerLength:     int64(len(expected)),
+				InnerVolumeSize: int64(len(volumePlain)),
+			},
+		},
+	}))
+
+	preMeta, err := ms.ReadFileMetadata(vpath)
+	require.NoError(t, err)
+	pre := streamAll(t, mvfWithCipher(t, ctx, fp, "nestedenc-pre", preMeta), preMeta.FileSize)
+	require.Equal(t, expected, pre, "pre-migration encrypted nested source must decrypt")
+
+	_ = runMigration(t, ctx, ms, configDir)
+
+	postMeta, err := ms.ReadFileMetadata(vpath)
+	require.NoError(t, err)
+	require.NotEmpty(t, postMeta.StoreRef)
+	require.Len(t, postMeta.NestedSources, 1)
+
+	ns := postMeta.NestedSources[0]
+	assert.Equal(t, testAESKey, ns.AesKey, "nested aes_key must survive migration")
+	assert.Equal(t, testAESIV, ns.AesIv, "nested aes_iv must survive migration")
+	assert.EqualValues(t, len(volumePlain), ns.InnerVolumeSize, "inner_volume_size must survive migration")
+	assert.EqualValues(t, 128, ns.InnerOffset)
+	assert.EqualValues(t, len(expected), ns.InnerLength)
+
+	post := streamAll(t, mvfWithCipher(t, ctx, fp, "nestedenc-post", postMeta), postMeta.FileSize)
+	assert.Equal(t, pre, post, "encrypted nested source must stream identically after migration")
+	assert.Equal(t, expected, post)
+	assert.False(t, bytes.Equal(post, encryptCBC(t, volumePlain)[128:384]),
+		"sanity: the stream must be plaintext, not ciphertext")
+}

--- a/internal/nzbfilesystem/migration_streaming_integration_test.go
+++ b/internal/nzbfilesystem/migration_streaming_integration_test.go
@@ -1,0 +1,241 @@
+package nzbfilesystem
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/metadata"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/altmount/internal/testsupport/segments"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// migration_streaming_integration_test.go answers the question the unit tests in
+// internal/metadata cannot: after a legacy library is migrated to the v3 shared
+// NZB store, do the old releases still *stream* — byte for byte, through the
+// real read path — rather than merely resolving to equal metadata?
+//
+// The test writes genuine v1 metadata (MetadataService.WriteFileMetadata with no
+// StoreRef emits exactly the pre-v3 on-disk format), streams every file to
+// completion through MetadataVirtualFile against a fake NNTP pool, runs the real
+// MigrationWorker, then streams the same files again from the rewritten .meta
+// files and compares the bytes.
+
+const (
+	itSegSize  = 128
+	itSegCount = 6
+)
+
+// mvfFromMeta builds a MetadataVirtualFile over an already-resolved metadata,
+// mirroring newTestMVF but taking its segments from a real .meta read off disk.
+func mvfFromMeta(t testing.TB, ctx context.Context, fp *fakepool.Client, name string, m *metapb.FileMetadata) *MetadataVirtualFile {
+	t.Helper()
+	mvf := &MetadataVirtualFile{
+		name: name,
+		meta: &fileHandleMeta{
+			FileSize:      m.FileSize,
+			ModifiedAt:    m.ModifiedAt,
+			SourceNzbPath: m.SourceNzbPath,
+			Encryption:    m.Encryption,
+			AesKey:        m.AesKey,
+			AesIv:         m.AesIv,
+			SegmentData:   m.SegmentData,
+			NestedSources: m.NestedSources,
+			KnownHoles:    m.KnownHoles,
+		},
+		poolManager:      newFakePoolManager(fp),
+		ctx:              ctx,
+		maxPrefetch:      4,
+		originalRangeEnd: -1,
+		streamTracker:    noopStreamTracker{},
+		streamID:         "integration-stream",
+	}
+	t.Cleanup(func() { _ = mvf.Close() })
+	return mvf
+}
+
+// streamAll reads the whole virtual file through ReadAt, the way a player would.
+func streamAll(t testing.TB, mvf *MetadataVirtualFile, size int64) []byte {
+	t.Helper()
+	buf := make([]byte, size)
+	n, err := mvf.ReadAt(buf, 0)
+	require.NoError(t, err)
+	require.EqualValues(t, size, n)
+	return buf
+}
+
+// slicedExpected is the payload an archive-sliced (partial-offset) file yields.
+func slicedExpected() []byte {
+	out := make([]byte, 0, 276)
+	out = append(out, segments.Payload(2, itSegSize)[40:]...)
+	out = append(out, segments.Payload(3, itSegSize)...)
+	out = append(out, segments.Payload(4, itSegSize)[:60]...)
+	return out
+}
+
+// runMigration executes the real worker and waits for it to finish.
+func runMigration(t *testing.T, ctx context.Context, ms *metadata.MetadataService, configDir string) *metadata.MigrationResult {
+	t.Helper()
+	cfg := &config.Config{}
+	cfg.Database.Path = filepath.Join(configDir, "altmount.db")
+	cfg.Metadata.Migration.DefaultGroup = "alt.binaries.misc"
+
+	worker := metadata.NewMigrationWorker(ms, func() *config.Config { return cfg })
+	require.NoError(t, worker.Start(ctx))
+	require.Eventually(t, func() bool {
+		s := worker.GetStatus()
+		return !s.IsRunning && s.LastResult != nil
+	}, 15*time.Second, 20*time.Millisecond, "migration should finish")
+
+	result := worker.GetStatus().LastResult
+	require.NotNil(t, result)
+	require.Equal(t, 0, result.FilesFailed, "no file may fail to migrate: %v", result.Failures)
+	return result
+}
+
+func TestMigration_LegacyReleaseStillStreamsByteForByte(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	configDir := t.TempDir()
+
+	ms := metadata.NewMetadataService(root)
+
+	fp := fakepool.New()
+	configurePoolForFile(fp, itSegCount, itSegSize, fakepool.SegmentBehavior{})
+
+	// Seed a legacy (v1, inline-segment) release: one plain file that will
+	// compact into segment_runs, and one archive-sliced file that must keep
+	// explicit refs with its partial offsets intact.
+	plainPath := filepath.Join("movies", "Plain.mkv")
+	slicedPath := filepath.Join("movies", "Sliced.mkv")
+	sourceNzb := filepath.Join(configDir, "release.nzb") // absent → synthesized store
+
+	plainSegs := make([]*metapb.SegmentData, itSegCount)
+	for i := range plainSegs {
+		plainSegs[i] = &metapb.SegmentData{
+			Id: segments.MessageID(i), SegmentSize: itSegSize, StartOffset: 0, EndOffset: itSegSize - 1,
+		}
+	}
+	require.NoError(t, ms.WriteFileMetadata(plainPath, &metapb.FileMetadata{
+		FileSize:      int64(itSegCount * itSegSize),
+		Status:        metapb.FileStatus_FILE_STATUS_HEALTHY,
+		SourceNzbPath: sourceNzb,
+		SegmentData:   plainSegs,
+	}))
+
+	slicedSegs := []*metapb.SegmentData{
+		{Id: segments.MessageID(2), SegmentSize: itSegSize, StartOffset: 40, EndOffset: itSegSize - 1},
+		{Id: segments.MessageID(3), SegmentSize: itSegSize, StartOffset: 0, EndOffset: itSegSize - 1},
+		{Id: segments.MessageID(4), SegmentSize: itSegSize, StartOffset: 0, EndOffset: 59},
+	}
+	require.NoError(t, ms.WriteFileMetadata(slicedPath, &metapb.FileMetadata{
+		FileSize:      276,
+		Status:        metapb.FileStatus_FILE_STATUS_HEALTHY,
+		SourceNzbPath: sourceNzb,
+		SegmentData:   slicedSegs,
+	}))
+
+	// --- Stream both files BEFORE migration.
+	preMetaPlain, err := ms.ReadFileMetadata(plainPath)
+	require.NoError(t, err)
+	preMetaSliced, err := ms.ReadFileMetadata(slicedPath)
+	require.NoError(t, err)
+
+	prePlain := streamAll(t, mvfFromMeta(t, ctx, fp, "plain-pre", preMetaPlain), preMetaPlain.FileSize)
+	preSliced := streamAll(t, mvfFromMeta(t, ctx, fp, "sliced-pre", preMetaSliced), preMetaSliced.FileSize)
+
+	// Sanity: the pre-migration stream really is the expected content.
+	assert.Equal(t, segments.FileBytes(itSegCount, itSegSize), prePlain,
+		"pre-migration plain file must stream the injected payload")
+	assert.Equal(t, slicedExpected(), preSliced,
+		"pre-migration sliced file must stream its partial ranges")
+
+	// --- Run the REAL migration worker, exactly as the panel button does.
+	result := runMigration(t, ctx, ms, configDir)
+	require.Equal(t, 2, result.FilesMigrated)
+
+	// The on-disk metadata really is v3 now, and the shared store exists.
+	rawPlain, err := os.ReadFile(filepath.Join(root, "movies", "Plain.mkv.meta"))
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x00, 'A', 'M', '3', 0x01}, rawPlain[:5], "meta must carry the v3 magic")
+
+	entries, err := os.ReadDir(filepath.Join(configDir, ".nzbs", "_migrated"))
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "both files share one .nzbz store")
+
+	// --- Stream both files AFTER migration, resolving through the store.
+	postMetaPlain, err := ms.ReadFileMetadata(plainPath)
+	require.NoError(t, err)
+	postMetaSliced, err := ms.ReadFileMetadata(slicedPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, postMetaPlain.StoreRef, "migrated meta points at the store")
+
+	postPlain := streamAll(t, mvfFromMeta(t, ctx, fp, "plain-post", postMetaPlain), postMetaPlain.FileSize)
+	postSliced := streamAll(t, mvfFromMeta(t, ctx, fp, "sliced-post", postMetaSliced), postMetaSliced.FileSize)
+
+	// The whole point: old releases stream identically after migration.
+	assert.Equal(t, prePlain, postPlain, "plain file must stream identically after migration")
+	assert.Equal(t, preSliced, postSliced, "archive-sliced file must stream identically after migration")
+	assert.Equal(t, segments.FileBytes(itSegCount, itSegSize), postPlain)
+	assert.Equal(t, slicedExpected(), postSliced)
+}
+
+func TestMigration_PartialRangeReadsMatchAfterMigration(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	configDir := t.TempDir()
+	ms := metadata.NewMetadataService(root)
+
+	fp := fakepool.New()
+	configurePoolForFile(fp, itSegCount, itSegSize, fakepool.SegmentBehavior{})
+
+	vpath := filepath.Join("movies", "Seek.mkv")
+	segs := make([]*metapb.SegmentData, itSegCount)
+	for i := range segs {
+		segs[i] = &metapb.SegmentData{
+			Id: segments.MessageID(i), SegmentSize: itSegSize, StartOffset: 0, EndOffset: itSegSize - 1,
+		}
+	}
+	require.NoError(t, ms.WriteFileMetadata(vpath, &metapb.FileMetadata{
+		FileSize:      int64(itSegCount * itSegSize),
+		Status:        metapb.FileStatus_FILE_STATUS_HEALTHY,
+		SourceNzbPath: filepath.Join(configDir, "seek.nzb"),
+		SegmentData:   segs,
+	}))
+
+	// Mid-file seeks are where a wrong flat index would surface first.
+	offsets := []int64{0, 1, 127, 128, 200, 511, 640}
+	readAtOffset := func(m *metapb.FileMetadata, off int64) []byte {
+		mvf := mvfFromMeta(t, ctx, fp, "seek", m)
+		buf := make([]byte, 64)
+		n, err := mvf.ReadAt(buf, off)
+		require.NoError(t, err)
+		return buf[:n]
+	}
+
+	preMeta, err := ms.ReadFileMetadata(vpath)
+	require.NoError(t, err)
+	before := make(map[int64][]byte, len(offsets))
+	for _, off := range offsets {
+		before[off] = readAtOffset(preMeta, off)
+	}
+
+	_ = runMigration(t, ctx, ms, configDir)
+
+	postMeta, err := ms.ReadFileMetadata(vpath)
+	require.NoError(t, err)
+	require.NotEmpty(t, postMeta.StoreRef)
+
+	full := segments.FileBytes(itSegCount, itSegSize)
+	for _, off := range offsets {
+		got := readAtOffset(postMeta, off)
+		assert.Equal(t, before[off], got, "read at offset %d must be unchanged by migration", off)
+		assert.Equal(t, full[off:off+int64(len(got))], got, "read at offset %d must match the source payload", off)
+	}
+}


### PR DESCRIPTION
## Summary

Libraries imported before the v3 shared-`NzbStore` format (#701) still carry `.meta` files with inline `segment_data` — one `SegmentData` message per segment, per file. For a RAR release every virtual file repeats the same outer-volume segments, so the on-disk cost is O(files × segments). New imports already write v3; existing libraries never converted.

This adds a manually-triggered migration that converts legacy metas to v3, merging every file of a release onto one shared `.nzbz`.

**Measured savings on realistic releases: 95–96%.**

| Release shape | Before | After | Saved |
|---|---|---|---|
| 1 file, 10 segments | 640 B | 404 B | +37% |
| 3 files × 500 segments | 99 KB | 4.9 KB | **+95.1%** |
| 40 files × 200 segments | 536 KB | 18 KB | **+96.6%** |

A `.nzbz` has a fixed ~340-byte floor, so releases under ~8 segments grow slightly. This is accepted deliberately: everything migrates, keeping the library in one uniform format.

## How it works

Driven from **Settings → Metadata → Storage Migration**: *Dry Run* reports measured savings, then *Migrate* converts after a confirmation modal. Progress is live and cancellable. Nothing runs on startup.

Per release group:

1. **Group** legacy metas by `source_nzb_path`, falling back to the parent directory. v3 metas are skipped by magic prefix, which makes the whole thing idempotent and resumable.
2. **Build the store** — faithful from the surviving source `.nzb` when it still exists (real subjects, posters, groups, segment numbers), otherwise synthesized from the inline segments. The faithful path is only used if it covers *every* segment referenced by *every* meta in the group; a mismatched NZB falls back to synthesis.
3. **Write and verify** the `.nzbz` under `<configDir>/.nzbs/_migrated/`, read back before use.
4. **Repoint each meta** through the existing `WriteFileMetadataV3`, which converts main/PAR2/nested segments to refs+runs and increments the store refcount exactly once.

## Safety

- **Core invariant:** after migration `ReadFileMetadata` returns `segment_data` byte-identical to before — same ids, sizes, and archive-slicing offsets, in the same order — and likewise for PAR2 files and nested sources. Directly tested.
- **Store before metas, always.** A meta never names a `.nzbz` that isn't already written and verified.
- **Safe while serving.** Meta rewrites use the existing atomic tmp+rename; an in-flight stream has already resolved its segments in memory, and the next open reads v3 through the store.
- **Content-hashed store paths.** A cancelled or partially-failed group leaves some metas v3 and some v1; rebuilding that group later produces a different flat index, so overwriting the original store would silently corrupt already-migrated metas. Store filenames embed a SHA-256 of their segment ids, so this can't happen.
- **Bounded memory.** The scan reads each meta for its group key and discards the proto, hydrating only one release at a time. Retaining every legacy meta at once is the pattern behind the 7.94 GB spike documented at `service.go:405`.
- **Nothing is deleted**, and per-file failures leave that file as v1 and are reported.
- Paced at 100 ms between groups so a large library doesn't saturate disk mid-stream.

## Notes

- New config `metadata.migration.default_group` (default `alt.binaries.misc`). Legacy metas don't retain the original newsgroup, and `nzb.BuildNZB` would otherwise emit an empty `<groups>` element that most NZB clients reject. Faithful stores carry the real groups.
- `BuildStore` moved from `internal/importer/parser` to `internal/metadata` — store construction now lives with the store, and the migration avoids depending on the importer. Two call sites; no import cycle.

## Test plan

- [x] `go test ./...` — clean
- [x] `make test-race` — clean
- [x] `bun run check` and `bun run build` — clean
- [x] 16 new tests: round-trip invariant across plain/archive-sliced/PAR2/nested/`shared_outer_sources` shapes, run compaction, grouping and dir fallback, faithful path with `BuildNZB`→`nzbparser` round-trip, faithful pre-check rejection, refcount correctness, partial-run store isolation, idempotence, dry-run leaving the library untouched, concurrent-run rejection

⚠️ `make` stops at `golangci-lint`, which fails identically on base commit `4b42c675` — golangci-lint 2.8.0 cannot decode Go 1.27 stdlib export data (`export data version 4 is greater than maximum supported version 2`). Pre-existing toolchain mismatch, unrelated to this PR, worth a separate bump.

## Design docs

- `docs/superpowers/specs/2026-08-21-metadata-v1-to-v3-migration-design.md`
- `docs/superpowers/plans/2026-08-21-metadata-v3-migration.md`
