### PR TITLE
fix(logging): redact ARR webhook credentials

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -16,7 +16,7 @@ import (
 	"github.com/javi11/altmount/frontend"
 	"github.com/javi11/altmount/internal/api"
 	"github.com/javi11/altmount/internal/arrs"
-	"github.com/javi11/altmount/internal/stremio"
+	"github.com/javi11/altmount/internal/arrs/registrar"
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/health"
 	"github.com/javi11/altmount/internal/metadata"
@@ -25,6 +25,7 @@ import (
 	"github.com/javi11/altmount/internal/progress"
 	"github.com/javi11/altmount/internal/rclone"
 	"github.com/javi11/altmount/internal/slogutil"
+	"github.com/javi11/altmount/internal/stremio"
 	"github.com/javi11/altmount/internal/webdav"
 	"github.com/spf13/cobra"
 )
@@ -278,7 +279,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 
 		if apiKey != "" {
-			logger.InfoContext(bgCtx, "Triggering automatic ARR webhook registration", "webhook_url", cfg.GetWebhookBaseURL())
+			logger.InfoContext(bgCtx, "Triggering automatic ARR webhook registration", "webhook_url", registrar.RedactWebhookURLForLog(cfg.GetWebhookBaseURL()))
 			if err := arrsService.EnsureWebhookRegistration(bgCtx, cfg.GetWebhookBaseURL(), apiKey); err != nil {
 				logger.ErrorContext(bgCtx, "Failed to register ARR webhooks on startup", "error", err)
 			}
@@ -438,7 +439,6 @@ func waitForHTTPServer(ctx context.Context, port int) error {
 		}
 	}
 }
-
 
 // intPtrValue returns the value pointed to by p, or 0 when p is nil. It is used
 // to compare optional integer config fields (e.g. segment cache ExpiryHours) by

--- a/internal/arrs/registrar/manager.go
+++ b/internal/arrs/registrar/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strings"
 
 	"github.com/javi11/altmount/internal/arrs/clients"
@@ -48,8 +49,8 @@ func (m *Manager) EnsureWebhookRegistration(ctx context.Context, altmountURL str
 	allInstances := m.instances.GetAllInstances()
 	webhookName := "AltMount Webhook"
 	webhookURL := fmt.Sprintf("%s/api/arrs/webhook?apikey=%s", altmountURL, apiKey)
-	// Redact the API key when logging; the real webhookURL is still used for registration.
-	redactedWebhookURL := fmt.Sprintf("%s/api/arrs/webhook?apikey=***", altmountURL)
+	// Redact all caller-controlled URL credentials when logging; the real webhookURL is still used for registration.
+	redactedWebhookURL := RedactWebhookURLForLog(altmountURL)
 
 	slog.InfoContext(ctx, "Ensuring webhook registration in ARR instances", "webhook_url", redactedWebhookURL)
 
@@ -388,6 +389,23 @@ func (m *Manager) EnsureWebhookRegistration(ctx context.Context, altmountURL str
 	}
 
 	return nil
+}
+
+// RedactWebhookURLForLog returns useful endpoint context without exposing URL
+// credentials, query parameters, or fragments in logs.
+func RedactWebhookURLForLog(altmountURL string) string {
+	parsed, err := url.Parse(altmountURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "invalid-url/api/arrs/webhook?apikey=***"
+	}
+
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.ForceQuery = false
+	parsed.Fragment = ""
+	parsed.RawFragment = ""
+
+	return strings.TrimRight(parsed.String(), "/") + "/api/arrs/webhook?apikey=***"
 }
 
 // EnsureDownloadClientRegistration ensures that AltMount is registered as a SABnzbd download client in all enabled ARR instances

--- a/internal/arrs/registrar/manager_test.go
+++ b/internal/arrs/registrar/manager_test.go
@@ -1,6 +1,9 @@
 package registrar
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestIsAltmountDownloadClient(t *testing.T) {
 	tests := []struct {
@@ -8,8 +11,8 @@ func TestIsAltmountDownloadClient(t *testing.T) {
 		want bool
 	}{
 		{AltmountDownloadClientName, true}, // exact registered name
-		{"Altmount", true},                // common manual name
-		{"altmount", true},                // lowercase
+		{"Altmount", true},                 // common manual name
+		{"altmount", true},                 // lowercase
 		{"AltMount (SABnzbd)", true},
 		{"My AltMount SAB", true},
 		{"", false},
@@ -21,5 +24,58 @@ func TestIsAltmountDownloadClient(t *testing.T) {
 		if got := IsAltmountDownloadClient(tt.name); got != tt.want {
 			t.Errorf("IsAltmountDownloadClient(%q) = %v, want %v", tt.name, got, tt.want)
 		}
+	}
+}
+
+func TestRedactWebhookURLForLog(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "removes sensitive query values",
+			url:  "https://altmount.example/base?api_key=api-key-secret&apikey=apikey-secret&token=token-secret#fragment-secret",
+			want: "https://altmount.example/base/api/arrs/webhook?apikey=***",
+		},
+		{
+			name: "removes userinfo",
+			url:  "https://admin:password-secret@altmount.example/base",
+			want: "https://altmount.example/base/api/arrs/webhook?apikey=***",
+		},
+		{
+			name: "preserves IPv6 endpoint and URL base path",
+			url:  "https://user:password@[2001:db8::1]:8443/sabnzbd?secret=query#secret-fragment",
+			want: "https://[2001:db8::1]:8443/sabnzbd/api/arrs/webhook?apikey=***",
+		},
+		{
+			name: "rejects relative URL",
+			url:  "/sabnzbd?secret=query#secret-fragment",
+			want: "invalid-url/api/arrs/webhook?apikey=***",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactWebhookURLForLog(tt.url)
+			if got != tt.want {
+				t.Fatalf("RedactWebhookURLForLog(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+			for _, secret := range []string{"api-key-secret", "apikey-secret", "token-secret", "fragment-secret", "admin", "password-secret", "secret", "user"} {
+				if strings.Contains(got, secret) {
+					t.Errorf("redacted URL contains secret %q: %q", secret, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRedactWebhookURLForLogInvalidURL(t *testing.T) {
+	got := RedactWebhookURLForLog("https://%invalid")
+	if strings.Contains(got, "%invalid") {
+		t.Fatalf("redacted URL contains invalid input: %q", got)
+	}
+	if got != "invalid-url/api/arrs/webhook?apikey=***" {
+		t.Fatalf("RedactWebhookURLForLog returned %q for invalid URL", got)
 	}
 }


### PR DESCRIPTION
## Summary

- sanitize the ARR webhook base URL before registrar and startup logging
- preserve useful scheme, host, port, IPv6, and URL-base path context
- remove userinfo, query values, and fragments; return fixed safe context for invalid or relative input
- keep the real authenticated URL unchanged for webhook registration

## Why

The configured webhook base can carry authentication in userinfo or query parameters. Logging the raw value makes reusable credentials persist in application and container logs. The existing apikey masking covered only the appended key, not credentials already present in the configured base URL, and startup logging still emitted the raw value.

## Validation

- go test ./internal/arrs/registrar ./cmd/altmount/cmd
- go test ./internal/arrs/...
- go vet ./internal/arrs/registrar ./cmd/altmount/cmd
- gofmt clean
- git diff --check