### PR TITLE
feat(importer): expand archive compatibility, password extraction, and optimize seek latency

### DIFF
--- a/internal/importer/archive/rar/processor.go
+++ b/internal/importer/archive/rar/processor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/javi11/altmount/internal/importer/archive"
 	"github.com/javi11/altmount/internal/importer/filesystem"
 	"github.com/javi11/altmount/internal/importer/parser"
+	"github.com/javi11/altmount/internal/importer/parser/fileinfo"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/pool"
 	"github.com/javi11/altmount/internal/progress"
@@ -324,19 +325,49 @@ func checkAnalyzedContentCoverage(ctx context.Context, log *slog.Logger, content
 	return nil
 }
 
-// checkForCompressedFiles validates that no files in the archive are compressed
-// Returns an error if any compressed files are detected
+func isStreamableOrMediaFile(filename string) bool {
+	if fileinfo.IsVideoFile(filename) || fileinfo.IsRarFile(filename) || fileinfo.Is7zFile(filename) {
+		return true
+	}
+	switch strings.ToLower(filepath.Ext(filename)) {
+	case ".iso", ".flac", ".mp3", ".m4a", ".aac", ".wav", ".ogg", ".opus", ".m4b":
+		return true
+	}
+	return false
+}
+
+// checkForCompressedFiles validates that media files in the archive are not compressed.
+// Compressed media files cannot be streamed directly; non-media sidecars (such as .nfo or .txt)
+// are ignored so stored media files can proceed.
 func (rh *rarProcessor) checkForCompressedFiles(aggregatedFiles []rardecode.ArchiveFileInfo) error {
+	hasStoredMedia := false
 	for _, file := range aggregatedFiles {
+		isMedia := isStreamableOrMediaFile(file.Name)
 		if file.Compressed {
-			compressionInfo := ""
-			if file.CompressionMethod != "" {
-				compressionInfo = fmt.Sprintf(" (uses %s compression)", file.CompressionMethod)
+			if isMedia {
+				compressionInfo := ""
+				if file.CompressionMethod != "" {
+					compressionInfo = fmt.Sprintf(" (uses %s compression)", file.CompressionMethod)
+				}
+				return errors.NewNonRetryableError(
+					fmt.Sprintf("compressed media files are not supported: %s%s", file.Name, compressionInfo),
+					nil,
+				)
 			}
-			return errors.NewNonRetryableError(
-				fmt.Sprintf("compressed files are not supported: %s%s", file.Name, compressionInfo),
-				nil,
-			)
+		} else if isMedia {
+			hasStoredMedia = true
+		}
+	}
+	// If the archive contains ONLY non-media files and ALL of them are compressed,
+	// fail fast if none are stored.
+	if !hasStoredMedia {
+		for _, file := range aggregatedFiles {
+			if file.Compressed {
+				return errors.NewNonRetryableError(
+					fmt.Sprintf("compressed files are not supported: %s", file.Name),
+					nil,
+				)
+			}
 		}
 	}
 	return nil
@@ -511,6 +542,11 @@ func (rh *rarProcessor) convertAggregatedFilesToRarContent(ctx context.Context, 
 	out := make([]Content, 0, len(aggregatedFiles))
 
 	for _, af := range aggregatedFiles {
+		if af.Compressed {
+			rh.log.DebugContext(ctx, "Skipping compressed file in RAR archive", "file", af.Name)
+			continue
+		}
+
 		// Normalize backslashes in path (Windows-style paths in RAR archives)
 		normalizedName := strings.ReplaceAll(af.Name, "\\", "/")
 

--- a/internal/importer/archive/rar/processor_test.go
+++ b/internal/importer/archive/rar/processor_test.go
@@ -296,3 +296,40 @@ func TestGroupArchivesByBaseName(t *testing.T) {
 	require.Len(t, group46, 46)
 	require.Len(t, group1, 1)
 }
+
+func TestCheckForCompressedFiles(t *testing.T) {
+	rp := &rarProcessor{}
+
+	// Case 1: Video file is stored, sidecar .nfo is compressed -> MUST PASS (nil error)
+	filesWithStoredVideo := []rardecode.ArchiveFileInfo{
+		{
+			Name:              "The.Umbrella.Academy.S01E01.1080p.mkv",
+			TotalUnpackedSize: 1000000,
+			TotalPackedSize:   1000000,
+			Compressed:        false,
+		},
+		{
+			Name:              "The.Umbrella.Academy.S01E01.nfo",
+			TotalUnpackedSize: 500,
+			TotalPackedSize:   200,
+			Compressed:        true,
+			CompressionMethod: "rar5.0",
+		},
+	}
+	err := rp.checkForCompressedFiles(filesWithStoredVideo)
+	require.NoError(t, err, "stored video with compressed .nfo sidecar should be allowed")
+
+	// Case 2: Video file is compressed -> MUST FAIL with error
+	filesWithCompressedVideo := []rardecode.ArchiveFileInfo{
+		{
+			Name:              "Project.Hail.Mary.2026.1080p.mkv",
+			TotalUnpackedSize: 1000000,
+			TotalPackedSize:   500000,
+			Compressed:        true,
+			CompressionMethod: "rar5.0",
+		},
+	}
+	err = rp.checkForCompressedFiles(filesWithCompressedVideo)
+	require.Error(t, err, "compressed video file must be rejected")
+	require.Contains(t, err.Error(), "compressed media files are not supported")
+}

--- a/internal/importer/archive/rar/utils.go
+++ b/internal/importer/archive/rar/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -176,6 +177,12 @@ func groupHasVolumeGap(files []parser.ParsedFile) bool {
 	expectedStart := 1
 	if scheme == schemeRoll {
 		expectedStart = 0
+		// Handle old-style RAR sets starting with .rar (0) followed by .r01 (2) without .r00 (1).
+		if len(nums) > 1 && nums[0] == 0 && nums[1] == 2 && !slices.Contains(nums, 1) {
+			for i := 1; i < len(nums); i++ {
+				nums[i]--
+			}
+		}
 	}
 	if nums[0] > expectedStart {
 		return true // leading volume(s) missing — archive header gone, can't read

--- a/internal/importer/archive/rar/utils_test.go
+++ b/internal/importer/archive/rar/utils_test.go
@@ -295,3 +295,49 @@ func TestNormalizeRarPartFilenameMix(t *testing.T) {
 	}
 }
 
+func TestGroupHasVolumeGap_NoR00Convention(t *testing.T) {
+	makeFiles := func(names ...string) []parser.ParsedFile {
+		out := make([]parser.ParsedFile, len(names))
+		for i, n := range names {
+			out[i] = parser.ParsedFile{Filename: n}
+		}
+		return out
+	}
+
+	// 11 volumes: movie.rar, movie.r01, movie.r02, ..., movie.r10 (no movie.r00)
+	// Must NOT be detected as having a volume gap
+	files := makeFiles(
+		"movie.rar",
+		"movie.r01",
+		"movie.r02",
+		"movie.r03",
+		"movie.r04",
+		"movie.r05",
+		"movie.r06",
+		"movie.r07",
+		"movie.r08",
+		"movie.r09",
+		"movie.r10",
+	)
+
+	hasGap := groupHasVolumeGap(files)
+	if hasGap {
+		t.Errorf("groupHasVolumeGap(movie.rar + movie.r01..r10) = true, want false (no gap)")
+	}
+
+	// 11 volumes with actual gap: movie.rar, movie.r01, movie.r03..r10 (missing movie.r02)
+	// Must be detected as having a volume gap
+	filesWithGap := makeFiles(
+		"movie.rar",
+		"movie.r01",
+		"movie.r03",
+		"movie.r04",
+		"movie.r05",
+	)
+
+	hasGap2 := groupHasVolumeGap(filesWithGap)
+	if !hasGap2 {
+		t.Errorf("groupHasVolumeGap with missing r02 = false, want true")
+	}
+}
+

--- a/internal/importer/parser/parser.go
+++ b/internal/importer/parser/parser.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"sort"
 	"strconv"
@@ -138,11 +140,9 @@ func (p *Parser) ParseNzb(ctx context.Context, n *nzbparser.Nzb, nzbPath string,
 	// (which may filter/reorder files). The index maps message-id → flat store index.
 	parsed.Store, parsed.SegmentIndex = metadata.BuildStore(n)
 
-	// Determine segment size from meta chunk_size or fallback to first segment size
-	if n.Meta != nil {
-		if pwd, ok := n.Meta["password"]; ok && pwd != "" {
-			parsed.SetPassword(pwd)
-		}
+	// Extract password from metadata, filename tags, subject lines, or raw NZB meta
+	if pwd := extractNzbPassword(n, nzbPath); pwd != "" {
+		parsed.SetPassword(pwd)
 	}
 
 	// Fetch first segment data for all files in parallel
@@ -1452,25 +1452,84 @@ func (p *Parser) determineNzbType(files []ParsedFile) NzbType {
 	return NzbTypeMultiFile
 }
 
+var (
+	passwordBracketsRegex = regexp.MustCompile(`(?i)\{\{\s*([^{}]+?)\s*\}\}`)
+	passwordSlashRegex    = regexp.MustCompile(`(?i)/(?:password|pwd)[:=]\s*([^\s/]+)`)
+	passwordMetaRegex     = regexp.MustCompile(`(?i)<meta\b[^>]*type\s*=\s*["']?(?:password|pass|pwd|password_hash)["']?[^>]*>([\s\S]*?)<\/meta>`)
+)
+
+func extractNzbPassword(n *nzbparser.Nzb, nzbPath string) string {
+	if n == nil {
+		return ""
+	}
+	// 1. Check n.Meta with case-insensitive keys
+	if n.Meta != nil {
+		for k, v := range n.Meta {
+			if strings.EqualFold(k, "password") || strings.EqualFold(k, "pass") || strings.EqualFold(k, "pwd") || strings.EqualFold(k, "password_hash") {
+				if trimmed := strings.TrimSpace(v); trimmed != "" {
+					return trimmed
+				}
+			}
+		}
+	}
+	// 2. Check filename for {{password}} or /password:xyz/ patterns
+	baseName := filepath.Base(nzbPath)
+	if m := passwordBracketsRegex.FindStringSubmatch(baseName); len(m) > 1 {
+		if trimmed := strings.TrimSpace(m[1]); trimmed != "" {
+			return trimmed
+		}
+	}
+	if m := passwordSlashRegex.FindStringSubmatch(baseName); len(m) > 1 {
+		if trimmed := strings.TrimSpace(m[1]); trimmed != "" {
+			return trimmed
+		}
+	}
+	// 3. Check file subjects for {{password}} or /password:xyz/
+	for _, f := range n.Files {
+		if m := passwordBracketsRegex.FindStringSubmatch(f.Subject); len(m) > 1 {
+			if trimmed := strings.TrimSpace(m[1]); trimmed != "" {
+				return trimmed
+			}
+		}
+		if m := passwordSlashRegex.FindStringSubmatch(f.Subject); len(m) > 1 {
+			if trimmed := strings.TrimSpace(m[1]); trimmed != "" {
+				return trimmed
+			}
+		}
+	}
+	// 4. Check NZB file on disk if available (for <meta type="password"> outside <head>)
+	if nzbPath != "" {
+		if data, err := os.ReadFile(nzbPath); err == nil && len(data) > 0 {
+			limit := len(data)
+			if limit > 64*1024 {
+				limit = 64 * 1024
+			}
+			if m := passwordMetaRegex.FindSubmatch(data[:limit]); len(m) > 1 {
+				if trimmed := strings.TrimSpace(string(m[1])); trimmed != "" {
+					return trimmed
+				}
+			}
+		}
+	}
+	return ""
+}
+
 // propagateArchiveType sets the archive-type flag on non-PAR2 files that are
-// confirmed archive parts. Propagation is gated on the file already being
-// detected as an archive (via magic bytes or extension), preventing non-archive
-// sidecars (.txt, .nfo, etc.) from being wrongly classified.
+// archive parts (including split continuation volumes with numeric or extensionless names).
+// Non-archive sidecars (.txt, .nfo, .sfv, etc.) are excluded so they are processed as regular files.
 func (p *Parser) propagateArchiveType(parsed *ParsedNzb) {
 	switch parsed.Type {
 	case NzbType7zArchive:
 		for i := range parsed.Files {
 			f := &parsed.Files[i]
-			if !f.IsPar2Archive && !fileinfo.IsPar2File(f.Filename) &&
-				(f.Is7zArchive || fileinfo.Is7zFile(f.Filename)) {
+			if !f.IsPar2Archive && !fileinfo.IsPar2File(f.Filename) && !isPar2SidecarExtension(f.Filename) {
 				f.Is7zArchive = true
 			}
 		}
 	case NzbTypeRarArchive:
 		for i := range parsed.Files {
 			f := &parsed.Files[i]
-			if !f.IsPar2Archive && !fileinfo.IsPar2File(f.Filename) &&
-				(f.IsRarArchive || fileinfo.IsRarFile(f.Filename)) {
+			if !f.IsPar2Archive && !fileinfo.IsPar2File(f.Filename) && !isPar2SidecarExtension(f.Filename) {
 				f.IsRarArchive = true
 			}
 		}

--- a/internal/importer/parser/parser_test.go
+++ b/internal/importer/parser/parser_test.go
@@ -282,3 +282,63 @@ func TestPropagateArchiveType_SkipsTxtSidecar(t *testing.T) {
 		}
 	}
 }
+
+func TestExtractNzbPassword(t *testing.T) {
+	// Case 1: n.Meta with password
+	n1 := &nzbparser.Nzb{
+		Meta: map[string]string{
+			"password": "secret_password_1",
+		},
+	}
+	assert.Equal(t, "secret_password_1", extractNzbPassword(n1, "movie.nzb"))
+
+	// Case 2: n.Meta with uppercase Password
+	n2 := &nzbparser.Nzb{
+		Meta: map[string]string{
+			"Password": "secret_password_2",
+		},
+	}
+	assert.Equal(t, "secret_password_2", extractNzbPassword(n2, "movie.nzb"))
+
+	// Case 3: Filename {{password}}
+	n3 := &nzbparser.Nzb{}
+	assert.Equal(t, "secret_in_name", extractNzbPassword(n3, "Movie.Title.2024.1080p{{secret_in_name}}.nzb"))
+
+	// Case 4: Subject {{password}}
+	n4 := &nzbparser.Nzb{
+		Files: []nzbparser.NzbFile{
+			{Subject: "[1234/5678] - \"movie.part01.rar\" yEnc (1/100) {{subject_pass}}"},
+		},
+	}
+	assert.Equal(t, "subject_pass", extractNzbPassword(n4, "movie.nzb"))
+
+	// Case 5: No password
+	n5 := &nzbparser.Nzb{
+		Files: []nzbparser.NzbFile{
+			{Subject: "[1234/5678] - \"movie.part01.rar\" yEnc (1/100)"},
+		},
+	}
+	assert.Equal(t, "", extractNzbPassword(n5, "movie.nzb"))
+}
+
+func TestPropagateArchiveType_NumericExtensions(t *testing.T) {
+	parsed := &ParsedNzb{
+		Type: NzbTypeRarArchive,
+		Files: []ParsedFile{
+			{Filename: "b082fa0beaa644d3aa01045d5b8d0b36.1", IsRarArchive: true},
+			{Filename: "b082fa0beaa644d3aa01045d5b8d0b36.2", IsRarArchive: false},
+			{Filename: "b082fa0beaa644d3aa01045d5b8d0b36.193", IsRarArchive: false},
+			{Filename: "b082fa0beaa644d3aa01045d5b8d0b36.nfo", IsRarArchive: false},
+			{Filename: "b082fa0beaa644d3aa01045d5b8d0b36.par2", IsPar2Archive: true},
+		},
+	}
+
+	p := &Parser{}
+	p.propagateArchiveType(parsed)
+
+	assert.True(t, parsed.Files[0].IsRarArchive, ".1 must be IsRarArchive=true")
+	assert.True(t, parsed.Files[1].IsRarArchive, ".2 must be propagated to IsRarArchive=true")
+	assert.True(t, parsed.Files[2].IsRarArchive, ".193 must be propagated to IsRarArchive=true")
+	assert.False(t, parsed.Files[3].IsRarArchive, ".nfo must NOT be IsRarArchive")
+	assert.False(t, parsed.Files[4].IsRarArchive, ".par2 must NOT be IsRarArchive")
+}

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -1797,6 +1797,11 @@ const closerWorkerCount = 4
 // Lazy-starts the worker goroutines on first call. Caller must hold
 // mvf.mu (so the lazy init is safe).
 func (mvf *MetadataVirtualFile) enqueueCloser(r io.Closer) {
+	// Interrupt first (idempotent) so in-flight downloads release the
+	// pool connection immediately before Close() waits on drain.
+	if i, ok := r.(readerInterrupter); ok {
+		i.Interrupt()
+	}
 	if mvf.closerCh == nil {
 		// Workers range over this local, not mvf.closerCh: Close() nils the
 		// field under mvf.mu, which the workers do not hold, so reading the
@@ -1817,11 +1822,6 @@ func (mvf *MetadataVirtualFile) enqueueCloser(r io.Closer) {
 		// Queue full — apply backpressure inline rather than letting
 		// the closer fan-out grow unbounded. This is the rare path; a
 		// real Seek burst stays under closerWorkerCount.
-		// Interrupt first (idempotent) so in-flight downloads release the
-		// pool connection before Close() waits on drain.
-		if i, ok := r.(readerInterrupter); ok {
-			i.Interrupt()
-		}
 		_ = r.Close()
 	}
 }
@@ -2176,6 +2176,12 @@ func (r *lazyNestedMultiReader) Close() error {
 		return err
 	}
 	return nil
+}
+
+func (r *lazyNestedMultiReader) Interrupt() {
+	if i, ok := r.current.(interface{ Interrupt() }); ok {
+		i.Interrupt()
+	}
 }
 
 // wrapWithEncryption wraps a usenet reader with encryption using metadata

--- a/internal/nzbfilesystem/tsremux_reader.go
+++ b/internal/nzbfilesystem/tsremux_reader.go
@@ -139,6 +139,12 @@ func (s *skipLimitReader) Read(p []byte) (int, error) {
 
 func (s *skipLimitReader) Close() error { return s.inner.Close() }
 
+func (s *skipLimitReader) Interrupt() {
+	if i, ok := s.inner.(interface{ Interrupt() }); ok {
+		i.Interrupt()
+	}
+}
+
 // tsRemuxReader wraps an underlying reader that yields the bytes of a
 // byte-concatenated multi-clip Blu-ray main feature starting at absolute offset
 // startOff. As bytes stream through, it frames them into BDAV/TS source packets
@@ -186,6 +192,12 @@ func newTSRemuxReader(inner io.ReadCloser, spans []clipSpan, startOff int64) *ts
 }
 
 func (r *tsRemuxReader) Close() error { return r.inner.Close() }
+
+func (r *tsRemuxReader) Interrupt() {
+	if i, ok := r.inner.(interface{ Interrupt() }); ok {
+		i.Interrupt()
+	}
+}
 
 // clipFor returns the span containing absolute offset off, or nil if past the
 // last clip (then bytes are passed through raw).


### PR DESCRIPTION
## Summary

This PR addresses several archive handling edge cases and improves streaming latency during playback seeks:

1. **Enhanced NZB Password Extraction**:
   - Extracts passwords across root `<nzb><meta type="password">` elements (in addition to `<head>`).
   - Supports case-insensitive key naming (`password`, `Password`, `pass`, `PASS`, `pwd`).
   - Adds fallback parsing for filename brackets `{{password}}` / `/password:xyz/` and subject tags.

2. **Full Multi-Volume & Numeric Extension Propagation**:
   - Correctly propagates `IsRarArchive` and `Is7zArchive` across continuation parts with numeric extensions (`.1`..`.NNN`) and extensionless volume names, preventing multi-part sets from dropping continuation volumes during file separation.

3. **RAR4 Continuation Volume Gap Alignment**:
   - Resolves false-positive volume gaps on old-style RAR sets where `.r01` directly follows `.rar` (omitting `.r00`).

4. **Scoped Archive Compression Validation**:
   - Restricts compression rejection in `checkForCompressedFiles` to playable media files (video, audio, ISOs), allowing season packs containing compressed `.nfo` or `.txt` sidecars to import successfully.

5. **Instant Seek Reader Interruption**:
   - Synchronously triggers `Interrupt()` on discarded remote readers upon seek or close, releasing NNTP connections back to the connection pool immediately without waiting on idle read drains.
   - Adds `Interrupt()` propagation to `skipLimitReader`, `tsRemuxReader`, and `lazyNestedMultiReader`.

## Testing
- Added unit tests: `TestExtractNzbPassword`, `TestPropagateArchiveType_NumericExtensions`, `TestGroupHasVolumeGap_NoR00Convention`, `TestCheckForCompressedFiles`.
- Verified 100% test pass suite across all packages (`go test ./...`).