### PR TITLE
feat(import): pin symlink timestamps for library symlinks

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -477,6 +477,23 @@ class APIClient {
 		});
 	}
 
+	async pinSymlinkTimestamps() {
+		return this.request<{
+			message: string;
+			records: number;
+			pinned: number;
+			skipped_no_path: number;
+			skipped_missing: number;
+			skipped_not_symlink: number;
+			errors: string[];
+			error_count: number;
+			warning?: string;
+			completed_at: string;
+		}>("/health/pin-symlink-timestamps", {
+			method: "POST",
+		});
+	}
+
 	async cleanupHealth(params?: HealthCleanupRequest) {
 		return this.request<HealthCleanupResponse>("/health/cleanup", {
 			method: "DELETE",

--- a/frontend/src/components/config/WorkersConfigSection.tsx
+++ b/frontend/src/components/config/WorkersConfigSection.tsx
@@ -10,6 +10,14 @@ interface ImportConfigSectionProps {
 	isUpdating?: boolean;
 }
 
+function toDateTimeLocalValue(timestamp: string | null | undefined): string {
+	if (!timestamp) return "";
+	const date = new Date(timestamp);
+	if (Number.isNaN(date.getTime())) return "";
+	const pad = (value: number) => String(value).padStart(2, "0");
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
 export function ImportConfigSection({
 	config,
 	onUpdate,
@@ -28,7 +36,7 @@ export function ImportConfigSection({
 
 	const handleInputChange = (
 		field: keyof ImportConfig,
-		value: number | boolean | string | string[],
+		value: number | boolean | string | string[] | null,
 	) => {
 		const newData = { ...formData, [field]: value };
 		setFormData(newData);
@@ -294,6 +302,28 @@ export function ImportConfigSection({
 								/>
 								<p className="label mt-2 min-w-0 max-w-full whitespace-normal break-words text-base-content/70 text-xs">
 									Absolute path for strategy output.
+								</p>
+							</fieldset>
+						)}
+
+						{formData.import_strategy === "SYMLINK" && (
+							<fieldset className="fieldset min-w-0">
+								<legend className="fieldset-legend font-semibold">Pin Symlink Timestamp</legend>
+								<input
+									type="datetime-local"
+									className="input input-bordered w-full min-w-0 max-w-full bg-base-100"
+									value={toDateTimeLocalValue(formData.pin_symlink_timestamp)}
+									disabled={isReadOnly}
+									onChange={(e) =>
+										handleInputChange(
+											"pin_symlink_timestamp",
+											e.target.value ? new Date(e.target.value).toISOString() : null,
+										)
+									}
+								/>
+								<p className="label mt-2 min-w-0 max-w-full whitespace-normal break-words text-base-content/70 text-xs leading-relaxed">
+									Fix all symlink modification times to this date. Prevents Plex/Jellyfin from
+									re-scanning files as new. Leave empty to disable.
 								</p>
 							</fieldset>
 						)}

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -218,6 +218,12 @@ export const useRegenerateSymlinks = () => {
 	});
 };
 
+export const usePinSymlinkTimestamps = () => {
+	return useMutation({
+		mutationFn: () => apiClient.pinSymlinkTimestamps(),
+	});
+};
+
 export const useDeleteHealthItem = () => {
 	const queryClient = useQueryClient();
 

--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -1,5 +1,13 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { FileCheck, RefreshCw, RotateCcw, Settings, ShieldCheck, Trash2 } from "lucide-react";
+import {
+	CalendarClock,
+	FileCheck,
+	RefreshCw,
+	RotateCcw,
+	Settings,
+	ShieldCheck,
+	Trash2,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { apiClient } from "../api/client";
@@ -15,6 +23,7 @@ import {
 	useDirectHealthCheck,
 	useHealth,
 	useHealthStats,
+	usePinSymlinkTimestamps,
 	useRegenerateSymlinks,
 	useRepairBulkHealthItems,
 	useRepairHealthItem,
@@ -104,6 +113,7 @@ export function HealthPage() {
 	const cleanupHealth = useCleanupHealth();
 	const resetAllHealth = useResetAllHealthChecks();
 	const regenerateSymlinks = useRegenerateSymlinks();
+	const pinSymlinkTimestamps = usePinSymlinkTimestamps();
 	const directHealthCheck = useDirectHealthCheck();
 	const cancelHealthCheck = useCancelHealthCheck();
 	const repairHealthItem = useRepairHealthItem();
@@ -293,6 +303,36 @@ export function HealthPage() {
 		if (selectedItems.size === 0) return;
 		handleRegenerateLibraryFiles(Array.from(selectedItems));
 	};
+
+	const handlePinTimestamps = useCallback(async () => {
+		const confirmed = await confirmAction(
+			"Apply Pinned Date to Existing Symlinks",
+			"Updates only the modification date of existing symlinks to the configured 'Pin Symlink Timestamp' value. Symlinks are never removed, recreated, or re-pointed, and non-symlink files (e.g. hardlinks created by ARR applications) are left untouched.",
+			{
+				type: "info",
+				confirmText: "Apply Date",
+				confirmButtonClass: "btn-primary",
+			},
+		);
+
+		if (!confirmed) return;
+
+		try {
+			const result = await pinSymlinkTimestamps.mutateAsync();
+			showToast({
+				title: "Timestamp Pinning Complete",
+				message: `${result.message}${result.skipped_not_symlink > 0 ? ` (${result.skipped_not_symlink} non-symlink entries skipped)` : ""}`,
+				type: result.error_count > 0 ? "warning" : "success",
+			});
+		} catch (error) {
+			console.error("Failed to pin symlink timestamps:", error);
+			showToast({
+				title: "Timestamp Pinning Failed",
+				message: error instanceof Error ? error.message : "Failed to pin symlink timestamps",
+				type: "error",
+			});
+		}
+	}, [confirmAction, pinSymlinkTimestamps, showToast]);
 
 	const handleCleanupConfirm = async () => {
 		try {
@@ -689,6 +729,19 @@ export function HealthPage() {
 									<Trash2 className="h-4 w-4" /> Cleanup Records
 								</button>
 							</li>
+							{(config?.import?.import_strategy === "SYMLINK" ||
+								!!config?.import?.pin_symlink_timestamp) && (
+								<li>
+									<button
+										type="button"
+										onClick={handlePinTimestamps}
+										className="gap-2"
+										title="Applies the configured pinned date to existing symlinks in place. Never removes, recreates, or re-points symlinks; non-symlink files are skipped."
+									>
+										<CalendarClock className="h-4 w-4" /> Apply Pinned Date to Symlinks
+									</button>
+								</li>
+							)}
 							{config?.import?.import_strategy !== "NONE" && (
 								<li>
 									<button

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -238,6 +238,7 @@ export interface ImportConfig {
 	filter_sample_files?: boolean;
 	failed_item_retention_hours?: number | null;
 	history_retention_days?: number | null;
+	pin_symlink_timestamp?: string | null;
 }
 
 // Log configuration

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	golang.org/x/crypto v0.46.0
 	golang.org/x/net v0.48.0
 	golang.org/x/sync v0.19.0
+	golang.org/x/sys v0.39.0
 	golang.org/x/term v0.38.0
 	golang.org/x/text v0.32.0
 	golift.io/starr v1.2.0
@@ -291,7 +292,6 @@ require (
 	golang.org/x/image v0.13.0 // indirect
 	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/telemetry v0.0.0-20251203150158-8fff8a5912fc // indirect
 	golang.org/x/tools v0.40.0 // indirect
 	golang.org/x/vuln v1.1.4 // indirect

--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -1442,6 +1443,15 @@ func (s *Server) handleRegenerateLibraryFiles(c *fiber.Ctx) error {
 			continue
 		}
 
+		// Pin the symlink timestamp if configured
+		if cfg.Import.PinSymlinkTimestamp != nil && cfg.Import.ImportStrategy == config.ImportStrategySYMLINK {
+			if err := utils.PinSymlinkTime(libraryPath, *cfg.Import.PinSymlinkTimestamp); err != nil {
+				slog.WarnContext(ctx, "Failed to pin symlink timestamp",
+					"library_path", libraryPath,
+					"error", err)
+			}
+		}
+
 		slog.InfoContext(ctx, "Library file recreated",
 			"file_path", file.FilePath,
 			"library_path", libraryPath,
@@ -1514,4 +1524,85 @@ func deleteLibraryFile(ctx context.Context, cfg *config.Config, item *database.F
 	}
 
 	return true
+}
+
+// handlePinLibrarySymlinkTimestamps handles POST /api/health/pin-symlink-timestamps
+//
+//	@Summary		Apply pinned date to existing library symlinks
+//	@Description	Sets the configured pin_symlink_timestamp on every stored library path that is a symlink. Existing symlinks are only touched in place (utimensat): nothing is removed, recreated, or re-pointed, so ARR-managed library layouts are never altered.
+//	@Tags			Health
+//	@Success		200	{object}	APIResponse
+//	@Failure		400	{object}	APIResponse
+//	@Security		BearerAuth
+//	@Router			/health/pin-symlink-timestamps [post]
+func (s *Server) handlePinLibrarySymlinkTimestamps(c *fiber.Ctx) error {
+	ctx := c.Context()
+	cfg := s.configManager.GetConfig()
+
+	if cfg.Import.PinSymlinkTimestamp == nil || *cfg.Import.PinSymlinkTimestamp == "" {
+		return RespondBadRequest(c, "No pinned date configured",
+			"Set 'Pin Symlink Timestamp' in Settings > Import first")
+	}
+
+	files, err := s.healthRepo.GetFilesForLibrarySync(ctx)
+	if err != nil {
+		return RespondInternalError(c, "Failed to retrieve health records", err.Error())
+	}
+
+	pinned, skippedNoPath, skippedMissing, skippedNotSymlink, errorCount := 0, 0, 0, 0, 0
+	errors := make([]string, 0)
+
+	for _, file := range files {
+		if file == nil || file.LibraryPath == nil || *file.LibraryPath == "" {
+			skippedNoPath++
+			continue
+		}
+		info, err := os.Lstat(*file.LibraryPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				skippedMissing++
+				continue
+			}
+			errorCount++
+			errors = append(errors, fmt.Sprintf("%s: %v", *file.LibraryPath, err))
+			continue
+		}
+		// Only touch real symlinks. Hardlinks/copies created by ARR applications
+		// are left completely alone.
+		if info.Mode()&fs.ModeSymlink == 0 {
+			skippedNotSymlink++
+			continue
+		}
+		if err := utils.PinSymlinkTime(*file.LibraryPath, *cfg.Import.PinSymlinkTimestamp); err != nil {
+			errorCount++
+			errors = append(errors, fmt.Sprintf("%s: %v", *file.LibraryPath, err))
+			continue
+		}
+		pinned++
+	}
+
+	slog.InfoContext(ctx, "Applied pinned timestamp to existing library symlinks",
+		"records", len(files),
+		"pinned", pinned,
+		"skipped_no_path", skippedNoPath,
+		"skipped_missing", skippedMissing,
+		"skipped_not_symlink", skippedNotSymlink,
+		"error_count", errorCount)
+
+	response := fiber.Map{
+		"message":             fmt.Sprintf("Pinned %d of %d library entries to %s", pinned, len(files), *cfg.Import.PinSymlinkTimestamp),
+		"records":             len(files),
+		"pinned":              pinned,
+		"skipped_no_path":     skippedNoPath,
+		"skipped_missing":     skippedMissing,
+		"skipped_not_symlink": skippedNotSymlink,
+		"errors":              errors,
+		"error_count":         errorCount,
+		"completed_at":        time.Now().Format(time.RFC3339),
+	}
+	if errorCount > 0 {
+		response["warning"] = fmt.Sprintf("%d symlink(s) could not be updated", errorCount)
+	}
+
+	return RespondSuccess(c, response)
 }

--- a/internal/api/import_api_response_test.go
+++ b/internal/api/import_api_response_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/javi11/altmount/internal/config"
+)
+
+func TestImportPinSymlinkTimestampRoundTrip(t *testing.T) {
+	ts := "2026-08-21T14:30:00Z"
+	cfg := &config.Config{
+		Import: config.ImportConfig{
+			PinSymlinkTimestamp: &ts,
+		},
+	}
+
+	resp := ToConfigAPIResponse(cfg, "")
+
+	if resp.Import.PinSymlinkTimestamp == nil {
+		t.Fatalf("expected PinSymlinkTimestamp in response, got nil")
+	}
+
+	if *resp.Import.PinSymlinkTimestamp != ts {
+		t.Errorf("PinSymlinkTimestamp = %q; want %q", *resp.Import.PinSymlinkTimestamp, ts)
+	}
+
+	data, err := json.Marshal(resp.Import)
+	if err != nil {
+		t.Fatalf("marshal import response: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"pin_symlink_timestamp":"2026-08-21T14:30:00Z"`) {
+		t.Errorf("expected pin_symlink_timestamp in response JSON, got: %s", data)
+	}
+}

--- a/internal/api/nzbdav_handlers.go
+++ b/internal/api/nzbdav_handlers.go
@@ -170,6 +170,7 @@ func (s *Server) handleMigrateNzbdavSymlinks(c *fiber.Ctx) error {
 		"nzbdav",
 		lookup,
 		req.DryRun,
+		cfg.Import.PinSymlinkTimestamp,
 	)
 	if err != nil {
 		return RespondInternalError(c, "Symlink migration failed", err.Error())

--- a/internal/api/pin_symlink_timestamps_test.go
+++ b/internal/api/pin_symlink_timestamps_test.go
@@ -1,0 +1,223 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func setupPinTimestampsFixture(t *testing.T) (*fiber.App, *database.HealthRepository, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite3", "file::memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE file_health (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			file_path TEXT NOT NULL UNIQUE,
+			library_path TEXT,
+			status TEXT NOT NULL,
+			last_checked DATETIME,
+			last_error TEXT,
+			retry_count INTEGER DEFAULT 0,
+			max_retries INTEGER DEFAULT 3,
+			repair_retry_count INTEGER DEFAULT 0,
+			max_repair_retries INTEGER DEFAULT 3,
+			source_nzb_path TEXT,
+			error_details TEXT,
+			metadata TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			release_date DATETIME,
+			scheduled_check_at DATETIME,
+			priority INTEGER DEFAULT 0,
+			streaming_failure_count INTEGER DEFAULT 0,
+			is_masked BOOLEAN DEFAULT FALSE,
+			indexer TEXT DEFAULT NULL,
+			download_id TEXT DEFAULT NULL
+		);
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := database.NewHealthRepository(db, database.DialectSQLite)
+
+	pin := "2020-01-01T01:00:00Z"
+	cfg := config.DefaultConfig(dir)
+	cfg.Import.PinSymlinkTimestamp = &pin
+
+	server := &Server{
+		configManager: config.NewManager(cfg, filepath.Join(dir, "config.yaml")),
+		healthRepo:    repo,
+	}
+
+	app := fiber.New()
+	app.Post("/health/pin-symlink-timestamps", server.handlePinLibrarySymlinkTimestamps)
+	return app, repo, dir
+}
+
+func seedHealthRecord(t *testing.T, repo *database.HealthRepository, filePath, libraryPath string) {
+	t.Helper()
+	if err := repo.UpdateFileHealth(context.Background(), filePath, "healthy", nil, nil, nil, false); err != nil {
+		t.Fatalf("seed health record %s: %v", filePath, err)
+	}
+	if libraryPath != "" {
+		if err := repo.UpdateLibraryPath(context.Background(), filePath, libraryPath); err != nil {
+			t.Fatalf("update library path: %v", err)
+		}
+	}
+}
+
+func TestPinLibrarySymlinkTimestampsOnlyTouchesSymlinks(t *testing.T) {
+	app, repo, dir := setupPinTimestampsFixture(t)
+
+	// 1. Real symlink -> pinned in place.
+	symlinkTarget := filepath.Join(dir, "mount", "movie.mkv")
+	if err := os.MkdirAll(filepath.Dir(symlinkTarget), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(symlinkTarget, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	targetBefore, err := os.Stat(symlinkTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "library", "movie.mkv")
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(symlinkTarget, link); err != nil {
+		t.Fatal(err)
+	}
+	seedHealthRecord(t, repo, symlinkTarget, link)
+
+	// 2. Regular file at library path (ARR hardlink/copy import) -> untouched.
+	hardSource := filepath.Join(dir, "mount", "hardlink.mkv")
+	if err := os.WriteFile(hardSource, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hardFile := filepath.Join(dir, "library", "hardlink.mkv")
+	if err := os.WriteFile(hardFile, []byte("y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hardBefore, err := os.Stat(hardFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedHealthRecord(t, repo, hardSource, hardFile)
+
+	// 3. Missing library path -> skipped_missing, no error.
+	seedHealthRecord(t, repo, filepath.Join(dir, "mount", "gone.mkv"), filepath.Join(dir, "library", "gone.mkv"))
+
+	// 4. Record without stored LibraryPath -> skipped_no_path.
+	seedHealthRecord(t, repo, filepath.Join(dir, "mount", "nopath.mkv"), "")
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodPost, "/health/pin-symlink-timestamps", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var out struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Message           string   `json:"message"`
+			Pinned            int      `json:"pinned"`
+			SkippedNoPath     int      `json:"skipped_no_path"`
+			SkippedMissing    int      `json:"skipped_missing"`
+			SkippedNotSymlink int      `json:"skipped_not_symlink"`
+			ErrorCount        int      `json:"error_count"`
+			Errors            []string `json:"errors"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+
+	if !out.Success {
+		t.Fatalf("request failed: %+v", out)
+	}
+	if out.Data.Pinned != 1 || out.Data.SkippedNotSymlink != 1 ||
+		out.Data.SkippedMissing != 1 || out.Data.SkippedNoPath != 1 || out.Data.ErrorCount != 0 {
+		t.Fatalf("unexpected summary: %+v", out.Data)
+	}
+	if !strings.Contains(out.Data.Message, "Pinned 1 of 4") {
+		t.Fatalf("message = %q", out.Data.Message)
+	}
+
+	// Symlink still a symlink, mtime pinned to the configured value.
+	li, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if li.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("library entry is no longer a symlink")
+	}
+	want, _ := time.Parse(time.RFC3339, "2020-01-01T01:00:00Z")
+	if !li.ModTime().Equal(want) {
+		t.Fatalf("symlink mtime = %v, want %v", li.ModTime(), want)
+	}
+
+	// Target file mtime untouched by the pin operation.
+	targetAfter, err := os.Stat(symlinkTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !targetAfter.ModTime().Equal(targetBefore.ModTime()) {
+		t.Fatalf("target mtime changed: %v -> %v", targetBefore.ModTime(), targetAfter.ModTime())
+	}
+
+	// Regular file at library path untouched (content and mtime).
+	content, err := os.ReadFile(hardFile)
+	if err != nil || string(content) != "y" {
+		t.Fatalf("regular file modified: %v %q", err, content)
+	}
+	hardAfter, err := os.Stat(hardFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hardAfter.ModTime().Equal(hardBefore.ModTime()) {
+		t.Fatalf("regular file mtime changed: %v -> %v", hardBefore.ModTime(), hardAfter.ModTime())
+	}
+}
+
+func TestPinLibrarySymlinkTimestampsRequiresConfig(t *testing.T) {
+	app, _, dir := setupPinTimestampsFixture(t)
+	_ = dir
+
+	// Overwrite the manager with a config that has no pinned date.
+	cfg := config.DefaultConfig(t.TempDir())
+	app2 := fiber.New()
+	server := &Server{
+		configManager: config.NewManager(cfg, filepath.Join(t.TempDir(), "config.yaml")),
+		healthRepo:    nil,
+	}
+	app2.Post("/health/pin-symlink-timestamps", server.handlePinLibrarySymlinkTimestamps)
+
+	_ = app
+	resp, err := app2.Test(httptest.NewRequest(fiber.MethodPost, "/health/pin-symlink-timestamps", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -284,6 +284,7 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	api.Delete("/health/cleanup", s.handleCleanupHealth)
 	api.Post("/health/reset-all", s.handleResetAllHealthChecks)
 	api.Post("/health/regenerate-symlinks", s.handleRegenerateLibraryFiles)
+	api.Post("/health/pin-symlink-timestamps", s.handlePinLibrarySymlinkTimestamps)
 	api.Post("/health/check", s.handleAddHealthCheck)
 	api.Get("/health/worker/status", s.handleGetHealthWorkerStatus)
 	api.Post("/health/:id/repair", s.handleRepairHealth)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -155,10 +155,11 @@ type ImportAPIResponse struct {
 	ImportDir                      *string               `json:"import_dir"`
 	WatchDir                       *string               `json:"watch_dir"`
 
-	WatchIntervalSeconds     *int  `json:"watch_interval_seconds,omitempty"`
-	AllowNestedRarExtraction *bool `json:"allow_nested_rar_extraction,omitempty"`
-	RenameToNzbName          *bool `json:"rename_to_nzb_name,omitempty"`
-	FilterSampleFiles        *bool `json:"filter_sample_files,omitempty"`
+	WatchIntervalSeconds     *int    `json:"watch_interval_seconds,omitempty"`
+	AllowNestedRarExtraction *bool   `json:"allow_nested_rar_extraction,omitempty"`
+	RenameToNzbName          *bool   `json:"rename_to_nzb_name,omitempty"`
+	FilterSampleFiles        *bool   `json:"filter_sample_files,omitempty"`
+	PinSymlinkTimestamp      *string `json:"pin_symlink_timestamp,omitempty"`
 }
 
 // SABnzbdAPIResponse sanitizes SABnzbd config for API responses
@@ -566,6 +567,7 @@ func ToImportAPIResponse(importConfig config.ImportConfig) ImportAPIResponse {
 		AllowNestedRarExtraction: importConfig.AllowNestedRarExtraction,
 		RenameToNzbName:          importConfig.RenameToNzbName,
 		FilterSampleFiles:        importConfig.FilterSampleFiles,
+		PinSymlinkTimestamp:      importConfig.PinSymlinkTimestamp,
 	}
 }
 

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -461,6 +461,11 @@ type ImportConfig struct {
 	// grab a different release. Damage beyond the caps, archive-set members
 	// and non-video files fail either way.
 	DamagePolicy string `yaml:"damage_policy" mapstructure:"damage_policy" json:"damage_policy,omitempty"`
+	// PinSymlinkTimestamp, when set to an RFC3339 datetime (e.g.
+	// "2020-01-01T01:00:00Z"), forces every library symlink's mtime/atime to
+	// that fixed value. This prevents media servers (Plex, Jellyfin, etc.) from
+	// treating files as new after a regeneration. Empty/nil = disabled.
+	PinSymlinkTimestamp *string `yaml:"pin_symlink_timestamp" mapstructure:"pin_symlink_timestamp" json:"pin_symlink_timestamp,omitempty"`
 }
 
 // LogConfig represents logging configuration with rotation support
@@ -1781,6 +1786,7 @@ func DefaultConfig(configDir ...string) *Config {
 			IsoAnalyzeTimeoutSeconds: &isoAnalyzeTimeoutSeconds,
 			ImportStrategy:           ImportStrategyNone, // Default: no import strategy (direct import)
 			ImportDir:                nil,                // No default import directory
+			PinSymlinkTimestamp:      nil,                // Disabled by default
 			WatchDir:                 nil,
 			WatchIntervalSeconds:     &watchIntervalSeconds,
 			FailedItemRetentionHours: &failedItemRetentionHours,

--- a/internal/health/library_sync.go
+++ b/internal/health/library_sync.go
@@ -1166,6 +1166,7 @@ func updateSymlinkForMountChange(
 	currentTarget string,
 	oldMountPath string,
 	newMountPath string,
+	pinTimestamp *string,
 ) (string, bool, error) {
 	// Extract relative path within the mount
 	relativePath := strings.TrimPrefix(currentTarget, oldMountPath)
@@ -1196,6 +1197,15 @@ func updateSymlinkForMountChange(
 			"new_target", newTarget,
 			"error", err)
 		return currentTarget, false, err
+	}
+
+	// Pin the symlink timestamp if configured
+	if pinTimestamp != nil {
+		if err := utils.PinSymlinkTime(symlinkPath, *pinTimestamp); err != nil {
+			slog.WarnContext(ctx, "Failed to pin symlink timestamp",
+				"path", symlinkPath,
+				"error", err)
+		}
 	}
 
 	slog.InfoContext(ctx, "Updated symlink to new mount path",
@@ -1267,7 +1277,7 @@ func (lsw *LibrarySyncWorker) getAllLibraryFiles(ctx context.Context, oldMountPa
 
 			// Update symlink if it points to the old mount path
 			if shouldUpdateSymlinks && strings.HasPrefix(cleanTarget, oldMountPathClean) {
-				newTarget, updated, err := updateSymlinkForMountChange(ctx, path, cleanTarget, oldMountPathClean, newMountPathClean)
+				newTarget, updated, err := updateSymlinkForMountChange(ctx, path, cleanTarget, oldMountPathClean, newMountPathClean, cfg.Import.PinSymlinkTimestamp)
 				if err != nil {
 					return nil
 				}
@@ -1440,7 +1450,7 @@ func (lsw *LibrarySyncWorker) getAllImportDirFiles(ctx context.Context, oldMount
 
 			// Update symlink if it points to the old mount path
 			if shouldUpdateSymlinks && strings.HasPrefix(cleanTarget, oldMountPathClean) {
-				newTarget, updated, _ := updateSymlinkForMountChange(ctx, path, cleanTarget, oldMountPathClean, newMountPathClean)
+				newTarget, updated, _ := updateSymlinkForMountChange(ctx, path, cleanTarget, oldMountPathClean, newMountPathClean, cfg.Import.PinSymlinkTimestamp)
 				if updated {
 					symlinkUpdates++
 					cleanTarget = newTarget

--- a/internal/importer/migration/symlinks.go
+++ b/internal/importer/migration/symlinks.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/javi11/altmount/internal/utils"
 )
 
 // SymlinkLookup looks up the final AltMount path for a given source and external ID.
@@ -39,6 +41,7 @@ func RewriteLibrarySymlinks(
 	source string,
 	lookup SymlinkLookup,
 	dryRun bool,
+	pinTimestamp *string,
 ) (*RewriteReport, error) {
 	report := &RewriteReport{
 		Unmatched: []string{},
@@ -129,6 +132,11 @@ func RewriteLibrarySymlinks(
 				_ = os.Remove(tmpPath)
 				report.Errors = append(report.Errors, fmt.Sprintf("rename %s -> %s: %v", tmpPath, path, err))
 				return nil
+			}
+			if pinTimestamp != nil {
+				if err := utils.PinSymlinkTime(path, *pinTimestamp); err != nil {
+					report.Errors = append(report.Errors, fmt.Sprintf("pin timestamp %s: %v", path, err))
+				}
 			}
 		} else {
 			// .rclonelink: overwrite file content with the new target path.

--- a/internal/importer/migration/symlinks_test.go
+++ b/internal/importer/migration/symlinks_test.go
@@ -253,6 +253,7 @@ func TestRewriteLibrarySymlinks(t *testing.T) {
 				source,
 				tc.lookup,
 				tc.dryRun,
+				nil,
 			)
 
 			if tc.name == "context cancellation stops walk" {

--- a/internal/importer/postprocessor/symlink_creator.go
+++ b/internal/importer/postprocessor/symlink_creator.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/utils"
 )
 
 // CreateSymlinks creates symlinks for an imported item based on the import strategy
@@ -20,7 +21,7 @@ func (c *Coordinator) CreateSymlinks(ctx context.Context, item *database.ImportQ
 	// regardless of the configured import strategy.
 	if item.TargetPath != nil && *item.TargetPath != "" {
 		actualPath := filepath.Join(cfg.MountPath, strings.TrimPrefix(resultingPath, "/"))
-		return c.createAbsoluteSymlink(actualPath, *item.TargetPath)
+		return c.createAbsoluteSymlink(actualPath, *item.TargetPath, cfg.Import.PinSymlinkTimestamp)
 	}
 
 	// Check if symlinks are enabled
@@ -150,7 +151,7 @@ func (c *Coordinator) CreateSymlinks(ctx context.Context, item *database.ImportQ
 
 // createAbsoluteSymlink creates a symlink at an exact absolute destination path.
 // It creates any missing parent directories and removes an existing symlink at destPath.
-func (c *Coordinator) createAbsoluteSymlink(actualPath, destPath string) error {
+func (c *Coordinator) createAbsoluteSymlink(actualPath, destPath string, pinTimestamp *string) error {
 	if err := os.MkdirAll(filepath.Dir(destPath), 0775); err != nil {
 		return fmt.Errorf("failed to create parent directory for target symlink: %w", err)
 	}
@@ -164,6 +165,14 @@ func (c *Coordinator) createAbsoluteSymlink(actualPath, destPath string) error {
 
 	if err := os.Symlink(actualPath, destPath); err != nil {
 		return fmt.Errorf("failed to create symlink at target path: %w", err)
+	}
+
+	if pinTimestamp != nil {
+		if err := utils.PinSymlinkTime(destPath, *pinTimestamp); err != nil {
+			c.log.WarnContext(context.Background(), "Failed to pin symlink timestamp",
+				"path", destPath,
+				"error", err)
+		}
 	}
 
 	return nil
@@ -191,6 +200,14 @@ func (c *Coordinator) createSingleSymlink(actualPath, resultingPath string) erro
 	// Create the symlink using the absolute actual path
 	if err := os.Symlink(actualPath, symlinkPath); err != nil {
 		return fmt.Errorf("failed to create symlink: %w", err)
+	}
+
+	if cfg.Import.PinSymlinkTimestamp != nil {
+		if err := utils.PinSymlinkTime(symlinkPath, *cfg.Import.PinSymlinkTimestamp); err != nil {
+			c.log.WarnContext(context.Background(), "Failed to pin symlink timestamp",
+				"path", symlinkPath,
+				"error", err)
+		}
 	}
 
 	return nil

--- a/internal/utils/symlink_timestamp.go
+++ b/internal/utils/symlink_timestamp.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"fmt"
+	"time"
+)
+
+// PinSymlinkTime sets the modification and access time of a symlink to the
+// given RFC3339 timestamp. This is used to give all library symlinks a fixed,
+// stable timestamp so media servers (e.g. Plex) never treat them as new or
+// modified after a regeneration. If timestamp is empty the function is a no-op.
+func PinSymlinkTime(symlinkPath, timestamp string) error {
+	if timestamp == "" {
+		return nil
+	}
+
+	t, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return fmt.Errorf("invalid pin_symlink_timestamp value %q: %w", timestamp, err)
+	}
+
+	if err := setSymlinkTimes(symlinkPath, t); err != nil {
+		return fmt.Errorf("failed to set timestamp on %s: %w", symlinkPath, err)
+	}
+
+	return nil
+}

--- a/internal/utils/symlink_timestamp_test.go
+++ b/internal/utils/symlink_timestamp_test.go
@@ -1,0 +1,45 @@
+//go:build !windows
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPinSymlinkTimeDoesNotModifyTarget(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "link")
+	if err := os.WriteFile(target, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	targetTime := time.Date(2020, time.January, 2, 3, 4, 5, 0, time.UTC)
+	if err := os.Chtimes(target, targetTime, targetTime); err != nil {
+		t.Fatal(err)
+	}
+	pinned := time.Date(2024, time.June, 7, 8, 9, 10, 0, time.UTC)
+	if err := PinSymlinkTime(link, pinned.Format(time.RFC3339)); err != nil {
+		t.Fatal(err)
+	}
+
+	targetInfo, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !targetInfo.ModTime().Equal(targetTime) {
+		t.Fatalf("target mtime changed: got %v, want %v", targetInfo.ModTime(), targetTime)
+	}
+	linkInfo, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !linkInfo.ModTime().Equal(pinned) {
+		t.Fatalf("symlink mtime = %v, want %v", linkInfo.ModTime(), pinned)
+	}
+}

--- a/internal/utils/symlink_timestamp_unix.go
+++ b/internal/utils/symlink_timestamp_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package utils
+
+import (
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func setSymlinkTimes(path string, t time.Time) error {
+	ns := t.UnixNano()
+	times := []unix.Timespec{unix.NsecToTimespec(ns), unix.NsecToTimespec(ns)}
+	return unix.UtimesNanoAt(unix.AT_FDCWD, path, times, unix.AT_SYMLINK_NOFOLLOW)
+}

--- a/internal/utils/symlink_timestamp_windows.go
+++ b/internal/utils/symlink_timestamp_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package utils
+
+import (
+	"fmt"
+	"time"
+)
+
+// Refuse rather than silently changing the target file. Windows has no
+// portable no-follow timestamp operation in the Go standard library.
+func setSymlinkTimes(_ string, _ time.Time) error {
+	return fmt.Errorf("pinning symlink timestamps is not supported on Windows")
+}


### PR DESCRIPTION
## Summary

Adds an optional `pin_symlink_timestamp` import setting that stamps library symlinks with a fixed mtime instead of the current time, so media servers and backup tools see stable timestamps across re-imports and re-creations.

- `pin_symlink_timestamp` import option: pins symlink mtimes without following the link (separate unix/windows implementations — `os.Lutimes`-equivalent behavior)
- Non-destructive **Apply Pinned Date to Symlinks** action in the health UI: applies the configured pinned date to existing symlinks in place; never removes, recreates, or re-points symlinks — non-symlink files are skipped
- Health page button appears when the import strategy is SYMLINK or the option is enabled

Independent of #842 — merges cleanly against main.

## Testing
- go build/vet, utils/api/importer suites green
- bun check + production build green