### PR TITLE
fix(pool): use stable NNTP provider IDs

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -294,7 +294,7 @@ profiler_enabled: false # Enable performance profiling (default: false)
 # Configure multiple providers for redundancy and load balancing
 providers:
   # Primary provider with SSL
-  - id: 1 # Auto-generated hash ID based on host:port@username (leave empty for auto-generation)
+  - id: provider_primary # Stable public identifier; keep unique and free of credentials/non-graphic characters
     host: 'ssl-news.provider.com' # Replace with your provider's SSL hostname
     port: 563
     username: 'your_username' # Replace with your username
@@ -310,7 +310,7 @@ providers:
     is_backup_provider: false # Mark as backup provider (default: false)
 
   # Backup provider without SSL
-  - id: 2 # Auto-generated hash ID (leave empty for auto-generation)
+  - id: provider_backup # Stable public identifier; keep unique and free of credentials/non-graphic characters
     host: 'news.provider.com' # Replace with your provider's standard hostname
     port: 119
     username: 'your_username' # Replace with your username

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -324,7 +324,7 @@ providers:
 
 
   # Secondary provider (optional)
-  # - id: '' # Auto-generated
+  # - id: provider_secondary # Stable public identifier; keep unique and free of credentials/non-graphic characters
   #   host: "news.otherprovider.com"
   #   port: 563
   #   username: "other_username"

--- a/docs/static/openapi.yaml
+++ b/docs/static/openapi.yaml
@@ -4359,6 +4359,7 @@ components:
         host:
           type: string
         id:
+          description: Stable public provider identifier; never credentials or non-graphic characters
           type: string
         inflight_requests:
           type: integer
@@ -4495,6 +4496,7 @@ components:
         host:
           type: string
         id:
+          description: Stable public provider identifier; never credentials or non-graphic characters
           type: string
         last_connection_attempt:
           type: string
@@ -4530,8 +4532,6 @@ components:
           type: string
         used_connections:
           type: integer
-        username:
-          type: string
       type: object
     api.ProviderTestRequest:
       properties:

--- a/docs/static/swagger.json
+++ b/docs/static/swagger.json
@@ -6535,6 +6535,7 @@
                     "type": "string"
                 },
                 "id": {
+                    "description": "Stable public provider identifier; never credentials or non-graphic characters",
                     "type": "string"
                 },
                 "inflight_requests": {
@@ -6743,6 +6744,7 @@
                     "type": "string"
                 },
                 "id": {
+                    "description": "Stable public provider identifier; never credentials or non-graphic characters",
                     "type": "string"
                 },
                 "last_connection_attempt": {
@@ -6795,9 +6797,6 @@
                 },
                 "used_connections": {
                     "type": "integer"
-                },
-                "username": {
-                    "type": "string"
                 }
             }
         },

--- a/docs/static/swagger.yaml
+++ b/docs/static/swagger.yaml
@@ -673,6 +673,7 @@ definitions:
       host:
         type: string
       id:
+        description: Stable public provider identifier; never credentials or non-graphic characters
         type: string
       inflight_requests:
         type: integer
@@ -809,6 +810,7 @@ definitions:
       host:
         type: string
       id:
+        description: Stable public provider identifier; never credentials or non-graphic characters
         type: string
       last_connection_attempt:
         type: string
@@ -844,8 +846,6 @@ definitions:
         type: string
       used_connections:
         type: integer
-      username:
-        type: string
     type: object
   api.ProviderTestRequest:
     properties:

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -450,7 +450,6 @@ export interface ProviderStatus {
 	id: string;
 	name?: string;
 	host: string;
-	username: string;
 	used_connections: number;
 	max_connections: number;
 	state: string;

--- a/internal/api/config_handlers.go
+++ b/internal/api/config_handlers.go
@@ -429,6 +429,12 @@ func (s *Server) handleTestProvider(c *fiber.Ctx) error {
 	defer cancel()
 
 	host := fmt.Sprintf("%s:%d", testReq.Host, testReq.Port)
+	providerName := testReq.ProviderID
+	if providerName == "" {
+		// Ad-hoc tests have no persisted provider ID. Keep the endpoint context
+		// while preventing nntppool from deriving a name from Auth.Username.
+		providerName = host
+	}
 	var tlsCfg *tls.Config
 	if testReq.TLS {
 		tlsCfg = &tls.Config{
@@ -439,6 +445,7 @@ func (s *Server) handleTestProvider(c *fiber.Ctx) error {
 
 	result := nntppool.TestProvider(ctx, nntppool.Provider{
 		Host:      host,
+		Name:      providerName,
 		TLSConfig: tlsCfg,
 		Auth:      nntppool.Auth{Username: testReq.Username, Password: testReq.Password},
 		SkipPing:  testReq.SkipPing,

--- a/internal/api/config_handlers.go
+++ b/internal/api/config_handlers.go
@@ -502,6 +502,22 @@ func (s *Server) handleTestProvider(c *fiber.Ctx) error {
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
 //	@Router			/providers [post]
+// nextProviderID picks the lowest-numbered "provider_N" id not already used
+// by an existing provider. Providers can be deleted, so the next free index
+// is not simply len(existing)+1 — that can collide with a surviving provider.
+func nextProviderID(existing []config.ProviderConfig) string {
+	used := make(map[string]struct{}, len(existing))
+	for _, p := range existing {
+		used[p.ID] = struct{}{}
+	}
+	for i := len(existing) + 1; ; i++ {
+		candidate := fmt.Sprintf("provider_%d", i)
+		if _, exists := used[candidate]; !exists {
+			return candidate
+		}
+	}
+}
+
 func (s *Server) handleCreateProvider(c *fiber.Ctx) error {
 	if s.configManager == nil {
 		return RespondServiceUnavailable(c, "Configuration management not available", "CONFIG_UNAVAILABLE")
@@ -560,8 +576,8 @@ func (s *Server) handleCreateProvider(c *fiber.Ctx) error {
 		return RespondValidationError(c, "MinConnectionsAlive must be between 0 and MaxConnections", "INVALID_MIN_CONNECTIONS_ALIVE")
 	}
 
-	// Generate new ID
-	newID := fmt.Sprintf("provider_%d", len(currentConfig.Providers)+1)
+	// Generate a new ID that doesn't collide with an existing one.
+	newID := nextProviderID(currentConfig.Providers)
 
 	// Create new provider
 	newProvider := config.ProviderConfig{

--- a/internal/api/config_handlers_provider_id_test.go
+++ b/internal/api/config_handlers_provider_id_test.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/javi11/altmount/internal/config"
+)
+
+func TestNextProviderIDSkipsCollisions(t *testing.T) {
+	existing := []config.ProviderConfig{
+		{ID: "provider_2"},
+	}
+
+	got := nextProviderID(existing)
+
+	if got == "provider_2" {
+		t.Fatalf("nextProviderID() = %q, collides with an existing provider", got)
+	}
+	for _, p := range existing {
+		if got == p.ID {
+			t.Fatalf("nextProviderID() = %q, collides with existing provider %q", got, p.ID)
+		}
+	}
+}
+
+func TestNextProviderIDWithNoProviders(t *testing.T) {
+	if got := nextProviderID(nil); got != "provider_1" {
+		t.Fatalf("nextProviderID(nil) = %q, want %q", got, "provider_1")
+	}
+}

--- a/internal/api/provider_speedtest_handler.go
+++ b/internal/api/provider_speedtest_handler.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -55,14 +54,9 @@ func (s *Server) handleTestProviderSpeed(c *fiber.Ctx) error {
 	testCtx, cancel := context.WithTimeout(c.Context(), 5*time.Minute)
 	defer cancel()
 
-	// Build the nntppool provider name the same way the production pool
-	// and coordinator do, so we can match the right per-provider stats
-	// entry in the result.
-	host := fmt.Sprintf("%s:%d", targetProvider.Host, targetProvider.Port)
-	providerName := host
-	if targetProvider.Username != "" {
-		providerName = host + "+" + targetProvider.Username
-	}
+	// Use the stable provider ID used by the production pool and coordinator
+	// to match the right per-provider stats entry in the result.
+	providerName := targetProvider.NNTPPoolName()
 
 	// Prefer the production pool when this provider is already part of
 	// it; otherwise fall back to the singleton coordinator so we never
@@ -137,16 +131,8 @@ func (s *Server) runProviderSpeedTest(ctx context.Context, p *config.ProviderCon
 	if s.poolManager != nil {
 		if cp, err := s.poolManager.GetPool(); err == nil && cp != nil {
 			if real, ok := cp.(*nntppool.Client); ok {
-				// Match the name the production pool registers for this
-				// provider: ToNNTPProvider sets Host = "host:port", and
-				// nntppool's resolveProviderName derives "host:port+user".
-				// Building the lookup from p.Host alone (no port) never
-				// matches, forcing the slow coordinator fallback.
-				host := fmt.Sprintf("%s:%d", p.Host, p.Port)
-				providerName := host
-				if p.Username != "" {
-					providerName = host + "+" + p.Username
-				}
+				// ToNNTPProvider registers the provider under its stable ID.
+				providerName := p.NNTPPoolName()
 				// Try the production pool first. If the provider isn't
 				// in it, nntppool returns an error and we fall through
 				// to the coordinator.

--- a/internal/api/provider_status_test.go
+++ b/internal/api/provider_status_test.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestProviderStatusResponseDoesNotExposeAuthenticationUsername(t *testing.T) {
+	encoded, err := json.Marshal(ProviderStatusResponse{ID: "provider-primary", Host: "news.example.test"})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if strings.Contains(string(encoded), "username") {
+		t.Fatalf("provider status response exposes an authentication field: %s", encoded)
+	}
+}

--- a/internal/api/speedtest_coordinator.go
+++ b/internal/api/speedtest_coordinator.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"sync"
 	"time"
@@ -124,10 +123,7 @@ func (sc *speedtestCoordinator) sweepExpired() {
 // nntppool-side provider name (used by SpeedTest).
 func (sc *speedtestCoordinator) getOrBuildClient(ctx context.Context, p *config.ProviderConfig) (*nntppool.Client, string, error) {
 	host := fmt.Sprintf("%s:%d", p.Host, p.Port)
-	providerName := host
-	if p.Username != "" {
-		providerName = host + "+" + p.Username
-	}
+	providerName := p.NNTPPoolName()
 
 	sc.mu.Lock()
 	if entry, ok := sc.clients[p.ID]; ok && time.Now().Before(entry.expiresAt) {
@@ -174,23 +170,11 @@ func (sc *speedtestCoordinator) getOrBuildClient(ctx context.Context, p *config.
 
 // buildAdHocClient dials a throwaway single-provider client; the caller owns Close.
 func buildAdHocClient(ctx context.Context, p *config.ProviderConfig, connections, inflight int) (*nntppool.Client, error) {
-	var tlsCfg *tls.Config
-	if p.TLS {
-		tlsCfg = &tls.Config{
-			InsecureSkipVerify: p.InsecureTLS,
-			ServerName:         p.Host,
-		}
-	}
-	return nntppool.NewClient(ctx, []nntppool.Provider{
-		{
-			Host:        fmt.Sprintf("%s:%d", p.Host, p.Port),
-			TLSConfig:   tlsCfg,
-			Auth:        nntppool.Auth{Username: p.Username, Password: p.Password},
-			Connections: connections,
-			Inflight:    inflight,
-			IdleTimeout: 60 * time.Second,
-		},
-	})
+	provider := p.ToNNTPProvider()
+	provider.Connections = connections
+	provider.Inflight = inflight
+	provider.IdleTimeout = 60 * time.Second
+	return nntppool.NewClient(ctx, []nntppool.Provider{provider})
 }
 
 // run executes fn under the singleflight key for the given provider,

--- a/internal/api/system_handlers.go
+++ b/internal/api/system_handlers.go
@@ -520,18 +520,16 @@ func (s *Server) handleGetPoolMetrics(c *fiber.Ctx) error {
 		var providerID string
 		var name string
 		var host string
-		var username string
 		var lastSpeedTestMbps float64
 		var lastSpeedTestTime *time.Time
 
 		if config != nil {
 			for _, p := range config.Providers {
-				// Match by provider name (v4 uses host:port or host:port+username)
+				// Match by the stable provider ID assigned to the nntppool entry.
 				if ps.Name == p.NNTPPoolName() {
 					providerID = p.ID
 					name = p.Name
 					host = p.Host
-					username = p.Username
 					lastSpeedTestMbps = p.LastSpeedTestMbps
 					lastSpeedTestTime = p.LastSpeedTestTime
 					break
@@ -605,7 +603,6 @@ func (s *Server) handleGetPoolMetrics(c *fiber.Ctx) error {
 			ID:                      providerID,
 			Name:                    name,
 			Host:                    host,
-			Username:                username,
 			UsedConnections:         ps.ActiveConnections,
 			MaxConnections:          ps.MaxConnections,
 			State:                   "active",

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -115,6 +115,7 @@ type RCloneAPIResponse struct {
 
 // ProviderAPIResponse sanitizes Provider config for API responses
 type ProviderAPIResponse struct {
+	// ID is a stable public provider identifier; it is not an authentication field.
 	ID                       string     `json:"id"`
 	Name                     string     `json:"name,omitempty"`
 	Host                     string     `json:"host"`
@@ -1182,7 +1183,6 @@ type ProviderStatusResponse struct {
 	ID                      string     `json:"id"`
 	Name                    string     `json:"name,omitempty"`
 	Host                    string     `json:"host"`
-	Username                string     `json:"username"`
 	UsedConnections         int        `json:"used_connections"`
 	MaxConnections          int        `json:"max_connections"`
 	State                   string     `json:"state"`

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/javi11/altmount/internal/utils"
@@ -735,6 +736,8 @@ type HealthConfig struct {
 
 // ProviderConfig represents a single NNTP provider configuration
 type ProviderConfig struct {
+	// ID is a stable public identifier used in pool names, metrics, and errors.
+	// It must never contain credentials or non-graphic characters.
 	ID                  string `yaml:"id" mapstructure:"id" json:"id"`
 	Name                string `yaml:"name" mapstructure:"name" json:"name,omitempty"`
 	Host                string `yaml:"host" mapstructure:"host" json:"host"`
@@ -1360,7 +1363,22 @@ func (c *Config) Validate() error {
 	}
 
 	// Validate each provider
+	providerIDs := make(map[string]struct{}, len(c.Providers))
 	for i, provider := range c.Providers {
+		trimmedID := strings.TrimSpace(provider.ID)
+		if trimmedID == "" {
+			return fmt.Errorf("provider %d: id cannot be empty", i)
+		}
+		if trimmedID != provider.ID {
+			return fmt.Errorf("provider %d: id cannot have leading or trailing whitespace", i)
+		}
+		if strings.IndexFunc(provider.ID, func(r rune) bool { return !unicode.IsGraphic(r) }) >= 0 {
+			return fmt.Errorf("provider %d: id contains non-graphic characters", i)
+		}
+		if _, exists := providerIDs[provider.ID]; exists {
+			return fmt.Errorf("provider %d: id %q is duplicated", i, provider.ID)
+		}
+		providerIDs[provider.ID] = struct{}{}
 		if provider.Host == "" {
 			return fmt.Errorf("provider %d: host cannot be empty", i)
 		}
@@ -1456,14 +1474,9 @@ type ProviderChange struct {
 	NewProvider *ProviderConfig // nil for Removed
 }
 
-// NNTPPoolName returns the name nntppool v4 uses to identify this provider.
-// Format: "host:port" or "host:port+username" when username is set.
+// NNTPPoolName returns the stable ID nntppool uses to identify this provider.
 func (p *ProviderConfig) NNTPPoolName() string {
-	name := fmt.Sprintf("%s:%d", p.Host, p.Port)
-	if p.Username != "" {
-		name += "+" + p.Username
-	}
-	return name
+	return p.ID
 }
 
 // ToNNTPProvider converts a single ProviderConfig to an nntppool.Provider.
@@ -1521,6 +1534,7 @@ func (p *ProviderConfig) ToNNTPProvider() nntppool.Provider {
 
 	return nntppool.Provider{
 		Host:              host,
+		Name:              p.ID,
 		TLSConfig:         tlsCfg,
 		Auth:              nntppool.Auth{Username: p.Username, Password: p.Password},
 		Connections:       p.MaxConnections,

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -911,6 +911,43 @@ func migrateGlobalUserAgent(config *Config) {
 	config.Nzblnk = NzblnkConfig{}
 }
 
+// migrateProviderIDs assigns a stable "provider_N" id to any provider whose
+// id is empty. ID was optional until Validate started requiring it: earlier
+// docs told users it was fine to leave blank ("leave empty for
+// auto-generation"), but nothing ever actually generated one for a
+// hand-edited config.yaml — only the create-provider API did. Without this,
+// such a config now fails validation and the process refuses to start.
+//
+// Existing non-empty ids are left untouched and never reused, so this never
+// collides with an id a provider already has.
+func migrateProviderIDs(config *Config) {
+	used := make(map[string]struct{}, len(config.Providers))
+	for _, p := range config.Providers {
+		if id := strings.TrimSpace(p.ID); id != "" {
+			used[id] = struct{}{}
+		}
+	}
+
+	next := 1
+	for i := range config.Providers {
+		if strings.TrimSpace(config.Providers[i].ID) != "" {
+			continue
+		}
+		var id string
+		for {
+			id = fmt.Sprintf("provider_%d", next)
+			next++
+			if _, exists := used[id]; !exists {
+				break
+			}
+		}
+		used[id] = struct{}{}
+		config.Providers[i].ID = id
+		slog.Warn("Assigned a stable id to a provider with a blank id",
+			"index", i, "host", config.Providers[i].Host, "assigned_id", id)
+	}
+}
+
 // migrateArrsCleanup folds the legacy split cleanup config (separate stuck-rules
 // list, allowlist, enable flag and grace period) into the unified QueueCleanupRules
 // model, then clears the legacy fields so they are dropped from saved YAML.
@@ -1880,6 +1917,7 @@ func (m *Manager) ReloadConfig() error {
 	migrateArrsCleanup(config)
 	migrateGlobalUserAgent(config)
 	migrateHealthSweepConcurrency(config)
+	migrateProviderIDs(config)
 
 	// Validate configuration
 	if err := config.Validate(); err != nil {
@@ -2388,6 +2426,7 @@ func LoadConfig(configFile string) (*Config, error) {
 	migrateArrsCleanup(config)
 	migrateGlobalUserAgent(config)
 	migrateHealthSweepConcurrency(config)
+	migrateProviderIDs(config)
 
 	// If log file was not explicitly set in the config file and we have a specific config file path,
 	// derive log file path from config file location

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -482,6 +482,35 @@ stremio:
 	assert.Equal(t, -100, cfg.Stremio.Prowlarr.CustomScores[`\b(aac[ ._-]?2\.0|stereo|mp3)\b`])
 }
 
+// A provider written by hand with no "id" (or an empty one) predates the id
+// requirement and must not prevent the process from starting: LoadConfig
+// should migrate it to a stable id rather than failing Validate.
+func TestLoadConfig_ProviderWithBlankIDDoesNotFailStartup(t *testing.T) {
+	tempDir := t.TempDir()
+	configFile := tempDir + "/config.yaml"
+
+	yamlContent := `
+providers:
+  - id: ''
+    host: news.example.test
+    port: 563
+    max_connections: 5
+  - host: news.other.test
+    port: 119
+    max_connections: 5
+`
+	err := os.WriteFile(configFile, []byte(yamlContent), 0644)
+	assert.NoError(t, err)
+
+	cfg, err := LoadConfig(configFile)
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+
+	assert.NotEmpty(t, cfg.Providers[0].ID)
+	assert.NotEmpty(t, cfg.Providers[1].ID)
+	assert.NotEqual(t, cfg.Providers[0].ID, cfg.Providers[1].ID)
+}
+
 // The patch directory defaults next to the metadata root but can be pointed
 // anywhere (e.g. a larger disk for patches and solver scratch files).
 func TestPar2RepairEffectivePatchDir(t *testing.T) {

--- a/internal/config/provider_identity_test.go
+++ b/internal/config/provider_identity_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProviderIdentityUsesStableID(t *testing.T) {
+	provider := ProviderConfig{
+		ID:       "provider-primary",
+		Host:     "news.example.test",
+		Port:     563,
+		Username: "synthetic-account",
+	}
+
+	if got := provider.NNTPPoolName(); got != provider.ID {
+		t.Fatalf("NNTPPoolName() = %q, want stable ID %q", got, provider.ID)
+	}
+
+	poolProvider := provider.ToNNTPProvider()
+	if poolProvider.Name != provider.ID {
+		t.Fatalf("ToNNTPProvider().Name = %q, want stable ID %q", poolProvider.Name, provider.ID)
+	}
+	if strings.Contains(poolProvider.Name, provider.Username) {
+		t.Fatalf("pool provider name contains the authentication username")
+	}
+}
+
+func TestProviderIdentityKeepsSameHostAccountsDistinct(t *testing.T) {
+	first := ProviderConfig{ID: "provider-first", Host: "news.example.test", Port: 563, Username: "first-account"}
+	second := ProviderConfig{ID: "provider-second", Host: "news.example.test", Port: 563, Username: "second-account"}
+
+	if first.NNTPPoolName() == second.NNTPPoolName() {
+		t.Fatal("same-host providers must retain distinct stable IDs")
+	}
+	if first.ToNNTPProvider().Name == second.ToNNTPProvider().Name {
+		t.Fatal("same-host nntppool providers must retain distinct stable IDs")
+	}
+}
+
+func TestConfigValidateRequiresUniqueProviderIDs(t *testing.T) {
+	validProvider := func(id string) ProviderConfig {
+		return ProviderConfig{ID: id, Host: "news.example.test", Port: 563, MaxConnections: 1}
+	}
+
+	t.Run("rejects empty ID", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Providers = []ProviderConfig{validProvider("")}
+		if err := cfg.Validate(); err == nil {
+			t.Fatal("Validate() accepted an empty provider ID")
+		}
+	})
+
+	t.Run("rejects duplicate IDs", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Providers = []ProviderConfig{validProvider("provider-duplicate"), validProvider("provider-duplicate")}
+		if err := cfg.Validate(); err == nil {
+			t.Fatal("Validate() accepted duplicate provider IDs")
+		}
+	})
+
+	for name, id := range map[string]string{
+		"leading whitespace":  " provider",
+		"trailing whitespace": "provider ",
+		"newline":             "provider\nline",
+		"line separator":      "provider\u2028line",
+		"paragraph separator": "provider\u2029line",
+		"bidi control":        "provider\u202Eline",
+	} {
+		t.Run("rejects "+name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Providers = []ProviderConfig{validProvider(id)}
+			if err := cfg.Validate(); err == nil {
+				t.Fatalf("Validate() accepted unsafe provider ID")
+			}
+		})
+	}
+}

--- a/internal/config/provider_identity_test.go
+++ b/internal/config/provider_identity_test.go
@@ -67,6 +67,45 @@ func TestMigrateProviderIDsAssignsBlankIDs(t *testing.T) {
 	}
 }
 
+// A whitespace-only id (e.g. `id: ' '` left over from hand-editing) is not a
+// usable id: Validate rejects it just like an empty one, so migration must
+// treat it the same way rather than treating it as already-set.
+func TestMigrateProviderIDsReplacesWhitespaceOnlyID(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Providers = []ProviderConfig{
+		{ID: "  ", Host: "news.example.test", Port: 563, MaxConnections: 1},
+	}
+
+	migrateProviderIDs(cfg)
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error after migration = %v", err)
+	}
+	if strings.TrimSpace(cfg.Providers[0].ID) == "" {
+		t.Fatalf("provider still has a whitespace-only id after migration: %q", cfg.Providers[0].ID)
+	}
+}
+
+// A reload must not keep reassigning ids on every call, or persisted quota
+// state (keyed by id) would drift each time the config is re-read from disk.
+func TestMigrateProviderIDsIsIdempotent(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Providers = []ProviderConfig{
+		{Host: "news.example.test", Port: 563, MaxConnections: 1},
+		{Host: "news.other.test", Port: 563, MaxConnections: 1},
+	}
+
+	migrateProviderIDs(cfg)
+	firstPass := []string{cfg.Providers[0].ID, cfg.Providers[1].ID}
+
+	migrateProviderIDs(cfg)
+	secondPass := []string{cfg.Providers[0].ID, cfg.Providers[1].ID}
+
+	if firstPass[0] != secondPass[0] || firstPass[1] != secondPass[1] {
+		t.Fatalf("migration is not idempotent: first pass %v, second pass %v", firstPass, secondPass)
+	}
+}
+
 func TestConfigValidateRequiresUniqueProviderIDs(t *testing.T) {
 	validProvider := func(id string) ProviderConfig {
 		return ProviderConfig{ID: id, Host: "news.example.test", Port: 563, MaxConnections: 1}

--- a/internal/config/provider_identity_test.go
+++ b/internal/config/provider_identity_test.go
@@ -38,6 +38,35 @@ func TestProviderIdentityKeepsSameHostAccountsDistinct(t *testing.T) {
 	}
 }
 
+func TestMigrateProviderIDsAssignsBlankIDs(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Providers = []ProviderConfig{
+		{Host: "news.example.test", Port: 563, MaxConnections: 1},
+		{ID: "provider_2", Host: "news.other.test", Port: 563, MaxConnections: 1},
+		{Host: "news.third.test", Port: 563, MaxConnections: 1},
+	}
+
+	migrateProviderIDs(cfg)
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error after migration = %v", err)
+	}
+
+	seen := make(map[string]struct{}, len(cfg.Providers))
+	for i, p := range cfg.Providers {
+		if strings.TrimSpace(p.ID) == "" {
+			t.Fatalf("provider %d still has a blank id after migration", i)
+		}
+		if _, exists := seen[p.ID]; exists {
+			t.Fatalf("migration assigned duplicate id %q", p.ID)
+		}
+		seen[p.ID] = struct{}{}
+	}
+	if cfg.Providers[1].ID != "provider_2" {
+		t.Fatalf("migration changed an already-set id: got %q, want %q", cfg.Providers[1].ID, "provider_2")
+	}
+}
+
 func TestConfigValidateRequiresUniqueProviderIDs(t *testing.T) {
 	validProvider := func(id string) ProviderConfig {
 		return ProviderConfig{ID: id, Host: "news.example.test", Port: 563, MaxConnections: 1}

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -1878,6 +1878,36 @@ func (r *Repository) UpdateSystemStat(ctx context.Context, key string, value int
 	return nil
 }
 
+// MigrateSystemStats atomically writes replacement system-stat keys and removes
+// a bounded set of legacy keys. Callers must treat returned errors as sensitive
+// and avoid logging their raw values.
+func (r *Repository) MigrateSystemStats(ctx context.Context, stats map[string]int64, deleteKeys []string) error {
+	if len(stats) == 0 && len(deleteKeys) == 0 {
+		return nil
+	}
+
+	return r.WithTransaction(ctx, func(txRepo *Repository) error {
+		for key, value := range stats {
+			query := `
+				INSERT INTO system_stats (key, value, updated_at)
+				VALUES (?, ?, CURRENT_TIMESTAMP)
+				ON CONFLICT(key) DO UPDATE SET
+				value = excluded.value,
+				updated_at = CURRENT_TIMESTAMP
+			`
+			if _, err := txRepo.db.ExecContext(ctx, query, key, value); err != nil {
+				return fmt.Errorf("failed to write migrated system stat: %w", err)
+			}
+		}
+		for _, key := range deleteKeys {
+			if _, err := txRepo.db.ExecContext(ctx, `DELETE FROM system_stats WHERE key = ?`, key); err != nil {
+				return fmt.Errorf("failed to remove migrated system stat: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
 // BatchUpdateSystemStats updates multiple system statistics in a single transaction
 func (r *Repository) BatchUpdateSystemStats(ctx context.Context, stats map[string]int64) error {
 	if len(stats) == 0 {

--- a/internal/nzbfilesystem/stream_bench_harness_test.go
+++ b/internal/nzbfilesystem/stream_bench_harness_test.go
@@ -69,6 +69,9 @@ func (noopBenchStats) GetOldestStatDate(context.Context) (time.Time, error) {
 func (noopBenchStats) GetOldestProviderStatDates(context.Context) (map[string]time.Time, error) {
 	return map[string]time.Time{}, nil
 }
+func (noopBenchStats) MigrateSystemStats(context.Context, map[string]int64, []string) error {
+	return nil
+}
 
 type benchHarness struct {
 	srv     []*nntpserver.Server

--- a/internal/pool/contention_bench_test.go
+++ b/internal/pool/contention_bench_test.go
@@ -80,6 +80,9 @@ func (noopStatsRepo) GetOldestStatDate(context.Context) (time.Time, error) {
 func (noopStatsRepo) GetOldestProviderStatDates(context.Context) (map[string]time.Time, error) {
 	return map[string]time.Time{}, nil
 }
+func (noopStatsRepo) MigrateSystemStats(context.Context, map[string]int64, []string) error {
+	return nil
+}
 
 // benchStreamSource is the StreamActivitySource the ImportBudget consults. The
 // benchmark drives the count itself instead of standing up api.StreamTracker.

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -51,7 +52,7 @@ type Manager interface {
 	// If no pool exists, a new one is created with this provider.
 	AddProvider(provider nntppool.Provider) error
 
-	// RemoveProvider removes a provider by its nntppool name (host:port or host:port+username).
+	// RemoveProvider removes a provider by its stable configuration ID.
 	// If the last provider is removed, the pool is closed.
 	RemoveProvider(name string) error
 
@@ -116,6 +117,7 @@ type Manager interface {
 type StatsRepository interface {
 	UpdateSystemStat(ctx context.Context, key string, value int64) error
 	BatchUpdateSystemStats(ctx context.Context, stats map[string]int64) error
+	MigrateSystemStats(ctx context.Context, stats map[string]int64, deleteKeys []string) error
 	GetSystemStats(ctx context.Context) (map[string]int64, error)
 	AddBytesDownloadedToDailyStat(ctx context.Context, bytes int64) error
 	AddProviderBytesToHourlyStat(ctx context.Context, providerID string, bytes int64) error
@@ -155,6 +157,13 @@ func NewManager(ctx context.Context, repo StatsRepository) Manager {
 
 // providerPoolName returns the lookup key nntppool uses for a provider.
 func providerPoolName(p nntppool.Provider) string {
+	if p.Name != "" {
+		return p.Name
+	}
+	return legacyProviderPoolName(p)
+}
+
+func legacyProviderPoolName(p nntppool.Provider) string {
 	name := p.Host
 	if p.Auth.Username != "" {
 		name += "+" + p.Auth.Username
@@ -187,12 +196,51 @@ func (m *manager) injectQuotaState(providers []nntppool.Provider) {
 		}
 	}
 
+	migrated := make(map[string]int64)
+	legacyKeys := make(map[string]struct{})
+	legacyProviderCounts := make(map[string]int)
 	for i := range providers {
 		name := providerPoolName(providers[i])
+		legacyName := legacyProviderPoolName(providers[i])
+		if name != legacyName {
+			legacyProviderCounts[legacyName]++
+		}
+	}
+
+	for i := range providers {
+		name := providerPoolName(providers[i])
+		legacyName := legacyProviderPoolName(providers[i])
+		used, hasUsed := quotaUsed[name]
+		resetNano, hasReset := quotaResetAt[name]
+		if name != legacyName {
+			if legacyProviderCounts[legacyName] == 1 {
+				// Provider IDs replaced host+username keys. Import each legacy value
+				// only when the new key does not already exist, so a restart cannot
+				// overwrite state written after a partial migration.
+				if !hasUsed {
+					used, hasUsed = quotaUsed[legacyName]
+					if hasUsed {
+						migrated["quota_used:"+name] = used
+					}
+				}
+				if !hasReset {
+					resetNano, hasReset = quotaResetAt[legacyName]
+					if hasReset {
+						migrated["quota_reset_at:"+name] = resetNano
+					}
+				}
+				if _, ok := quotaUsed[legacyName]; ok {
+					legacyKeys["quota_used:"+legacyName] = struct{}{}
+				}
+				if _, ok := quotaResetAt[legacyName]; ok {
+					legacyKeys["quota_reset_at:"+legacyName] = struct{}{}
+				}
+			}
+		}
 
 		hasResetTime := false
 		var resetTime time.Time
-		if resetNano, ok := quotaResetAt[name]; ok && resetNano > 0 {
+		if hasReset && resetNano > 0 {
 			resetTime = time.Unix(0, resetNano)
 			hasResetTime = true
 		}
@@ -200,7 +248,7 @@ func (m *manager) injectQuotaState(providers []nntppool.Provider) {
 		if hasResetTime {
 			if resetTime.After(time.Now()) {
 				// The quota period is still active: restore the used bytes and the reset time
-				if used, ok := quotaUsed[name]; ok && used > 0 {
+				if hasUsed && used > 0 {
 					providers[i].QuotaUsed = used
 				}
 				providers[i].QuotaResetAt = resetTime
@@ -211,9 +259,24 @@ func (m *manager) injectQuotaState(providers []nntppool.Provider) {
 			}
 		} else {
 			// No persisted reset time: restore whatever usage we have (fallback)
-			if used, ok := quotaUsed[name]; ok && used > 0 {
+			if hasUsed && used > 0 {
 				providers[i].QuotaUsed = used
 			}
+		}
+	}
+
+	if len(legacyKeys) > 0 {
+		keys := make([]string, 0, len(legacyKeys))
+		for key := range legacyKeys {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		if err := m.repo.MigrateSystemStats(m.ctx, migrated, keys); err != nil {
+			m.logger.ErrorContext(m.ctx, "Failed to migrate legacy provider quota state", "error_class", "repository")
+		}
+	} else if len(migrated) > 0 {
+		if err := m.repo.MigrateSystemStats(m.ctx, migrated, nil); err != nil {
+			m.logger.ErrorContext(m.ctx, "Failed to migrate legacy provider quota state", "error_class", "repository")
 		}
 	}
 }

--- a/internal/pool/manager_quota_test.go
+++ b/internal/pool/manager_quota_test.go
@@ -1,0 +1,221 @@
+package pool
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/javi11/nntppool/v4"
+)
+
+type quotaStatsRepo struct {
+	stats        map[string]int64
+	deleted      []string
+	migrationErr error
+}
+
+func (r *quotaStatsRepo) UpdateSystemStat(_ context.Context, key string, value int64) error {
+	if r.stats == nil {
+		r.stats = make(map[string]int64)
+	}
+	r.stats[key] = value
+	return nil
+}
+
+func (r *quotaStatsRepo) BatchUpdateSystemStats(_ context.Context, stats map[string]int64) error {
+	for key, value := range stats {
+		if err := r.UpdateSystemStat(context.Background(), key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *quotaStatsRepo) MigrateSystemStats(_ context.Context, stats map[string]int64, keys []string) error {
+	if r.migrationErr != nil {
+		return r.migrationErr
+	}
+	for key, value := range stats {
+		if err := r.UpdateSystemStat(context.Background(), key, value); err != nil {
+			return err
+		}
+	}
+	for _, key := range keys {
+		delete(r.stats, key)
+		r.deleted = append(r.deleted, key)
+	}
+	return nil
+}
+
+func (r *quotaStatsRepo) GetSystemStats(context.Context) (map[string]int64, error) {
+	stats := make(map[string]int64, len(r.stats))
+	for key, value := range r.stats {
+		stats[key] = value
+	}
+	return stats, nil
+}
+
+func (r *quotaStatsRepo) AddBytesDownloadedToDailyStat(context.Context, int64) error { return nil }
+
+func (r *quotaStatsRepo) AddProviderBytesToHourlyStat(context.Context, string, int64) error {
+	return nil
+}
+
+func (r *quotaStatsRepo) RecordProviderSpeedTest(context.Context, string, float64) error {
+	return nil
+}
+
+func (r *quotaStatsRepo) GetProviderHourlyStats(context.Context, int) (map[string]int64, error) {
+	return nil, nil
+}
+
+func (r *quotaStatsRepo) ClearProviderHourlyStats(context.Context) error { return nil }
+
+func (r *quotaStatsRepo) GetOldestStatDate(context.Context) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (r *quotaStatsRepo) GetOldestProviderStatDates(context.Context) (map[string]time.Time, error) {
+	return nil, nil
+}
+
+var _ StatsRepository = (*quotaStatsRepo)(nil)
+
+func TestInjectQuotaStateMigratesLegacyProviderKeys(t *testing.T) {
+	resetAt := time.Now().Add(time.Hour).Truncate(time.Nanosecond)
+	legacyName := "news.example.test:563+account-a"
+	repo := &quotaStatsRepo{stats: map[string]int64{
+		"quota_used:" + legacyName:     123,
+		"quota_reset_at:" + legacyName: resetAt.UnixNano(),
+	}}
+	m := &manager{ctx: context.Background(), repo: repo, logger: testLogger()}
+	providers := []nntppool.Provider{{
+		Name:       "provider-primary",
+		Host:       "news.example.test:563",
+		Auth:       nntppool.Auth{Username: "account-a"},
+		QuotaBytes: 1000,
+	}}
+
+	m.injectQuotaState(providers)
+
+	if providers[0].QuotaUsed != 123 {
+		t.Fatalf("QuotaUsed = %d, want migrated value 123", providers[0].QuotaUsed)
+	}
+	if !providers[0].QuotaResetAt.Equal(resetAt) {
+		t.Fatalf("QuotaResetAt = %v, want %v", providers[0].QuotaResetAt, resetAt)
+	}
+	if got := repo.stats["quota_used:provider-primary"]; got != 123 {
+		t.Fatalf("migrated quota_used = %d, want 123", got)
+	}
+	if got := repo.stats["quota_reset_at:provider-primary"]; got != resetAt.UnixNano() {
+		t.Fatalf("migrated quota_reset_at = %d, want %d", got, resetAt.UnixNano())
+	}
+	if _, ok := repo.stats["quota_used:"+legacyName]; ok {
+		t.Fatal("legacy quota_used key was not removed")
+	}
+	if _, ok := repo.stats["quota_reset_at:"+legacyName]; ok {
+		t.Fatal("legacy quota_reset_at key was not removed")
+	}
+}
+
+func TestInjectQuotaStateMigratesSameHostAccountsToDistinctIDs(t *testing.T) {
+	legacyA := "news.example.test:563+account-a"
+	legacyB := "news.example.test:563+account-b"
+	repo := &quotaStatsRepo{stats: map[string]int64{
+		"quota_used:" + legacyA: 11,
+		"quota_used:" + legacyB: 22,
+	}}
+	m := &manager{ctx: context.Background(), repo: repo, logger: testLogger()}
+	providers := []nntppool.Provider{
+		{Name: "provider-a", Host: "news.example.test:563", Auth: nntppool.Auth{Username: "account-a"}},
+		{Name: "provider-b", Host: "news.example.test:563", Auth: nntppool.Auth{Username: "account-b"}},
+	}
+
+	m.injectQuotaState(providers)
+
+	if providers[0].QuotaUsed != 11 || providers[1].QuotaUsed != 22 {
+		t.Fatalf("same-host quota migration lost account distinction: got %d and %d", providers[0].QuotaUsed, providers[1].QuotaUsed)
+	}
+	if repo.stats["quota_used:provider-a"] != 11 || repo.stats["quota_used:provider-b"] != 22 {
+		t.Fatal("same-host quota keys were not migrated to distinct IDs")
+	}
+}
+
+func TestInjectQuotaStatePrefersStableStateAfterPartialMigration(t *testing.T) {
+	legacyName := "news.example.test:563+account-a"
+	repo := &quotaStatsRepo{stats: map[string]int64{
+		"quota_used:provider-primary": 99,
+		"quota_used:" + legacyName:    11,
+	}}
+	m := &manager{ctx: context.Background(), repo: repo, logger: testLogger()}
+	providers := []nntppool.Provider{{
+		Name: "provider-primary",
+		Host: "news.example.test:563",
+		Auth: nntppool.Auth{Username: "account-a"},
+	}}
+
+	m.injectQuotaState(providers)
+
+	if providers[0].QuotaUsed != 99 {
+		t.Fatalf("QuotaUsed = %d, want stable value 99", providers[0].QuotaUsed)
+	}
+	if _, ok := repo.stats["quota_used:"+legacyName]; ok {
+		t.Fatal("legacy key survived partial migration")
+	}
+}
+
+func TestInjectQuotaStateDoesNotDuplicateAmbiguousLegacyKey(t *testing.T) {
+	legacyName := "news.example.test:563+account-a"
+	repo := &quotaStatsRepo{stats: map[string]int64{
+		"quota_used:" + legacyName: 77,
+	}}
+	m := &manager{ctx: context.Background(), repo: repo, logger: testLogger()}
+	providers := []nntppool.Provider{
+		{Name: "provider-a", Host: "news.example.test:563", Auth: nntppool.Auth{Username: "account-a"}},
+		{Name: "provider-b", Host: "news.example.test:563", Auth: nntppool.Auth{Username: "account-a"}},
+	}
+
+	m.injectQuotaState(providers)
+
+	if providers[0].QuotaUsed != 0 || providers[1].QuotaUsed != 0 {
+		t.Fatalf("ambiguous legacy quota was credited to a provider: got %d and %d", providers[0].QuotaUsed, providers[1].QuotaUsed)
+	}
+	if _, ok := repo.stats["quota_used:"+legacyName]; !ok {
+		t.Fatal("ambiguous legacy key was removed instead of being retained")
+	}
+}
+
+func TestInjectQuotaStateMigrationLogOmitsRepositoryError(t *testing.T) {
+	legacyName := "news.example.test:563+account-a"
+	repo := &quotaStatsRepo{
+		stats:        map[string]int64{"quota_used:" + legacyName: 77},
+		migrationErr: errors.New("write failed for legacy quota key " + legacyName),
+	}
+	var logs bytes.Buffer
+	m := &manager{
+		ctx:    context.Background(),
+		repo:   repo,
+		logger: slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	providers := []nntppool.Provider{{
+		Name: "provider-a", Host: "news.example.test:563", Auth: nntppool.Auth{Username: "account-a"},
+	}}
+
+	m.injectQuotaState(providers)
+
+	if strings.Contains(logs.String(), "account-a") {
+		t.Fatalf("migration log exposed a legacy provider key: %s", logs.String())
+	}
+	if !strings.Contains(logs.String(), "error_class=repository") {
+		t.Fatalf("migration log did not retain a value-free error classification: %s", logs.String())
+	}
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}


### PR DESCRIPTION
## Summary

nntppool PR #87 adds an optional stable `Provider.Name` with the existing host/account fallback for callers that do not provide one. This change validates unique non-empty provider IDs, sets `Name: p.ID` at the AltMount boundary, and uses the ID for pool lookup, metrics, speed tests, and propagated errors. Authentication usernames therefore do not enter external provider names while endpoint host context remains available where it is operationally useful.

Provider status no longer includes an authentication username. Frontend types and checked-in Swagger/OpenAPI artifacts are synchronized. Existing quota keys are migrated atomically from the legacy host/account form to stable IDs; ambiguous legacy keys are retained rather than credited to multiple IDs.

The companion nntppool change must merge and release before this PR is merge-ready. No contributor-fork replace is part of this branch.

## Tests

- nntppool PR #87: `go test -race ./...` and `go vet ./...` pass.
- AltMount focused config/pool/database tests pass.
- AltMount focused race tests for config/pool/database and API pass.
- AltMount full `go vet ./...` passes.
- AltMount full `go test ./...` reaches the complete suite; only the existing environment-sensitive `internal/metadata` directory-mtime and `internal/updater` writability tests fail.
- Frontend build is not runnable in this checkout because frontend dependencies (`tsc`) are not installed.