### PR TITLE
fix(fuse): preserve stable inode identity in Hanwen FUSE Lookup and Mkdir

### DIFF
--- a/internal/fuse/backend/hanwen/dir.go
+++ b/internal/fuse/backend/hanwen/dir.go
@@ -138,7 +138,10 @@ func (d *Dir) Mkdir(ctx context.Context, name string, mode uint32, out *fuse.Ent
 		noModTime:     d.noModTime,
 	}
 
-	return d.NewInode(ctx, node, fs.StableAttr{Mode: fuse.S_IFDIR}), 0
+	ino := stableInode(fullPath)
+	out.Ino = ino
+
+	return d.NewInode(ctx, node, fs.StableAttr{Mode: fuse.S_IFDIR, Ino: ino}), 0
 }
 
 // Lookup implements fs.NodeLookuper.
@@ -154,6 +157,8 @@ func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.
 	}
 
 	fillAttr(info, &out.Attr, d.uid, d.gid, d.noModTime)
+	ino := stableInode(fullPath)
+	out.Ino = ino
 
 	if info.IsDir() {
 		node := &Dir{
@@ -166,7 +171,7 @@ func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.
 			asyncBufSize:  d.asyncBufSize,
 			noModTime:     d.noModTime,
 		}
-		return d.NewInode(ctx, node, fs.StableAttr{Mode: fuse.S_IFDIR}), 0
+		return d.NewInode(ctx, node, fs.StableAttr{Mode: fuse.S_IFDIR, Ino: ino}), 0
 	}
 
 	node := &File{
@@ -180,7 +185,7 @@ func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.
 		asyncBufSize:  d.asyncBufSize,
 		noModTime:     d.noModTime,
 	}
-	return d.NewInode(ctx, node, fs.StableAttr{Mode: fuse.S_IFREG}), 0
+	return d.NewInode(ctx, node, fs.StableAttr{Mode: fuse.S_IFREG, Ino: ino}), 0
 }
 
 // Rename implements fs.NodeRenamer.
@@ -250,7 +255,7 @@ func (d *Dir) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 		entries = append(entries, fuse.DirEntry{
 			Name: info.Name(),
 			Mode: mode,
-			Ino:  hashPath(filepath.Join(d.path, info.Name())),
+			Ino:  stableInode(filepath.Join(d.path, info.Name())),
 		})
 	}
 

--- a/internal/fuse/backend/hanwen/dir.go
+++ b/internal/fuse/backend/hanwen/dir.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/javi11/altmount/internal/fuse/backend"
-	"github.com/javi11/altmount/internal/nzbfilesystem"
 )
 
 // ensure Dir implements fs.Node* interfaces
@@ -30,20 +29,20 @@ var _ fs.NodeRmdirer = (*Dir)(nil)
 // Dir represents a directory in the FUSE filesystem.
 type Dir struct {
 	fs.Inode
-	nzbfs         *nzbfilesystem.NzbFilesystem
+	nzbfs         nzbFS
 	streamTracker backend.StreamTracker
 	path          string
 	logger        *slog.Logger
 	isRootDir     bool
 	uid           uint32
 	gid           uint32
-	asyncBufSize  int  // read-ahead buffer size in bytes, propagated to File nodes
+	asyncBufSize  int // read-ahead buffer size in bytes, propagated to File nodes
 	noModTime     bool
 }
 
 // NewDir creates a new directory node for the FUSE filesystem.
 func NewDir(
-	nzbfs *nzbfilesystem.NzbFilesystem,
+	nzbfs nzbFS,
 	path string,
 	logger *slog.Logger,
 	uid, gid uint32,
@@ -179,12 +178,13 @@ func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.
 		streamTracker: d.streamTracker,
 		path:          fullPath,
 		logger:        d.logger,
-		size:          info.Size(),
 		uid:           d.uid,
 		gid:           d.gid,
 		asyncBufSize:  d.asyncBufSize,
 		noModTime:     d.noModTime,
 	}
+	node.size.Store(info.Size())
+
 	return d.NewInode(ctx, node, fs.StableAttr{Mode: fuse.S_IFREG, Ino: ino}), 0
 }
 

--- a/internal/fuse/backend/hanwen/file.go
+++ b/internal/fuse/backend/hanwen/file.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log/slog"
 	"os"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/hanwen/go-fuse/v2/fs"
@@ -25,15 +26,18 @@ var _ fs.NodeSetattrer = (*File)(nil)
 // File represents a file in the FUSE filesystem.
 type File struct {
 	fs.Inode
-	nzbfs         *nzbfilesystem.NzbFilesystem
+	nzbfs         nzbFS
 	streamTracker backend.StreamTracker
 	path          string
 	logger        *slog.Logger
-	size          int64
-	uid           uint32
-	gid           uint32
-	asyncBufSize  int // per-handle read-ahead buffer size in bytes; 0 = disabled
-	noModTime     bool
+	// size is the last known file size, used only as a fallback when the
+	// per-open Stat fails. Retained nodes can be opened concurrently, so it
+	// must be accessed atomically.
+	size         atomic.Int64
+	uid          uint32
+	gid          uint32
+	asyncBufSize int // per-handle read-ahead buffer size in bytes; 0 = disabled
+	noModTime    bool
 }
 
 // Getattr implements fs.NodeGetattrer.
@@ -75,10 +79,10 @@ func (f *File) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, s
 		return nil, 0, syscall.EIO
 	}
 
-	fileSize := f.size
+	fileSize := f.size.Load()
 	if fi, statErr := aferoFile.Stat(); statErr == nil {
 		fileSize = fi.Size()
-		f.size = fileSize
+		f.size.Store(fileSize)
 	}
 
 	// Create a FUSE-level stream (one per file open) that lives for the

--- a/internal/fuse/backend/hanwen/file.go
+++ b/internal/fuse/backend/hanwen/file.go
@@ -62,22 +62,10 @@ func (f *File) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, s
 		return nil, 0, syscall.EACCES
 	}
 
-	// Create a FUSE-level stream (one per file open) that lives for the
-	// duration of the handle. Backend opens are told to suppress their
-	// own stream creation via SuppressStreamTrackingKey.
-	var stream *nzbfilesystem.ActiveStream
-	if f.streamTracker != nil {
-		stream = f.streamTracker.AddStream(f.path, "FUSE", "FUSE", "", "", f.size)
-	}
-
 	ctx = context.WithValue(ctx, utils.SuppressStreamTrackingKey, true)
 
 	aferoFile, err := f.nzbfs.Open(ctx, f.path)
 	if err != nil {
-		if stream != nil {
-			f.streamTracker.Remove(stream.ID)
-		}
-
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			f.logger.DebugContext(ctx, "File Open canceled", "path", f.path)
 			return nil, 0, syscall.EINTR
@@ -87,12 +75,26 @@ func (f *File) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, s
 		return nil, 0, syscall.EIO
 	}
 
+	fileSize := f.size
+	if fi, statErr := aferoFile.Stat(); statErr == nil {
+		fileSize = fi.Size()
+		f.size = fileSize
+	}
+
+	// Create a FUSE-level stream (one per file open) that lives for the
+	// duration of the handle. Backend opens are told to suppress their
+	// own stream creation via SuppressStreamTrackingKey.
+	var stream *nzbfilesystem.ActiveStream
+	if f.streamTracker != nil {
+		stream = f.streamTracker.AddStream(f.path, "FUSE", "FUSE", "", "", fileSize)
+	}
+
 	// Attach a read-ahead buffer for sufficiently large files. The buffer
 	// stays in passthrough mode until sustained sequential reads are observed,
 	// so header probes and seek/scrub bursts never allocate it.
 	var asyncBuf *backend.AsyncReadBuffer
 	if rac, ok := aferoFile.(readAtContexter); ok {
-		asyncBuf = newHandleAsyncBuffer(ctx, rac, f.asyncBufSize, f.size, f.logger)
+		asyncBuf = newHandleAsyncBuffer(ctx, rac, f.asyncBufSize, fileSize, f.logger)
 	}
 
 	handle := NewHandle(aferoFile, f.logger, f.path, stream, f.streamTracker, asyncBuf)
@@ -100,7 +102,7 @@ func (f *File) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, s
 	// Use DIRECT_IO when file size is unknown/zero to prevent the kernel
 	// from caching pages with stale size metadata (rclone mount2 pattern).
 	fuseFlags := uint32(fuse.FOPEN_KEEP_CACHE)
-	if f.size <= 0 {
+	if fileSize <= 0 {
 		fuseFlags = uint32(fuse.FOPEN_DIRECT_IO)
 	}
 	return handle, fuseFlags, 0

--- a/internal/fuse/backend/hanwen/inode_test.go
+++ b/internal/fuse/backend/hanwen/inode_test.go
@@ -1,0 +1,56 @@
+//go:build linux
+
+package hanwen
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStableInode_RootPaths(t *testing.T) {
+	assert.Equal(t, uint64(1), stableInode(""))
+	assert.Equal(t, uint64(1), stableInode("."))
+	assert.Equal(t, uint64(1), stableInode("/"))
+}
+
+func TestStableInode_Deterministic(t *testing.T) {
+	path := "movies/Fight Club (1999)/Fight.Club.1999.mkv"
+	ino1 := stableInode(path)
+	ino2 := stableInode(path)
+	ino3 := stableInode(path)
+
+	assert.Equal(t, ino1, ino2)
+	assert.Equal(t, ino2, ino3)
+	assert.Greater(t, ino1, uint64(1), "inode must not be 0 or 1 for regular file")
+}
+
+func TestStableInode_DistinctForDifferentPaths(t *testing.T) {
+	path1 := "movies/Movie A (2020)/movie.mkv"
+	path2 := "movies/Movie B (2020)/movie.mkv"
+	path3 := "tv/Show A/season 01/episode 01.mkv"
+
+	ino1 := stableInode(path1)
+	ino2 := stableInode(path2)
+	ino3 := stableInode(path3)
+
+	assert.NotEqual(t, ino1, ino2)
+	assert.NotEqual(t, ino1, ino3)
+	assert.NotEqual(t, ino2, ino3)
+}
+
+func TestStableInode_ReaddirAndLookupConsistency(t *testing.T) {
+	dirPath := "movies/Inception (2010)"
+	fileName := "Inception.2010.mkv"
+	fullPath := filepath.Join(dirPath, fileName)
+
+	// Inode computed during Readdir:
+	readdirIno := stableInode(filepath.Join(dirPath, fileName))
+
+	// Inode computed during Lookup:
+	lookupIno := stableInode(fullPath)
+
+	assert.Equal(t, readdirIno, lookupIno, "Readdir and Lookup must produce the exact same inode for identical paths")
+	assert.Greater(t, lookupIno, uint64(1))
+}

--- a/internal/fuse/backend/hanwen/node_test.go
+++ b/internal/fuse/backend/hanwen/node_test.go
@@ -1,0 +1,424 @@
+//go:build linux
+
+package hanwen
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/javi11/altmount/internal/nzbfilesystem"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- in-memory nzbFS fake -------------------------------------------------
+
+type fakeInfo struct {
+	name string
+	size int64
+	dir  bool
+}
+
+func (fi fakeInfo) Name() string { return fi.name }
+func (fi fakeInfo) Size() int64  { return fi.size }
+func (fi fakeInfo) Mode() os.FileMode {
+	if fi.dir {
+		return os.ModeDir | 0o755
+	}
+	return 0o644
+}
+func (fi fakeInfo) ModTime() time.Time { return time.Unix(0, 0) }
+func (fi fakeInfo) IsDir() bool        { return fi.dir }
+func (fi fakeInfo) Sys() any           { return nil }
+
+// fakeAferoFile is a snapshot of an entry taken at open time: Stat keeps
+// reporting the size the handle was opened with, mirroring a real handle that
+// is pinned to one revision of the file.
+type fakeAferoFile struct {
+	info     fakeInfo
+	children []os.FileInfo
+	closed   bool
+}
+
+func (f *fakeAferoFile) Close() error               { f.closed = true; return nil }
+func (f *fakeAferoFile) Read(p []byte) (int, error) { return 0, io.EOF }
+func (f *fakeAferoFile) ReadAt([]byte, int64) (int, error) {
+	return 0, io.EOF
+}
+func (f *fakeAferoFile) Seek(int64, int) (int64, error)     { return 0, nil }
+func (f *fakeAferoFile) Write([]byte) (int, error)          { return 0, syscall.EPERM }
+func (f *fakeAferoFile) WriteAt([]byte, int64) (int, error) { return 0, syscall.EPERM }
+func (f *fakeAferoFile) Name() string                       { return f.info.name }
+func (f *fakeAferoFile) Readdir(int) ([]os.FileInfo, error) { return f.children, nil }
+func (f *fakeAferoFile) Readdirnames(int) ([]string, error) {
+	names := make([]string, 0, len(f.children))
+	for _, c := range f.children {
+		names = append(names, c.Name())
+	}
+	return names, nil
+}
+func (f *fakeAferoFile) Stat() (os.FileInfo, error)      { return f.info, nil }
+func (f *fakeAferoFile) Sync() error                     { return nil }
+func (f *fakeAferoFile) Truncate(int64) error            { return syscall.EPERM }
+func (f *fakeAferoFile) WriteString(string) (int, error) { return 0, syscall.EPERM }
+
+// fakeNzbFS is a minimal in-memory nzbFS. Paths are stored without a leading
+// separator, matching what filepath.Join produces from the empty root path.
+type fakeNzbFS struct {
+	mu      sync.Mutex
+	entries map[string]fakeInfo
+}
+
+func newFakeNzbFS() *fakeNzbFS {
+	return &fakeNzbFS{entries: map[string]fakeInfo{"": {name: "", dir: true}}}
+}
+
+func (fs *fakeNzbFS) addFile(path string, size int64) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	fs.entries[path] = fakeInfo{name: filepath.Base(path), size: size}
+}
+
+func (fs *fakeNzbFS) addDir(path string) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	fs.entries[path] = fakeInfo{name: filepath.Base(path), dir: true}
+}
+
+// replaceFile simulates an in-place replacement: same virtual path, new size.
+func (fs *fakeNzbFS) replaceFile(path string, size int64) {
+	fs.addFile(path, size)
+}
+
+func (fs *fakeNzbFS) Stat(_ context.Context, name string) (os.FileInfo, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	info, ok := fs.entries[name]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return info, nil
+}
+
+func (fs *fakeNzbFS) Open(_ context.Context, name string) (afero.File, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	info, ok := fs.entries[name]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	f := &fakeAferoFile{info: info}
+	if info.dir {
+		f.children = fs.childrenLocked(name)
+	}
+	return f, nil
+}
+
+func (fs *fakeNzbFS) childrenLocked(dir string) []os.FileInfo {
+	prefix := dir
+	if prefix != "" {
+		prefix += string(filepath.Separator)
+	}
+	var out []os.FileInfo
+	for path, info := range fs.entries {
+		if path == dir || !strings.HasPrefix(path, prefix) {
+			continue
+		}
+		if strings.Contains(strings.TrimPrefix(path, prefix), string(filepath.Separator)) {
+			continue
+		}
+		out = append(out, info)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name() < out[j].Name() })
+	return out
+}
+
+func (fs *fakeNzbFS) Mkdir(_ context.Context, name string, _ os.FileMode) error {
+	fs.addDir(name)
+	return nil
+}
+
+func (fs *fakeNzbFS) Rename(_ context.Context, oldName, newName string) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	info, ok := fs.entries[oldName]
+	if !ok {
+		return os.ErrNotExist
+	}
+	delete(fs.entries, oldName)
+	info.name = filepath.Base(newName)
+	fs.entries[newName] = info
+	return nil
+}
+
+func (fs *fakeNzbFS) Remove(_ context.Context, name string) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if _, ok := fs.entries[name]; !ok {
+		return os.ErrNotExist
+	}
+	delete(fs.entries, name)
+	return nil
+}
+
+// recordingTracker captures the size each Open reports for its stream.
+type recordingTracker struct {
+	mu    sync.Mutex
+	sizes []int64
+}
+
+func (t *recordingTracker) AddStream(filePath, source, userName, clientIP, userAgent string, totalSize int64) *nzbfilesystem.ActiveStream {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.sizes = append(t.sizes, totalSize)
+	return &nzbfilesystem.ActiveStream{ID: filePath, FilePath: filePath, TotalSize: totalSize}
+}
+
+func (t *recordingTracker) UpdateProgress(string, int64) {}
+func (t *recordingTracker) Remove(string)                {}
+
+func (t *recordingTracker) recorded() []int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]int64(nil), t.sizes...)
+}
+
+// newTestFS builds a live go-fuse node tree (no kernel mount required) so
+// Lookup runs through the real bridge, inode allocation and child registration.
+func newTestFS(t *testing.T, backing *fakeNzbFS, tracker *recordingTracker) (fuse.RawFileSystem, *Dir) {
+	t.Helper()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	root := NewDir(backing, "", logger, 0, 0, tracker, 0, false)
+	raw := fs.NewNodeFS(root, &fs.Options{})
+	require.NotNil(t, raw)
+
+	return raw, root
+}
+
+func lookupEntry(t *testing.T, raw fuse.RawFileSystem, parentNodeID uint64, name string) *fuse.EntryOut {
+	t.Helper()
+
+	var out fuse.EntryOut
+	status := raw.Lookup(nil, &fuse.InHeader{NodeId: parentNodeID}, name, &out)
+	require.True(t, status.Ok(), "Lookup(%q) failed: %v", name, status)
+
+	return &out
+}
+
+// childOps returns the node implementation registered under parent for name.
+func childOps(t *testing.T, parent *fs.Inode, name string) fs.InodeEmbedder {
+	t.Helper()
+
+	child := parent.GetChild(name)
+	require.NotNil(t, child, "child %q is not registered on the parent inode", name)
+
+	return child.Operations()
+}
+
+func childDir(t *testing.T, parent *fs.Inode, name string) *Dir {
+	t.Helper()
+
+	dir, ok := childOps(t, parent, name).(*Dir)
+	require.True(t, ok, "child %q is not a *Dir", name)
+
+	return dir
+}
+
+func childFile(t *testing.T, parent *fs.Inode, name string) *File {
+	t.Helper()
+
+	file, ok := childOps(t, parent, name).(*File)
+	require.True(t, ok, "child %q is not a *File", name)
+
+	return file
+}
+
+func openFile(t *testing.T, f *File) *Handle {
+	t.Helper()
+
+	fh, _, errno := f.Open(context.Background(), syscall.O_RDONLY)
+	require.Equal(t, syscall.Errno(0), errno)
+
+	handle, ok := fh.(*Handle)
+	require.True(t, ok)
+
+	return handle
+}
+
+// --- tests ----------------------------------------------------------------
+
+// Readdir and Lookup must agree on inodes when both run through the real node
+// implementations, not just when stableInode is called twice.
+func TestLookupAndReaddirInodeParity(t *testing.T) {
+	backing := newFakeNzbFS()
+	backing.addDir("movies")
+	backing.addFile(filepath.Join("movies", "Inception.2010.mkv"), 4096)
+	backing.addFile(filepath.Join("movies", "Arrival.2016.mkv"), 8192)
+	backing.addDir(filepath.Join("movies", "extras"))
+
+	raw, root := newTestFS(t, backing, nil)
+
+	moviesEntry := lookupEntry(t, raw, 1, "movies")
+	assert.Equal(t, stableInode("movies"), moviesEntry.Ino)
+
+	moviesDir := childDir(t, &root.Inode, "movies")
+
+	stream, errno := moviesDir.Readdir(context.Background())
+	require.Equal(t, syscall.Errno(0), errno)
+	defer stream.Close()
+
+	readdirInos := map[string]uint64{}
+	for stream.HasNext() {
+		entry, errno := stream.Next()
+		require.Equal(t, syscall.Errno(0), errno)
+		readdirInos[entry.Name] = entry.Ino
+	}
+	require.Len(t, readdirInos, 3)
+
+	for name, readdirIno := range readdirInos {
+		entry := lookupEntry(t, raw, moviesEntry.NodeId, name)
+		assert.Equal(t, readdirIno, entry.Ino, "Readdir/Lookup inode mismatch for %q", name)
+		assert.Greater(t, entry.Ino, uint64(1), "%q must not use a reserved inode", name)
+	}
+}
+
+// A retained node keeps its inode across lookups, and a later open reports the
+// replacement size rather than the size captured at first lookup.
+func TestRetainedNodeSeesReplacementSize(t *testing.T) {
+	const name = "Dune.2021.mkv"
+	path := filepath.Join("movies", name)
+
+	backing := newFakeNzbFS()
+	backing.addDir("movies")
+	backing.addFile(path, 1000)
+
+	tracker := &recordingTracker{}
+	raw, root := newTestFS(t, backing, tracker)
+
+	moviesEntry := lookupEntry(t, raw, 1, "movies")
+	first := lookupEntry(t, raw, moviesEntry.NodeId, name)
+	file := childFile(t, &childDir(t, &root.Inode, "movies").Inode, name)
+
+	handle := openFile(t, file)
+	require.Equal(t, []int64{1000}, tracker.recorded())
+	require.Equal(t, syscall.Errno(0), handle.Release(context.Background()))
+
+	// In-place replacement at the same virtual path.
+	backing.replaceFile(path, 2000)
+
+	second := lookupEntry(t, raw, moviesEntry.NodeId, name)
+	assert.Equal(t, first.Ino, second.Ino, "inode must stay stable across a replacement")
+	assert.Same(t, file, childFile(t, &childDir(t, &root.Inode, "movies").Inode, name),
+		"the node must be retained, not rebuilt")
+
+	handle2 := openFile(t, file)
+	defer func() { _ = handle2.Release(context.Background()) }()
+
+	assert.Equal(t, []int64{1000, 2000}, tracker.recorded(),
+		"the new open must report the replacement size")
+	assert.Equal(t, int64(2000), file.size.Load())
+}
+
+// An already-open handle stays pinned to the size it was opened with while a
+// replacement changes what new opens see.
+func TestExistingHandleUnaffectedByReplacement(t *testing.T) {
+	const name = "Tenet.2020.mkv"
+	path := filepath.Join("movies", name)
+
+	backing := newFakeNzbFS()
+	backing.addDir("movies")
+	backing.addFile(path, 500)
+
+	raw, root := newTestFS(t, backing, &recordingTracker{})
+
+	moviesEntry := lookupEntry(t, raw, 1, "movies")
+	moviesDir := childDir(t, &root.Inode, "movies")
+	_ = lookupEntry(t, raw, moviesEntry.NodeId, name)
+	file := childFile(t, &moviesDir.Inode, name)
+
+	old := openFile(t, file)
+	oldSnapshot, err := old.file.Stat()
+	require.NoError(t, err)
+
+	backing.replaceFile(path, 900)
+
+	fresh := openFile(t, file)
+	freshSnapshot, err := fresh.file.Stat()
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(500), oldSnapshot.Size(), "existing handle must stay internally consistent")
+	assert.Equal(t, int64(900), freshSnapshot.Size(), "new open must see the replacement size")
+
+	require.Equal(t, syscall.Errno(0), old.Release(context.Background()))
+	require.Equal(t, syscall.Errno(0), fresh.Release(context.Background()))
+}
+
+// Concurrent opens of a retained node while the backing size changes must not
+// race on File.size (run under -race).
+func TestConcurrentOpensNoRaceOnSize(t *testing.T) {
+	const name = "Heat.1995.mkv"
+	path := filepath.Join("movies", name)
+
+	backing := newFakeNzbFS()
+	backing.addDir("movies")
+	backing.addFile(path, 1<<20)
+
+	raw, root := newTestFS(t, backing, &recordingTracker{})
+
+	moviesEntry := lookupEntry(t, raw, 1, "movies")
+	_ = lookupEntry(t, raw, moviesEntry.NodeId, name)
+	file := childFile(t, &childDir(t, &root.Inode, "movies").Inode, name)
+
+	const workers = 16
+	stop := make(chan struct{})
+
+	var replacer sync.WaitGroup
+	replacer.Add(1)
+	go func() {
+		defer replacer.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			backing.replaceFile(path, int64(1<<20)+int64(i%64))
+		}
+	}()
+
+	var opens sync.WaitGroup
+	opens.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer opens.Done()
+			for j := 0; j < 50; j++ {
+				fh, _, errno := file.Open(context.Background(), syscall.O_RDONLY)
+				if errno != 0 {
+					t.Errorf("Open failed: %v", errno)
+					return
+				}
+				_ = file.size.Load()
+				_ = fh.(*Handle).Release(context.Background())
+			}
+		}()
+	}
+
+	opens.Wait()
+	close(stop)
+	replacer.Wait()
+
+	assert.GreaterOrEqual(t, file.size.Load(), int64(1<<20))
+}

--- a/internal/fuse/backend/hanwen/nzbfs.go
+++ b/internal/fuse/backend/hanwen/nzbfs.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package hanwen
+
+import (
+	"context"
+	"os"
+
+	"github.com/spf13/afero"
+)
+
+// nzbFS is the subset of *nzbfilesystem.NzbFilesystem used by the FUSE nodes.
+// Depending on the interface instead of the concrete type keeps Dir/File
+// testable without standing up the full metadata stack.
+type nzbFS interface {
+	Open(ctx context.Context, name string) (afero.File, error)
+	Stat(ctx context.Context, name string) (os.FileInfo, error)
+	Mkdir(ctx context.Context, name string, perm os.FileMode) error
+	Rename(ctx context.Context, oldName, newName string) error
+	Remove(ctx context.Context, name string) error
+}

--- a/internal/fuse/backend/hanwen/utils.go
+++ b/internal/fuse/backend/hanwen/utils.go
@@ -33,6 +33,20 @@ func hashPath(path string) uint64 {
 	return h.Sum64()
 }
 
+// stableInode returns a deterministic, non-reserved inode number from a virtual path.
+// It maps empty string, ".", or "/" to root inode 1, and maps regular paths to
+// hashes avoiding reserved inode 0 (invalid) and 1 (reserved for FUSE root).
+func stableInode(path string) uint64 {
+	if path == "" || path == "." || path == "/" {
+		return 1
+	}
+	ino := hashPath(path)
+	if ino <= 1 {
+		return 2
+	}
+	return ino
+}
+
 // translateError maps OS-level errors to FUSE syscall.Errno values.
 // Does not log; callers should log unexpected errors before calling.
 func translateError(err error) syscall.Errno {


### PR DESCRIPTION
## Summary

Fixes #841

This PR resolves an issue where Hanwen FUSE allocates unstable, dynamically incrementing 64-bit inode numbers on fresh Lookups after the kernel directory cache expires:

1. **Deterministic Inode Assignment in Lookup & Mkdir**:
   - Sets `StableAttr.Ino` and `EntryOut.Ino` using `stableInode(fullPath)` derived via path hashing.
   - Avoids reserved inodes `0` (invalid) and `1` (reserved for root).

2. **Readdir & Lookup Inode Parity**:
   - Replaces raw `hashPath` in `Readdir` with `stableInode(filepath.Join(d.path, info.Name()))` ensuring 1:1 inode consistency across directory enumerations and direct stat lookups.

3. **Retained Node Metadata Refresh on Open**:
   - Snapshots the opened file's actual size on `File.Open` to ensure that retained nodes (kept in memory by stable Ino) accurately reflect file replacements at the same virtual path.

## Testing
- Added unit tests in `internal/fuse/backend/hanwen/inode_test.go` verifying root path mappings, determinism, distinct inode assignment for different paths, and `Readdir`/`Lookup` parity.
- Verified 100% test pass suite (`go test ./...`).