### PR TITLE
feat: deduplicate full-import health validation

### DIFF
--- a/cmd/altmount/cmd/setup.go
+++ b/cmd/altmount/cmd/setup.go
@@ -81,7 +81,8 @@ func initializeImporter(
 	}
 
 	serviceConfig := importer.ServiceConfig{
-		Workers: maxProcessorWorkers,
+		Workers:            maxProcessorWorkers,
+		CalculateNextCheck: health.CalculateNextCheck,
 	}
 
 	importerService, err := importer.NewService(serviceConfig, metadataService, db, poolManager, rcloneClient, configGetter, healthRepo, broadcaster, userRepo)

--- a/internal/database/health_fixes_test.go
+++ b/internal/database/health_fixes_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -333,4 +334,56 @@ func TestBatchAddFileToHealthCheck_PreservesRepairBudget(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, fresh, "new path normalized and inserted")
 	assert.Equal(t, HealthStatusPending, fresh.Status)
+}
+
+func TestBatchAddFileToHealthCheck_CoveredRecordsUseHealthyFutureBatches(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, retry_count, repair_retry_count, last_error, error_details)
+		VALUES ('pending-conflict.mkv', 'repair_triggered', 2, 4, 'old error', '{"old":true}'),
+		       ('covered-conflict.mkv', 'repair_triggered', 2, 4, 'old error', '{"old":true}')
+	`)
+	require.NoError(t, err)
+
+	future := time.Now().UTC().Add(2 * time.Hour)
+	records := []HealthCheckUpsert{
+		{FilePath: "pending-conflict.mkv", MaxRetries: 3, MaxRepairRetries: 5},
+		{FilePath: "covered-conflict.mkv", MaxRetries: 3, MaxRepairRetries: 5, InitialStatus: HealthStatusHealthy, ScheduledCheckAt: &future},
+	}
+	for i := 0; i < 95; i++ {
+		scheduled := future.Add(time.Duration(i+1) * time.Minute)
+		records = append(records, HealthCheckUpsert{
+			FilePath:         fmt.Sprintf("covered-%03d.mkv", i),
+			MaxRetries:       3,
+			MaxRepairRetries: 5,
+			InitialStatus:    HealthStatusHealthy,
+			ScheduledCheckAt: &scheduled,
+		})
+	}
+
+	require.NoError(t, repo.BatchAddFileToHealthCheck(ctx, records))
+
+	pending, err := repo.GetFileHealth(ctx, "pending-conflict.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, pending)
+	assert.Equal(t, HealthStatusPending, pending.Status)
+	assert.Equal(t, 4, pending.RepairRetryCount)
+
+	covered, err := repo.GetFileHealth(ctx, "covered-conflict.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, covered)
+	assert.Equal(t, HealthStatusHealthy, covered.Status)
+	assert.Equal(t, 0, covered.RepairRetryCount)
+	assert.Equal(t, 0, covered.RetryCount)
+	assert.Nil(t, covered.LastError)
+	assert.Nil(t, covered.ErrorDetails)
+	require.NotNil(t, covered.LastChecked)
+
+	scheduled := scheduledCheckAt(t, repo, "covered-conflict.mkv")
+	require.True(t, scheduled.Valid)
+	scheduledAt, err := time.Parse(time.RFC3339, scheduled.String)
+	require.NoError(t, err)
+	assert.True(t, scheduledAt.After(time.Now().UTC()))
 }

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -732,6 +732,8 @@ type HealthCheckUpsert struct {
 	ReleaseDate      *time.Time
 	Metadata         *string
 	DownloadID       *string
+	InitialStatus    HealthStatus
+	ScheduledCheckAt *time.Time
 }
 
 // BatchAddFileToHealthCheck upserts many health records in a few multi-row statements
@@ -744,27 +746,43 @@ func (r *HealthRepository) BatchAddFileToHealthCheck(ctx context.Context, record
 		return nil
 	}
 
-	// 10 bound params per row; keep batches under SQLite's ~999 parameter limit.
-	const batchSize = 95
-
-	for i := 0; i < len(records); i += batchSize {
-		end := min(i+batchSize, len(records))
-		if err := r.batchUpsertFileHealthCheck(ctx, records[i:end]); err != nil {
-			return fmt.Errorf("failed to upsert health-check batch at index %d: %w", i, err)
+	pending := make([]HealthCheckUpsert, 0, len(records))
+	healthy := make([]HealthCheckUpsert, 0, len(records))
+	for _, record := range records {
+		switch record.InitialStatus {
+		case "", HealthStatusPending:
+			pending = append(pending, record)
+		case HealthStatusHealthy:
+			if record.ScheduledCheckAt == nil || !record.ScheduledCheckAt.After(time.Now()) {
+				return fmt.Errorf("healthy health-check record requires a future scheduled check")
+			}
+			healthy = append(healthy, record)
+		default:
+			return fmt.Errorf("unsupported initial health status: %q", record.InitialStatus)
 		}
 	}
 
+	// Pending rows retain the existing 10-bind SQL and batch size.
+	const pendingBatchSize = 95
+	for i := 0; i < len(pending); i += pendingBatchSize {
+		end := min(i+pendingBatchSize, len(pending))
+		if err := r.batchUpsertFileHealthCheck(ctx, pending[i:end]); err != nil {
+			return fmt.Errorf("failed to upsert pending health-check batch at index %d: %w", i, err)
+		}
+	}
+
+	if err := r.batchUpsertHealthyFileHealthCheck(ctx, healthy); err != nil {
+		return err
+	}
 	return nil
 }
 
-// batchUpsertFileHealthCheck performs a single multi-row upsert.
+// batchUpsertFileHealthCheck performs a pending multi-row upsert.
 func (r *HealthRepository) batchUpsertFileHealthCheck(ctx context.Context, records []HealthCheckUpsert) error {
 	valueStrings := make([]string, len(records))
 	args := make([]any, 0, len(records)*10)
 
 	for i, rec := range records {
-		// status, retry_count and repair_retry_count are literals so excluded.status is
-		// always 'pending' (matching the single-row upsert's bound HealthStatusPending).
 		valueStrings[i] = "(?, ?, 'pending', datetime('now'), 0, ?, 0, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'), datetime('now'))"
 
 		var releaseDateStr any = nil
@@ -802,7 +820,63 @@ func (r *HealthRepository) batchUpsertFileHealthCheck(ctx context.Context, recor
 	if _, err := r.db.ExecContext(ctx, query, args...); err != nil {
 		return fmt.Errorf("failed to batch upsert file health checks: %w", err)
 	}
+	return nil
+}
 
+// batchUpsertHealthyFileHealthCheck initializes validated records as healthy.
+func (r *HealthRepository) batchUpsertHealthyFileHealthCheck(ctx context.Context, records []HealthCheckUpsert) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	const coveredBindsPerRow = 11
+	batchSize := 999 / coveredBindsPerRow
+	if batchSize <= 0 {
+		return fmt.Errorf("invalid covered health-check batch size")
+	}
+	for i := 0; i < len(records); i += batchSize {
+		end := min(i+batchSize, len(records))
+		valueStrings := make([]string, end-i)
+		args := make([]any, 0, (end-i)*coveredBindsPerRow)
+		for j, rec := range records[i:end] {
+			valueStrings[j] = "(?, ?, 'healthy', datetime('now'), 0, ?, 0, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'), ?)"
+			var releaseDateStr any = nil
+			if rec.ReleaseDate != nil {
+				releaseDateStr = rec.ReleaseDate.UTC().Format("2006-01-02 15:04:05")
+			}
+			args = append(args,
+				normalizeHealthPath(rec.FilePath), rec.LibraryPath,
+				rec.MaxRetries, rec.MaxRepairRetries,
+				rec.SourceNzbPath, rec.Priority, releaseDateStr, rec.Metadata, rec.Indexer, rec.DownloadID,
+				rec.ScheduledCheckAt.UTC().Format("2006-01-02 15:04:05"))
+		}
+
+		query := fmt.Sprintf(`
+			INSERT INTO file_health (file_path, library_path, status, last_checked, retry_count, max_retries, repair_retry_count, max_repair_retries, source_nzb_path, priority, release_date, metadata, indexer, download_id, created_at, updated_at, scheduled_check_at)
+			VALUES %s
+			ON CONFLICT(file_path) DO UPDATE SET
+				library_path = COALESCE(excluded.library_path, library_path),
+				status = 'healthy',
+				last_checked = datetime('now'),
+				retry_count = 0,
+				repair_retry_count = 0,
+				last_error = NULL,
+				error_details = NULL,
+				max_retries = excluded.max_retries,
+				max_repair_retries = excluded.max_repair_retries,
+				source_nzb_path = COALESCE(excluded.source_nzb_path, source_nzb_path),
+				priority = excluded.priority,
+				release_date = COALESCE(excluded.release_date, release_date),
+				metadata = COALESCE(excluded.metadata, metadata),
+				indexer = COALESCE(excluded.indexer, indexer),
+				download_id = COALESCE(excluded.download_id, download_id),
+				updated_at = datetime('now'),
+				scheduled_check_at = excluded.scheduled_check_at
+		`, strings.Join(valueStrings, ","))
+		if _, err := r.db.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("failed to batch upsert healthy file health checks: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/internal/health/checker_batch_test.go
+++ b/internal/health/checker_batch_test.go
@@ -5,7 +5,11 @@ import (
 	"fmt"
 	"runtime"
 	"testing"
+	"time"
 
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/importer/postprocessor"
+	"github.com/javi11/altmount/internal/importer/validation"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/pool"
 	"github.com/javi11/altmount/internal/testsupport/fakepool"
@@ -69,6 +73,91 @@ func writeHealthyFile(t *testing.T, env *repairTestEnv, filePath string) string 
 	)
 	require.NoError(t, env.metadataService.WriteFileMetadata(filePath, meta))
 	return seg.Id
+}
+
+func TestFullImportValidationSkipsImmediateHealthStat(t *testing.T) {
+	client := fakepool.New()
+	env := newBatchTestEnv(t, t.TempDir(), client)
+	ctx := context.Background()
+	filePath := "complete/import.mkv"
+	segmentID := writeHealthyFile(t, env, filePath)
+
+	missing, err := validation.FastFailReleaseProbe(ctx, []validation.FastFailFile{{
+		Filename: filePath,
+		Segments: []*metapb.SegmentData{{Id: segmentID}},
+	}}, &fakeClientPoolManager{client: client}, 100, 1, time.Second)
+	require.NoError(t, err)
+	assert.False(t, missing)
+
+	coordinator := postprocessor.NewCoordinator(postprocessor.Config{
+		ConfigGetter:       env.hw.configGetter,
+		MetadataService:    env.metadataService,
+		HealthRepo:         env.healthRepo,
+		CalculateNextCheck: CalculateNextCheck,
+	})
+	receipt := validation.NewFullValidationReceipt([]string{segmentID})
+	require.NoError(t, coordinator.ScheduleHealthCheck(ctx, nil, filePath, []string{filePath}, receipt))
+	require.NoError(t, env.hw.runHealthCheckCycle(ctx))
+	assert.Equal(t, int64(1), client.StatCalls(), "the immediate health cycle must not repeat the import STAT")
+
+	health, err := env.healthRepo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, health)
+	assert.Equal(t, database.HealthStatusHealthy, health.Status)
+
+	var scheduledAt time.Time
+	require.NoError(t, env.db.QueryRow(
+		"SELECT scheduled_check_at FROM file_health WHERE file_path = ?", filePath,
+	).Scan(&scheduledAt))
+	assert.True(t, scheduledAt.After(time.Now().UTC()))
+}
+
+func TestFullImportValidationReceiptFallsBackWhenAbsentOrMismatched(t *testing.T) {
+	tests := []struct {
+		name    string
+		receipt func(segmentID string) *validation.FullValidationReceipt
+	}{
+		{
+			name: "receipt absent",
+			receipt: func(string) *validation.FullValidationReceipt {
+				return nil
+			},
+		},
+		{
+			name: "receipt does not cover current metadata",
+			receipt: func(string) *validation.FullValidationReceipt {
+				return validation.NewFullValidationReceipt([]string{"previous-import@test.example.com"})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fakepool.New()
+			env := newBatchTestEnv(t, t.TempDir(), client)
+			ctx := context.Background()
+			filePath := "complete/import.mkv"
+			segmentID := writeHealthyFile(t, env, filePath)
+
+			missing, err := validation.FastFailReleaseProbe(ctx, []validation.FastFailFile{{
+				Filename: filePath,
+				Segments: []*metapb.SegmentData{{Id: segmentID}},
+			}}, &fakeClientPoolManager{client: client}, 100, 1, time.Second)
+			require.NoError(t, err)
+			assert.False(t, missing)
+
+			coordinator := postprocessor.NewCoordinator(postprocessor.Config{
+				ConfigGetter:       env.hw.configGetter,
+				MetadataService:    env.metadataService,
+				HealthRepo:         env.healthRepo,
+				CalculateNextCheck: CalculateNextCheck,
+			})
+			receipt := tt.receipt(segmentID)
+			require.NoError(t, coordinator.ScheduleHealthCheck(ctx, nil, filePath, []string{filePath}, receipt))
+			require.NoError(t, env.hw.runHealthCheckCycle(ctx))
+			assert.Equal(t, int64(2), client.StatCalls(), "an uncovered import must be checked by health immediately")
+		})
+	}
 }
 
 func TestCheckFilesBatch(t *testing.T) {

--- a/internal/importer/battery_helpers_test.go
+++ b/internal/importer/battery_helpers_test.go
@@ -100,22 +100,24 @@ func (e *batteryEnv) registerContent(
 func (e *batteryEnv) runImport(nzb *nzbparser.Nzb, name string) (string, []string, error) {
 	e.t.Helper()
 	nzbPath := nzbbuild.WriteTemp(e.t, nzb, name)
-	return e.proc.ProcessNzbFile(
+	result, paths, _, err := e.proc.ProcessNzbFile(
 		context.Background(),
 		nzbPath, filepath.Dir(nzbPath),
 		1, nil, nil, nil, nil, nil, nil,
 	)
+	return result, paths, err
 }
 
 // runImportWithCategory is like runImport but passes queueID and category.
 func (e *batteryEnv) runImportWithCategory(nzb *nzbparser.Nzb, name string, queueID int, category string) (string, []string, error) {
 	e.t.Helper()
 	nzbPath := nzbbuild.WriteTemp(e.t, nzb, name)
-	return e.proc.ProcessNzbFile(
+	result, paths, _, err := e.proc.ProcessNzbFile(
 		context.Background(),
 		nzbPath, filepath.Dir(nzbPath),
 		queueID, nil, nil, nil, &category, nil, nil,
 	)
+	return result, paths, err
 }
 
 // readMeta reads and returns FileMetadata for a virtual path, fatal on error.

--- a/internal/importer/cleanup_test.go
+++ b/internal/importer/cleanup_test.go
@@ -287,15 +287,17 @@ func TestHandleFailure_CleansUpCachedPaths(t *testing.T) {
 
 	// Simulate what ProcessItem does: store the written path in the cache
 	var fakeItemID int64 = 99
-	svc.writtenPathsCache.Store(fakeItemID, []string{virtualPath})
+	svc.writtenPathsCache.Store(fakeItemID, processArtifact{paths: []string{virtualPath}})
 
 	// Confirm the cache entry exists
 	_, ok := svc.writtenPathsCache.Load(fakeItemID)
 	require.True(t, ok, "cache should contain the written paths before HandleFailure")
 
 	// Exercise the cache-retrieval + cleanup path (mirrors HandleFailure minus the DB call)
-	if paths, ok := svc.writtenPathsCache.LoadAndDelete(fakeItemID); ok {
-		svc.cleanupWrittenPaths(ctx, fakeItemID, paths.([]string))
+	if stored, ok := svc.writtenPathsCache.LoadAndDelete(fakeItemID); ok {
+		artifact, valid := stored.(processArtifact)
+		require.True(t, valid)
+		svc.cleanupWrittenPaths(ctx, fakeItemID, artifact.paths)
 	}
 
 	// Cache must be cleared
@@ -317,7 +319,7 @@ func TestProcessItem_StoresPaths_HandleSuccess_ClearsCache(t *testing.T) {
 	writeTestMeta(t, ms, virtualPath)
 
 	var fakeItemID int64 = 77
-	svc.writtenPathsCache.Store(fakeItemID, []string{virtualPath})
+	svc.writtenPathsCache.Store(fakeItemID, processArtifact{paths: []string{virtualPath}})
 
 	// Simulate HandleSuccess cache cleanup
 	svc.writtenPathsCache.Delete(fakeItemID)

--- a/internal/importer/postprocessor/coordinator.go
+++ b/internal/importer/postprocessor/coordinator.go
@@ -15,42 +15,46 @@ import (
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/errors"
+	"github.com/javi11/altmount/internal/importer/validation"
 	"github.com/javi11/altmount/internal/metadata"
 	"github.com/javi11/altmount/pkg/rclonecli"
 )
 
 // Coordinator orchestrates all post-import processing steps
 type Coordinator struct {
-	mu              sync.RWMutex
-	configGetter    config.ConfigGetter
-	metadataService *metadata.MetadataService
-	rcloneClient    rclonecli.RcloneRcClient
-	healthRepo      *database.HealthRepository
-	arrsService     *arrs.Service
-	userRepo        *database.UserRepository
-	log             *slog.Logger
+	mu                  sync.RWMutex
+	configGetter        config.ConfigGetter
+	metadataService     *metadata.MetadataService
+	rcloneClient        rclonecli.RcloneRcClient
+	healthRepo          *database.HealthRepository
+	calculateNextCheck  func(releaseDate, lastCheck time.Time) time.Time
+	arrsService         *arrs.Service
+	userRepo            *database.UserRepository
+	log                 *slog.Logger
 }
 
 // Config holds configuration for the Coordinator
 type Config struct {
-	ConfigGetter    config.ConfigGetter
-	MetadataService *metadata.MetadataService
-	RcloneClient    rclonecli.RcloneRcClient
-	HealthRepo      *database.HealthRepository
-	ArrsService     *arrs.Service
-	UserRepo        *database.UserRepository
+	ConfigGetter        config.ConfigGetter
+	MetadataService     *metadata.MetadataService
+	RcloneClient        rclonecli.RcloneRcClient
+	HealthRepo          *database.HealthRepository
+	CalculateNextCheck  func(releaseDate, lastCheck time.Time) time.Time
+	ArrsService         *arrs.Service
+	UserRepo            *database.UserRepository
 }
 
 // NewCoordinator creates a new post-processor coordinator
 func NewCoordinator(cfg Config) *Coordinator {
 	return &Coordinator{
-		configGetter:    cfg.ConfigGetter,
-		metadataService: cfg.MetadataService,
-		rcloneClient:    cfg.RcloneClient,
-		healthRepo:      cfg.HealthRepo,
-		arrsService:     cfg.ArrsService,
-		userRepo:        cfg.UserRepo,
-		log:             slog.Default().With("component", "postprocessor"),
+		configGetter:       cfg.ConfigGetter,
+		metadataService:    cfg.MetadataService,
+		rcloneClient:       cfg.RcloneClient,
+		healthRepo:         cfg.HealthRepo,
+		calculateNextCheck: cfg.CalculateNextCheck,
+		arrsService:        cfg.ArrsService,
+		userRepo:           cfg.UserRepo,
+		log:                slog.Default().With("component", "postprocessor"),
 	}
 }
 
@@ -81,7 +85,11 @@ type ProcessingResult struct {
 // HandleSuccess performs all post-processing for successful imports.
 // writtenPaths lists every virtual file the import wrote (nil falls back to
 // resultingPath); multi-file imports (season packs) get a per-file health check.
-func (c *Coordinator) HandleSuccess(ctx context.Context, item *database.ImportQueueItem, resultingPath string, writtenPaths []string) (*ProcessingResult, error) {
+func (c *Coordinator) HandleSuccess(ctx context.Context, item *database.ImportQueueItem, resultingPath string, writtenPaths []string, receipts ...*validation.FullValidationReceipt) (*ProcessingResult, error) {
+	var receipt *validation.FullValidationReceipt
+	if len(receipts) > 0 {
+		receipt = receipts[0]
+	}
 	c.mu.RLock()
 	rcloneClient := c.rcloneClient
 	arrsService := c.arrsService
@@ -130,7 +138,7 @@ func (c *Coordinator) HandleSuccess(ctx context.Context, item *database.ImportQu
 	}
 
 	// 4. Schedule health check
-	if err := c.ScheduleHealthCheck(ctx, item, resultingPath, writtenPaths); err != nil {
+	if err := c.ScheduleHealthCheck(ctx, item, resultingPath, writtenPaths, receipt); err != nil {
 		c.log.WarnContext(ctx, "Failed to schedule health check",
 			"path", resultingPath,
 			"error", err)

--- a/internal/importer/postprocessor/health_scheduler.go
+++ b/internal/importer/postprocessor/health_scheduler.go
@@ -6,10 +6,12 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/importer/parser/fileinfo"
+	"github.com/javi11/altmount/internal/importer/validation"
 )
 
 // maxDirExpansionDepth bounds the recursive walk of "DIR:" written-path entries.
@@ -23,7 +25,11 @@ const maxDirExpansionDepth = 8
 // way each episode gets verified right after import and a partially-dead pack
 // surfaces immediately. Single-file imports keep the old behavior (one check on
 // resultingPath).
-func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.ImportQueueItem, resultingPath string, writtenPaths []string) error {
+func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.ImportQueueItem, resultingPath string, writtenPaths []string, receipts ...*validation.FullValidationReceipt) error {
+	var receipt *validation.FullValidationReceipt
+	if len(receipts) > 0 {
+		receipt = receipts[0]
+	}
 	if c.healthRepo == nil {
 		return nil // Health checks not configured
 	}
@@ -94,6 +100,29 @@ func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.Im
 		// the batch outlive the loop and do not retain the proto message.
 		filePath := p
 		srcNzb := fileMeta.SourceNzbPath
+		var initialStatus database.HealthStatus
+		var scheduledCheckAt *time.Time
+		if receipt != nil && c.calculateNextCheck != nil && receipt.Covers(fileMeta) {
+			now := time.Now().UTC()
+			baseline := now
+			existing, lookupErr := c.healthRepo.GetFileHealth(ctx, filePath)
+			if lookupErr != nil {
+				lastErr = lookupErr
+			} else {
+				if existing != nil {
+					if existing.ReleaseDate != nil {
+						baseline = existing.ReleaseDate.UTC()
+					} else {
+						baseline = existing.CreatedAt.UTC()
+					}
+				}
+				nextCheck := c.calculateNextCheck(baseline, now)
+				if nextCheck.After(now) {
+					initialStatus = database.HealthStatusHealthy
+					scheduledCheckAt = &nextCheck
+				}
+			}
+		}
 		records = append(records, database.HealthCheckUpsert{
 			FilePath:         filePath,
 			LibraryPath:      &filePath,
@@ -103,6 +132,8 @@ func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.Im
 			MaxRetries:       cfg.GetMaxRetries(),
 			MaxRepairRetries: cfg.GetMaxRepairRetries(),
 			DownloadID:       downloadID,
+			InitialStatus:    initialStatus,
+			ScheduledCheckAt: scheduledCheckAt,
 		})
 		repairDirs[filepath.Dir(p)] = struct{}{}
 	}

--- a/internal/importer/postprocessor/health_scheduler_test.go
+++ b/internal/importer/postprocessor/health_scheduler_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/importer/validation"
 	"github.com/javi11/altmount/internal/metadata"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	_ "github.com/mattn/go-sqlite3"
@@ -170,6 +172,32 @@ func TestScheduleHealthCheck_PlainPathsUnchanged(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, h)
 	assert.Equal(t, database.HealthStatusPending, h.Status)
+}
+
+func TestScheduleHealthCheck_InitializesCoveredPathHealthy(t *testing.T) {
+	coordinator, ms, repo, db := setupSchedulerTest(t)
+	coordinator.calculateNextCheck = func(_, lastCheck time.Time) time.Time {
+		return lastCheck.Add(time.Hour)
+	}
+	ctx := context.Background()
+	filePath := "/tv/Covered.S01E01.mkv"
+	writeTestMetadata(t, ms, filePath)
+
+	receipt := validation.NewFullValidationReceipt([]string{"article-001@test.example.com"})
+	require.NoError(t, coordinator.ScheduleHealthCheck(ctx, nil, filePath, []string{filePath}, receipt))
+
+	health, err := repo.GetFileHealth(ctx, "tv/Covered.S01E01.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, health)
+	assert.Equal(t, database.HealthStatusHealthy, health.Status)
+	require.NotNil(t, health.LastChecked)
+
+	var scheduledAt sql.NullTime
+	require.NoError(t, db.QueryRow(
+		"SELECT scheduled_check_at FROM file_health WHERE file_path = ?", "tv/Covered.S01E01.mkv",
+	).Scan(&scheduledAt))
+	require.True(t, scheduledAt.Valid)
+	assert.True(t, scheduledAt.Time.After(time.Now().UTC()))
 }
 
 // TestScheduleHealthCheck_DisabledQueuesNothing verifies that with health checking

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -173,12 +173,12 @@ func (proc *Processor) checkCancellation(ctx context.Context) error {
 // preParseFastFail runs a per-file Stat-based reachability check against the raw NZB
 // before any Body fetches. PAR2 files and sidecars are never Stat-checked (they're
 // included regardless), so their segments are omitted from the sweep to avoid wasted
-// round-trips. Returns (brokenFileIndexes, knownMissingSegmentIDs, error).
+// round-trips. Returns (brokenFileIndexes, knownMissingSegmentIDs, fullValidationReceipt, error).
 // Both maps are nil when no pool is available.
 // Returns ErrNoFilesProcessed (wrapped) when all eligible regular files are broken.
-func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, cfg *config.Config, queueID int, category *string, downloadID *string) (map[int]struct{}, map[string]struct{}, error) {
+func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, cfg *config.Config, queueID int, category *string, downloadID *string) (map[int]struct{}, map[string]struct{}, *validation.FullValidationReceipt, error) {
 	if !proc.poolManager.HasPool() {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	// Build the fast-fail input index-aligned with n.Files. PAR2 files keep their
@@ -224,7 +224,7 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 		proc.validationTimeout,
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if !missing {
 		if proc.log != nil {
@@ -232,7 +232,18 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 				"files", len(fastFailFiles),
 				"duration", time.Since(probeStart))
 		}
-		return nil, nil, nil
+		if cfg.Import.SegmentSamplePercentage != 100 {
+			return nil, nil, nil, nil
+		}
+		var segmentIDs []string
+		for _, file := range fastFailFiles {
+			for _, segment := range file.Segments {
+				if segment != nil && segment.Id != "" {
+					segmentIDs = append(segmentIDs, segment.Id)
+				}
+			}
+		}
+		return nil, nil, validation.NewFullValidationReceipt(segmentIDs), nil
 	}
 
 	isStremioImport := (category != nil && *category == "stremio") || (downloadID != nil && strings.HasPrefix(*downloadID, "stremio:"))
@@ -242,7 +253,7 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 				"files", len(fastFailFiles),
 				"probe_duration", time.Since(probeStart))
 		}
-		return nil, nil, multifile.ErrNoFilesProcessed
+		return nil, nil, nil, multifile.ErrNoFilesProcessed
 	}
 
 	// Phase 2 (escalation): the probe found an unreachable segment, so map
@@ -273,11 +284,12 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 		fastFailTracker,
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	brokenIdx := make(map[int]struct{})
 	missingIDs := make(map[string]struct{})
+	var validatedIDs []string
 	eligibleRegularCount := 0
 	tolerant := cfg.GetImportDamagePolicyTolerant()
 
@@ -287,6 +299,13 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 
 		if !isPar2 {
 			eligibleRegularCount++
+		}
+		if cfg.Import.SegmentSamplePercentage == 100 && !result.Broken && !isPar2 && len(f.Segments) > 0 {
+			for _, segment := range f.Segments {
+				if segment.ID != "" {
+					validatedIDs = append(validatedIDs, segment.ID)
+				}
+			}
 		}
 
 		if result.Broken && !isPar2 {
@@ -329,11 +348,11 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 	// this equality is logical-unit accurate: it holds only when every RAR set and
 	// every standalone regular file is broken — nothing healthy remains to import.
 	if eligibleRegularCount > 0 && len(brokenIdx) == eligibleRegularCount {
-		return nil, nil, multifile.ErrNoFilesProcessed
+		return nil, nil, nil, multifile.ErrNoFilesProcessed
 	}
 
 	if len(brokenIdx) == 0 {
-		return nil, nil, nil
+		return nil, nil, validation.NewFullValidationReceipt(validatedIDs), nil
 	}
 
 	if proc.log != nil {
@@ -349,7 +368,7 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 			"eligible_files", eligibleRegularCount)
 	}
 
-	return brokenIdx, missingIDs, nil
+	return brokenIdx, missingIDs, validation.NewFullValidationReceipt(validatedIDs), nil
 }
 
 // longestSampledRun maps missing segment IDs back to their indices in the
@@ -391,17 +410,17 @@ func fastFailConcurrency(cfg *config.Config) int {
 }
 
 // ProcessNzbFile processes an NZB or STRM file maintaining the folder structure relative to relative path.
-// Returns (resultPath, writtenMetadataPaths, error). writtenMetadataPaths contains all virtual paths of
-// metadata files written to disk; it is populated even on partial failure so callers can clean up.
+// Returns (resultPath, writtenMetadataPaths, fullValidationReceipt, error). writtenMetadataPaths contains all virtual paths of
+// metadata files written to disk; it is populated even on partial failure so callers can clean them up.
 // Paths prefixed with "DIR:" indicate a metadata directory that should be removed entirely.
-func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePath string, queueID int, allowedExtensionsOverride *[]string, virtualDirOverride *string, extractedFiles []parser.ExtractedFileInfo, category *string, metadata *string, downloadID *string) (string, []string, error) {
+func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePath string, queueID int, allowedExtensionsOverride *[]string, virtualDirOverride *string, extractedFiles []parser.ExtractedFileInfo, category *string, metadata *string, downloadID *string) (string, []string, *validation.FullValidationReceipt, error) {
 	// Gate this import behind the pool admission controller so we can cap how
 	// many NZB imports run concurrently end-to-end and yield to streams under
 	// load. The Acquire is a no-op when no caps are configured.
 	if proc.poolManager != nil {
 		release, err := proc.poolManager.AcquireImportSlot(ctx)
 		if err != nil {
-			return "", nil, fmt.Errorf("import admission cancelled: %w", err)
+			return "", nil, nil, fmt.Errorf("import admission cancelled: %w", err)
 		}
 		defer release()
 	}
@@ -419,32 +438,33 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 	proc.updateProgressWithStage(queueID, 0, "Parsing NZB")
 	file, err := nzbfile.Open(filePath)
 	if err != nil {
-		return "", nil, NewNonRetryableError("failed to open file", err)
+		return "", nil, nil, NewNonRetryableError("failed to open file", err)
 	}
 	defer file.Close()
 
 	var parsed *parser.ParsedNzb
 	var brokenIdx map[int]struct{}
+	var validationReceipt *validation.FullValidationReceipt
 
 	// Determine file type and parse accordingly
 	if strings.HasSuffix(strings.ToLower(filePath), strmFileExtension) {
 		parsed, err = proc.strmParser.ParseStrmFile(file, filePath)
 		if err != nil {
-			return "", nil, NewNonRetryableError("failed to parse STRM file", err)
+			return "", nil, nil, NewNonRetryableError("failed to parse STRM file", err)
 		}
 
 		// Validate the parsed STRM
 		if err := proc.strmParser.ValidateStrmFile(parsed); err != nil {
-			return "", nil, NewNonRetryableError("STRM validation failed", err)
+			return "", nil, nil, NewNonRetryableError("STRM validation failed", err)
 		}
 	} else {
 		// Parse XML first — cheap, no network needed.
 		n, xmlErr := nzbparser.Parse(file)
 		if xmlErr != nil {
-			return "", nil, NewNonRetryableError("failed to parse NZB file", xmlErr)
+			return "", nil, nil, NewNonRetryableError("failed to parse NZB file", xmlErr)
 		}
 		if len(n.Files) == 0 {
-			return "", nil, NewNonRetryableError("NZB file contains no files", nil)
+			return "", nil, nil, NewNonRetryableError("NZB file contains no files", nil)
 		}
 
 		parser.SanitizeNzbFilenames(n)
@@ -453,9 +473,9 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 		proc.updateProgressWithStage(queueID, 0, "Checking segment availability")
 		var missingIDs map[string]struct{}
 		var fastFailErr error
-		brokenIdx, missingIDs, fastFailErr = proc.preParseFastFail(ctx, n, cfg, queueID, category, downloadID)
+		brokenIdx, missingIDs, validationReceipt, fastFailErr = proc.preParseFastFail(ctx, n, cfg, queueID, category, downloadID)
 		if fastFailErr != nil {
-			return "", nil, NewNonRetryableError("fast-fail segment check failed", fastFailErr)
+			return "", nil, nil, NewNonRetryableError("fast-fail segment check failed", fastFailErr)
 		}
 
 		parseTracker := progress.NewTracker(proc.broadcaster, queueID, 2, 10)
@@ -464,12 +484,12 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 			KnownMissingSegmentIDs: missingIDs,
 		})
 		if err != nil {
-			return "", nil, NewNonRetryableError("failed to parse NZB file", err)
+			return "", nil, nil, NewNonRetryableError("failed to parse NZB file", err)
 		}
 
 		// Validate the parsed NZB
 		if err := proc.parser.ValidateNzb(parsed); err != nil {
-			return "", nil, NewNonRetryableError("NZB validation failed", err)
+			return "", nil, nil, NewNonRetryableError("NZB validation failed", err)
 		}
 	}
 
@@ -482,7 +502,7 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 
 	// Check for cancellation after parsing
 	if err := proc.checkCancellation(ctx); err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 
 	// For NZB-based imports, ensure at least one NNTP provider is configured
@@ -493,7 +513,7 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 		if !proc.poolManager.HasPool() {
 			proc.log.WarnContext(ctx, "No NNTP providers configured, deferring item processing",
 				"file_path", filePath, "queue_id", queueID)
-			return "", nil, fmt.Errorf("no NNTP providers configured - item will be retried when providers are added")
+			return "", nil, nil, fmt.Errorf("no NNTP providers configured - item will be retried when providers are added")
 		}
 
 		// Doomed RAR/7z sets are excluded whole during fast-fail (set-level
@@ -528,7 +548,7 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 
 	// Check for cancellation before main processing
 	if err := proc.checkCancellation(ctx); err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 
 	// Step 5: Process based on file type
@@ -637,7 +657,7 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 			},
 		}, regularFiles, virtualDir, proc.getCleanNzbName(parsed.Path, queueID), parsed.Path, isoReleaseDate)
 		if isoErr != nil {
-			return "", writtenPaths, NewNonRetryableError("bare-ISO expansion failed", isoErr)
+			return "", writtenPaths, validationReceipt, NewNonRetryableError("bare-ISO expansion failed", isoErr)
 		}
 		writtenPaths = append(writtenPaths, isoWritten...)
 		regularFiles = expandedRegularFiles
@@ -649,7 +669,7 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 		// trigger spuriously.
 		if len(regularFiles) == 0 && len(archiveFiles) == 0 && len(isoWritten) > 0 {
 			proc.updateProgress(queueID, 100)
-			return isoWritten[0], writtenPaths, nil
+			return isoWritten[0], writtenPaths, validationReceipt, nil
 		}
 	}
 
@@ -680,7 +700,7 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 		result, dispatchPaths, err = proc.processSingleFile(ctx, virtualDir, regularFiles, par2Files, parsed.Path, queueID, allowedExtensions, category, metadata, downloadID, storeIndex, storeRef)
 
 	default:
-		return "", writtenPaths, NewNonRetryableError(fmt.Sprintf("unknown file type: %s", parsed.Type), nil)
+		return "", writtenPaths, validationReceipt, NewNonRetryableError(fmt.Sprintf("unknown file type: %s", parsed.Type), nil)
 	}
 	writtenPaths = append(writtenPaths, dispatchPaths...)
 
@@ -688,10 +708,10 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 	if err == nil {
 		proc.updateProgress(queueID, 100)
 	} else if errors.Is(err, nntppool.ErrArticleNotFound) {
-		return result, writtenPaths, ErrArticlesNotFound
+		return result, writtenPaths, validationReceipt, ErrArticlesNotFound
 	}
 
-	return result, writtenPaths, err
+	return result, writtenPaths, validationReceipt, err
 }
 
 // processSingleFile handles single file imports

--- a/internal/importer/processor_test.go
+++ b/internal/importer/processor_test.go
@@ -72,7 +72,7 @@ func TestPreParseFastFailSkipsOnlyMissingEpisode(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	brokenIdx, missingIDs, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
+	brokenIdx, missingIDs, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestPreParseFastFailMarksWholeRarSetBroken(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
+	brokenIdx, _, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestPreParseFastFailAllRarSetsBrokenReturnsNoFilesProcessed(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
+	_, _, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
 		t.Fatalf("preParseFastFail error = %v, want ErrNoFilesProcessed", err)
 	}
@@ -172,7 +172,7 @@ func TestPreParseFastFailDoesNotStatPar2(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	brokenIdx, missingIDs, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
+	brokenIdx, missingIDs, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestPreParseFastFailAllMissingReturnsNoFilesProcessed(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
+	_, _, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
 		t.Fatalf("preParseFastFail error = %v, want ErrNoFilesProcessed", err)
 	}
@@ -231,7 +231,7 @@ func TestPreParseFastFailHealthyReleaseSkipsPerFileSweep(t *testing.T) {
 	n := buildTestNzb(files)
 	cfg := config.DefaultConfig() // default 1% sampling, capped at 55
 
-	brokenIdx, missingIDs, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
+	brokenIdx, missingIDs, receipt, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
@@ -241,10 +241,39 @@ func TestPreParseFastFailHealthyReleaseSkipsPerFileSweep(t *testing.T) {
 	if missingIDs != nil {
 		t.Errorf("missingIDs = %v, want nil (healthy release)", missingIDs)
 	}
+	if receipt != nil {
+		t.Fatal("partial validation must not produce a full-validation receipt")
+	}
 	// The probe samples the whole release once (capped at 55). With no missing
 	// segment it must NOT escalate, so total Stats stay well under fileCount.
 	if got := client.StatCalls(); got > 55 {
 		t.Errorf("StatCalls = %d, want ≤55 (release probe only, no per-file sweep)", got)
+	}
+}
+
+func TestPreParseFastFailFullValidationReturnsReceipt(t *testing.T) {
+	client := fakepool.New()
+	proc := &Processor{
+		poolManager:       processorTestPoolManager{client: client},
+		validationTimeout: 100 * time.Millisecond,
+	}
+	n := buildTestNzb([]testNzbFile{
+		{name: "movie.mkv", segID: "movie-1"},
+		{name: "movie.nfo", segID: "sidecar-1"},
+	})
+	cfg := config.DefaultConfig()
+	cfg.Import.SegmentSamplePercentage = 100
+
+	_, _, receipt, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
+	if err != nil {
+		t.Fatalf("preParseFastFail returned error: %v", err)
+	}
+	if receipt == nil {
+		t.Fatal("full validation should return a receipt")
+	}
+	meta := &metapb.FileMetadata{SegmentData: []*metapb.SegmentData{{Id: "movie-1"}, {Id: "sidecar-1"}}}
+	if !receipt.Covers(meta) {
+		t.Fatal("receipt should cover all segments from the full validation")
 	}
 }
 
@@ -619,7 +648,7 @@ func TestPreParseFastFailTolerantImportsDegradedVideo(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
+	brokenIdx, _, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
@@ -641,7 +670,7 @@ func TestPreParseFastFailStrictFailsDegradedVideo(t *testing.T) {
 	cfg.Import.SegmentSamplePercentage = 100
 	cfg.Import.DamagePolicy = "strict"
 
-	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
+	brokenIdx, _, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
 		// Single file, and it's broken → all eligible broken → ErrNoFilesProcessed.
 		t.Fatalf("strict policy: err = %v, want ErrNoFilesProcessed", err)
@@ -662,7 +691,7 @@ func TestPreParseFastFailTolerantStillFailsLongRun(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
+	_, _, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
 		t.Fatalf("tolerant policy with long run: err = %v, want ErrNoFilesProcessed", err)
 	}
@@ -678,7 +707,7 @@ func TestPreParseFastFailStremioHeaderOnly(t *testing.T) {
 	cfg := config.DefaultConfig()
 	stremioCat := "stremio"
 
-	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, &stremioCat, nil)
+	_, _, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, &stremioCat, nil)
 	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
 		t.Fatalf("stremio header fast-fail: err = %v, want ErrNoFilesProcessed", err)
 	}

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/javi11/altmount/internal/importer/queue"
 	"github.com/javi11/altmount/internal/importer/scanner"
 	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
+	"github.com/javi11/altmount/internal/importer/validation"
 	"github.com/javi11/altmount/internal/metadata"
 	"github.com/javi11/altmount/internal/nzbfile"
 	"github.com/javi11/altmount/internal/pool"
@@ -38,7 +39,13 @@ import (
 
 // ServiceConfig holds configuration for the NZB import service
 type ServiceConfig struct {
-	Workers int // Number of parallel queue workers (default: 2)
+	Workers            int // Number of parallel queue workers (default: 2)
+	CalculateNextCheck func(releaseDate, lastCheck time.Time) time.Time
+}
+
+type processArtifact struct {
+	paths   []string
+	receipt *validation.FullValidationReceipt
 }
 
 // Type aliases from scanner package for backward compatibility
@@ -205,9 +212,8 @@ type Service struct {
 	// categoryPathCache memoizes buildCategoryPath results; cleared on config reload.
 	categoryPathCache sync.Map
 
-	// writtenPathsCache stores the metadata paths written during ProcessItem so that
-	// HandleFailure can clean them up without changing the ItemProcessor interface.
-	// Keys are item.ID (int64), values are []string.
+	// writtenPathsCache stores the per-item metadata paths and one-shot validation
+	// receipt produced during ProcessItem so post-processing can consume them.
 	writtenPathsCache sync.Map
 	grabbedIndexers   sync.Map
 }
@@ -234,8 +240,9 @@ func NewService(config ServiceConfig, metadataService *metadata.MetadataService,
 		ConfigGetter:    configGetter,
 		MetadataService: metadataService,
 		RcloneClient:    rcloneClient,
-		HealthRepo:      healthRepo,
-		UserRepo:        userRepo,
+		HealthRepo:         healthRepo,
+		CalculateNextCheck: config.CalculateNextCheck,
+		UserRepo:           userRepo,
 	})
 
 	service := &Service{
@@ -353,27 +360,27 @@ func (s *Service) Start(ctx context.Context) error {
 
 // ProcessItem implements queue.ItemProcessor - processes a single queue item
 func (s *Service) ProcessItem(ctx context.Context, item *database.ImportQueueItem) (string, error) {
-	resultPath, writtenPaths, err := s.processNzbItem(ctx, item)
-	// Always store written paths so HandleFailure can clean them up on error.
-	s.writtenPathsCache.Store(item.ID, writtenPaths)
+	resultPath, paths, receipt, err := s.processNzbItem(ctx, item)
+	// Always store the artifact so HandleFailure can clean paths on error.
+	s.writtenPathsCache.Store(item.ID, processArtifact{paths: paths, receipt: receipt})
 	return resultPath, err
 }
 
 // HandleSuccess implements queue.ItemProcessor - handles successful processing
 func (s *Service) HandleSuccess(ctx context.Context, item *database.ImportQueueItem, resultingPath string) error {
-	// The written virtual paths are carried over from ProcessItem so multi-file
-	// imports (season packs) can schedule a per-episode post-import health check.
-	var writtenPaths []string
-	if paths, ok := s.writtenPathsCache.LoadAndDelete(item.ID); ok {
-		writtenPaths, _ = paths.([]string)
+	artifact := processArtifact{}
+	if stored, ok := s.writtenPathsCache.LoadAndDelete(item.ID); ok {
+		artifact, _ = stored.(processArtifact)
 	}
-	return s.handleProcessingSuccess(ctx, item, resultingPath, writtenPaths)
+	return s.handleProcessingSuccess(ctx, item, resultingPath, artifact.paths, artifact.receipt)
 }
 
 // HandleFailure implements queue.ItemProcessor - handles failed processing
 func (s *Service) HandleFailure(ctx context.Context, item *database.ImportQueueItem, err error) {
-	if paths, ok := s.writtenPathsCache.LoadAndDelete(item.ID); ok {
-		s.cleanupWrittenPaths(ctx, item.ID, paths.([]string))
+	if stored, ok := s.writtenPathsCache.LoadAndDelete(item.ID); ok {
+		if artifact, valid := stored.(processArtifact); valid {
+			s.cleanupWrittenPaths(ctx, item.ID, artifact.paths)
+		}
 	}
 	s.handleProcessingFailure(ctx, item, err)
 }
@@ -819,7 +826,7 @@ func (s *Service) FindAndUpdatePendingUpload(ctx context.Context, filename strin
 }
 
 // processNzbItem processes the NZB file for a queue item
-func (s *Service) processNzbItem(ctx context.Context, item *database.ImportQueueItem) (string, []string, error) {
+func (s *Service) processNzbItem(ctx context.Context, item *database.ImportQueueItem) (string, []string, *validation.FullValidationReceipt, error) {
 	// Determine the base path
 	basePath := ""
 	if item.RelativePath != nil {
@@ -831,7 +838,7 @@ func (s *Service) processNzbItem(ctx context.Context, item *database.ImportQueue
 
 	// Ensure NZB is in a persistent location to prevent data loss if /tmp is cleaned
 	if err := s.ensurePersistentNzb(ctx, item); err != nil {
-		return "", nil, fmt.Errorf("failed to ensure persistent NZB: %w", err)
+		return "", nil, nil, fmt.Errorf("failed to ensure persistent NZB: %w", err)
 	}
 
 	// Determine if allowed extensions override is needed
@@ -1214,7 +1221,7 @@ func (s *Service) resolveIndexerFromArrs(ctx context.Context, downloadID string)
 // handleProcessingSuccess handles all steps after successful NZB processing.
 // writtenPaths lists every virtual file the import wrote (may be nil for legacy
 // callers); multi-file imports use it to health-check each file individually.
-func (s *Service) handleProcessingSuccess(ctx context.Context, item *database.ImportQueueItem, resultingPath string, writtenPaths []string) error {
+func (s *Service) handleProcessingSuccess(ctx context.Context, item *database.ImportQueueItem, resultingPath string, writtenPaths []string, receipt *validation.FullValidationReceipt) error {
 	// Log persistent indexer statistic
 	indexerName := database.IndexerUnknown
 	if item.Indexer != nil && *item.Indexer != "" {
@@ -1261,7 +1268,7 @@ func (s *Service) handleProcessingSuccess(ctx context.Context, item *database.Im
 
 	// Delegate all post-processing to the coordinator
 	// This handles: VFS notification, symlinks, ID links, STRM files, health checks, ARR notifications
-	result, err := s.postProcessor.HandleSuccess(ctx, item, resultingPath, writtenPaths)
+	result, err := s.postProcessor.HandleSuccess(ctx, item, resultingPath, writtenPaths, receipt)
 	if err != nil {
 		s.log.ErrorContext(ctx, "Post-processing failed", "queue_id", item.ID, "error", err)
 		return err
@@ -1620,7 +1627,7 @@ func (s *Service) ProcessItemInBackground(ctx context.Context, itemID int64) {
 		}()
 
 		// Process the NZB file using cancellable context
-		resultingPath, writtenPaths, processingErr := s.processNzbItem(itemCtx, item)
+		resultingPath, writtenPaths, receipt, processingErr := s.processNzbItem(itemCtx, item)
 
 		// Update queue database with results
 		if processingErr != nil {
@@ -1629,7 +1636,7 @@ func (s *Service) ProcessItemInBackground(ctx context.Context, itemID int64) {
 			s.handleProcessingFailure(ctx, item, processingErr)
 		} else {
 			// Handle success (storage path, VFS notification, symlinks, status update)
-			s.handleProcessingSuccess(ctx, item, resultingPath, writtenPaths)
+			s.handleProcessingSuccess(ctx, item, resultingPath, writtenPaths, receipt)
 		}
 	}()
 }
@@ -1786,7 +1793,7 @@ func (s *Service) RegenerateMetadata(ctx context.Context, mountRelativePath stri
 
 	// Re-process the NZB file. We use a dummy queue ID.
 	// This will overwrite the existing .meta file.
-	_, _, err = s.processor.ProcessNzbFile(ctx, foundNzbPath, "", 0, nil, &virtualDir, nil, nil, nil, nil)
+	_, _, _, err = s.processor.ProcessNzbFile(ctx, foundNzbPath, "", 0, nil, &virtualDir, nil, nil, nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to re-process NZB: %w", err)
 	}

--- a/internal/importer/validation/fast_fail.go
+++ b/internal/importer/validation/fast_fail.go
@@ -65,6 +65,46 @@ type FastFailFile struct {
 	GroupKey string
 }
 
+// FullValidationReceipt contains the exact segment IDs validated by a complete
+// import-time sweep. It is intentionally transient and only matches metadata
+// with non-empty segment IDs.
+type FullValidationReceipt struct {
+	segmentIDs map[string]struct{}
+}
+
+// NewFullValidationReceipt creates an immutable receipt from validated segment IDs.
+func NewFullValidationReceipt(segmentIDs []string) *FullValidationReceipt {
+	ids := make(map[string]struct{}, len(segmentIDs))
+	for _, id := range segmentIDs {
+		if id != "" {
+			ids[id] = struct{}{}
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	return &FullValidationReceipt{segmentIDs: ids}
+}
+
+// Covers reports whether every non-empty segment ID in metadata was validated.
+func (r *FullValidationReceipt) Covers(metadata *metapb.FileMetadata) bool {
+	if r == nil || metadata == nil || len(metadata.GetSegmentData()) == 0 {
+		return false
+	}
+
+	hasSegmentID := false
+	for _, segment := range metadata.GetSegmentData() {
+		if segment == nil || segment.Id == "" {
+			continue
+		}
+		hasSegmentID = true
+		if _, ok := r.segmentIDs[segment.Id]; !ok {
+			return false
+		}
+	}
+	return hasSegmentID
+}
+
 // FastFailReleaseProbe is the cheap phase-1 reachability gate for an NZB import.
 // It flattens all candidate segments across the release and Stats a single
 // sample (usenet.SelectSegmentsForValidation: first 3 + last 2 + random middle,

--- a/internal/importer/validation/fast_fail_test.go
+++ b/internal/importer/validation/fast_fail_test.go
@@ -47,6 +47,30 @@ func (m fastFailPoolManager) ImportConnCapacity() int                   { return
 func (m fastFailPoolManager) SetStreamSource(pool.StreamActivitySource) {}
 func (m fastFailPoolManager) NotifyStreamChange()                       {}
 
+func TestFullValidationReceiptCoversExactSegmentIDs(t *testing.T) {
+	receipt := NewFullValidationReceipt([]string{"a", "b", "", "a"})
+
+	covered := &metapb.FileMetadata{SegmentData: []*metapb.SegmentData{
+		{Id: "a"},
+		{Id: "b"},
+	}}
+	changed := &metapb.FileMetadata{SegmentData: []*metapb.SegmentData{
+		{Id: "a"},
+		{Id: "c"},
+	}}
+	empty := &metapb.FileMetadata{}
+
+	if !receipt.Covers(covered) {
+		t.Fatal("receipt should cover metadata with the exact validated segment IDs")
+	}
+	if receipt.Covers(changed) {
+		t.Fatal("receipt must not cover metadata with an unvalidated segment ID")
+	}
+	if receipt.Covers(empty) {
+		t.Fatal("receipt must not cover metadata without segments")
+	}
+}
+
 func TestFastFailReleaseProbeUsesSegmentSamplePercentage(t *testing.T) {
 	client := fakepool.New()
 	files := []FastFailFile{


### PR DESCRIPTION
## What this PR is for

A successful full import already performs a complete 100% STAT validation, but the importer could immediately schedule another health STAT for the same fully validated file. This PR carries a short-lived, exact-segment validation receipt into post-import health scheduling so that redundant check is skipped only when the evidence still matches.

In practical terms: it removes duplicate provider work after a successful complete import without weakening normal health checking.

## What changes

- Carry the exact segment IDs covered by a successful 100% import STAT validation as a transient receipt.
- Initialize only fully covered imported files as healthy with their normal future check schedule.
- Avoid the immediate duplicate health STAT for files covered by that receipt.
- Preserve the normal health-check path for partial, sampled, degraded, stale, mismatched, re-imported, PAR2, or uncertain coverage.

## What this deliberately does not change

- It does not add persistent availability caching.
- It does not change provider behavior, streaming, article reads, importer validation semantics, or external configuration.
- It does not treat degraded/tolerant imports as complete validation.
- It does not address the unrelated metadata directory-mtime test or existing API lint findings.

## Verification

- Focused importer, scheduler/database, health, package, race, and build checks: PASS
- `git diff --check`: PASS
- `make build`: PASS
- `make test`: blocked by the pre-existing `internal/metadata/TestDirectoryModTime_StableAcrossHealthSweep` failure, reproduced on the clean base.
- `make lint` / `make check`: blocked by three pre-existing findings in unchanged `internal/api` files.

The metadata test and API lint/check findings are intentionally excluded from this PR and should be handled separately.