### PR TITLE
fix(health): invalidate rclone VFS cache on file deletions and moves

### DIFF
--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -234,6 +234,9 @@ func (s *Server) handleDeleteHealth(c *fiber.Ctx) error {
 				slog.ErrorContext(c.Context(), "Failed to delete metadata during health record deletion", "file_path", item.FilePath, "error", delErr)
 			} else {
 				metaDeleted = true
+				if s.healthWorker != nil {
+					s.healthWorker.NotifyRcloneVFS(item.FilePath)
+				}
 			}
 		}
 
@@ -315,6 +318,9 @@ func (s *Server) handleDeleteHealthBulk(c *fiber.Ctx) error {
 					slog.ErrorContext(c.Context(), "Failed to delete metadata during bulk deletion", "file_path", item.FilePath, "error", delErr)
 				} else {
 					metaDeletedCount++
+					if s.healthWorker != nil {
+						s.healthWorker.NotifyRcloneVFS(item.FilePath)
+					}
 				}
 			}
 

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -351,13 +351,11 @@ func (hc *HealthChecker) CheckFilesBatch(ctx context.Context, filePaths []string
 	return events
 }
 
-// NotifyRcloneVFS notifies rclone VFS about a file status change (async, non-blocking)
-func (hc *HealthChecker) notifyRcloneVFS(filePath string, event HealthEvent) {
-	if hc.rcloneClient == nil {
-		return // No rclone client configured
+// NotifyRcloneVFS notifies rclone VFS to forget and refresh the directory containing filePath (async, non-blocking).
+func (hc *HealthChecker) NotifyRcloneVFS(filePath string) {
+	if hc == nil || hc.rcloneClient == nil {
+		return
 	}
-
-	// Only notify for rclone-based mounts; FUSE and none don't use rclone VFS
 	cfg := hc.configGetter()
 	switch cfg.MountType {
 	case config.MountTypeRClone, config.MountTypeRCloneExternal:
@@ -366,21 +364,40 @@ func (hc *HealthChecker) notifyRcloneVFS(filePath string, event HealthEvent) {
 		return
 	}
 
-	// Only notify on significant status changes (healthy <-> corrupted)
-	switch event.Type {
-	case EventTypeFileHealthy, EventTypeFileCorrupted:
-		// Continue with notification
+	virtualDir := filepath.Dir(filePath)
+	hc.NotifyRcloneVFSDirs([]string{virtualDir})
+}
+
+// NotifyRcloneVFSDirs notifies rclone VFS to forget and refresh the specified directories (async, non-blocking).
+func (hc *HealthChecker) NotifyRcloneVFSDirs(dirs []string) {
+	if hc == nil || hc.rcloneClient == nil || len(dirs) == 0 {
+		return
+	}
+	cfg := hc.configGetter()
+	switch cfg.MountType {
+	case config.MountTypeRClone, config.MountTypeRCloneExternal:
+		// continue
 	default:
-		return // No notification needed for other event types
+		return
 	}
 
-	// Start async notification
-	go func() {
-		// Extract directory path from file path for VFS refresh
-		virtualDir := filepath.Dir(filePath)
+	// Filter and deduplicate directories
+	uniqueDirs := make([]string, 0, len(dirs))
+	seen := make(map[string]bool)
+	for _, d := range dirs {
+		if d == "" {
+			d = "/"
+		}
+		if !seen[d] {
+			seen[d] = true
+			uniqueDirs = append(uniqueDirs, d)
+		}
+	}
+	if len(uniqueDirs) == 0 {
+		return
+	}
 
-		// Use background context with timeout for VFS notification
-		// Increased timeout to 60 seconds as vfs/refresh can be slow
+	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
@@ -389,12 +406,21 @@ func (hc *HealthChecker) notifyRcloneVFS(filePath string, event HealthEvent) {
 			vfsName = config.MountProvider
 		}
 
-		// Refresh cache asynchronously to avoid blocking health checks
-		err := hc.rcloneClient.RefreshDir(ctx, vfsName, []string{virtualDir})
+		err := hc.rcloneClient.RefreshDir(ctx, vfsName, uniqueDirs)
 		if err != nil {
-			slog.ErrorContext(ctx, "Failed to notify rclone VFS about file status change", "file", filePath, "event", event.Type, "err", err)
+			slog.ErrorContext(ctx, "Failed to notify rclone VFS to forget/refresh directories", "dirs", uniqueDirs, "err", err)
 		}
 	}()
+}
+
+// notifyRcloneVFS notifies rclone VFS about a file status change (async, non-blocking)
+func (hc *HealthChecker) notifyRcloneVFS(filePath string, event HealthEvent) {
+	switch event.Type {
+	case EventTypeFileHealthy, EventTypeFileCorrupted:
+		hc.NotifyRcloneVFS(filePath)
+	default:
+		return
+	}
 }
 
 type metadataSegmentLoader struct {

--- a/internal/health/library_sync.go
+++ b/internal/health/library_sync.go
@@ -818,6 +818,7 @@ func (lsw *LibrarySyncWorker) SyncLibrary(ctx context.Context, dryRun bool) *Dry
 			}
 
 			deleteSourceNzb := cfg.Metadata.ShouldDeleteSourceNzb()
+			deletedDirs := make(map[string]bool)
 
 			for relativeMountPath := range currentMetaOrphans {
 				select {
@@ -838,10 +839,31 @@ func (lsw *LibrarySyncWorker) SyncLibrary(ctx context.Context, dryRun bool) *Dry
 							slog.InfoContext(ctx, "Deleted confirmed orphaned metadata file (not found in library for 2 consecutive syncs)",
 								"path", relativeMountPath)
 							metadataDeletedCount++
+							deletedDirs[filepath.Dir(relativeMountPath)] = true
 						}
 					} else {
 						metadataDeletedCount++
 					}
+				}
+			}
+
+			if !dryRun && lsw.rcloneClient != nil && len(deletedDirs) > 0 {
+				cfg := lsw.configGetter()
+				switch cfg.MountType {
+				case config.MountTypeRClone, config.MountTypeRCloneExternal:
+					dirs := make([]string, 0, len(deletedDirs))
+					for d := range deletedDirs {
+						dirs = append(dirs, d)
+					}
+					vfsName := cfg.RClone.VFSName
+					if vfsName == "" {
+						vfsName = config.MountProvider
+					}
+					go func() {
+						c, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+						defer cancel()
+						_ = lsw.rcloneClient.RefreshDir(c, vfsName, dirs)
+					}()
 				}
 			}
 

--- a/internal/health/rclone_vfs_notify_test.go
+++ b/internal/health/rclone_vfs_notify_test.go
@@ -1,0 +1,98 @@
+package health
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRcloneClient struct {
+	mu          sync.Mutex
+	refreshCalls []struct {
+		VFSName string
+		Dirs    []string
+	}
+}
+
+func (m *mockRcloneClient) RefreshDir(ctx context.Context, vfsName string, dirs []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.refreshCalls = append(m.refreshCalls, struct {
+		VFSName string
+		Dirs    []string
+	}{VFSName: vfsName, Dirs: dirs})
+	return nil
+}
+
+func (m *mockRcloneClient) ForgetDir(ctx context.Context, vfsName string, dirs []string) error {
+	return nil
+}
+
+func (m *mockRcloneClient) GetMountInfo(provider string) (any, bool) {
+	return nil, false
+}
+
+func (m *mockRcloneClient) IsReady() bool {
+	return true
+}
+
+func TestHealthChecker_NotifyRcloneVFS(t *testing.T) {
+	mockRclone := &mockRcloneClient{}
+	cfg := &config.Config{
+		MountType: config.MountTypeRCloneExternal,
+		RClone: config.RCloneConfig{
+			VFSName: "altmount_vfs",
+		},
+	}
+
+	checker := &HealthChecker{
+		rcloneClient: mockRclone,
+		configGetter: func() *config.Config { return cfg },
+	}
+
+	checker.NotifyRcloneVFS("movies/Fight Club (1999)/Fight.Club.1999.mkv")
+
+	// Allow async goroutine to execute
+	require.Eventually(t, func() bool {
+		mockRclone.mu.Lock()
+		defer mockRclone.mu.Unlock()
+		return len(mockRclone.refreshCalls) == 1
+	}, 2*time.Second, 20*time.Millisecond)
+
+	mockRclone.mu.Lock()
+	defer mockRclone.mu.Unlock()
+	assert.Equal(t, "altmount_vfs", mockRclone.refreshCalls[0].VFSName)
+	assert.Equal(t, []string{"movies/Fight Club (1999)"}, mockRclone.refreshCalls[0].Dirs)
+}
+
+func TestHealthChecker_NotifyRcloneVFSDirs_Deduplication(t *testing.T) {
+	mockRclone := &mockRcloneClient{}
+	cfg := &config.Config{
+		MountType: config.MountTypeRClone,
+		RClone: config.RCloneConfig{
+			VFSName: "altmount_vfs",
+		},
+	}
+
+	checker := &HealthChecker{
+		rcloneClient: mockRclone,
+		configGetter: func() *config.Config { return cfg },
+	}
+
+	checker.NotifyRcloneVFSDirs([]string{"movies/DirA", "movies/DirB", "movies/DirA"})
+
+	require.Eventually(t, func() bool {
+		mockRclone.mu.Lock()
+		defer mockRclone.mu.Unlock()
+		return len(mockRclone.refreshCalls) == 1
+	}, 2*time.Second, 20*time.Millisecond)
+
+	mockRclone.mu.Lock()
+	defer mockRclone.mu.Unlock()
+	assert.Equal(t, []string{"movies/DirA", "movies/DirB"}, mockRclone.refreshCalls[0].Dirs)
+}

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -1116,6 +1116,8 @@ func (hw *HealthWorker) cleanupZombieRecord(ctx context.Context, item *database.
 	deleteSourceNzb := cfg.Metadata.ShouldDeleteSourceNzb()
 	if delMetaErr := hw.metadataService.DeleteFileMetadataWithSourceNzb(ctx, relativePath, deleteSourceNzb); delMetaErr != nil {
 		slog.ErrorContext(ctx, "Failed to delete metadata during cleanup", "file_path", item.FilePath, "error", delMetaErr)
+	} else {
+		hw.NotifyRcloneVFS(item.FilePath)
 	}
 }
 
@@ -1357,5 +1359,21 @@ func (hw *HealthWorker) moveMetadataToSafetyFolder(ctx context.Context, item *da
 	slog.InfoContext(ctx, "Moving metadata file for corrupted item to safety folder to trigger replacement", "file_path", item.FilePath)
 	if moveErr := hw.metadataService.MoveToCorrupted(ctx, relativePath); moveErr != nil {
 		slog.WarnContext(ctx, "Failed to move corrupted metadata file", "error", moveErr)
+	} else {
+		hw.NotifyRcloneVFS(item.FilePath)
+	}
+}
+
+// NotifyRcloneVFS notifies rclone VFS to forget and refresh the directory containing filePath.
+func (hw *HealthWorker) NotifyRcloneVFS(filePath string) {
+	if hw != nil && hw.healthChecker != nil {
+		hw.healthChecker.NotifyRcloneVFS(filePath)
+	}
+}
+
+// NotifyRcloneVFSDirs notifies rclone VFS to forget and refresh the specified directories.
+func (hw *HealthWorker) NotifyRcloneVFSDirs(dirs []string) {
+	if hw != nil && hw.healthChecker != nil {
+		hw.healthChecker.NotifyRcloneVFSDirs(dirs)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #835

This PR addresses an issue where Rclone mounts (both internal and external) continue caching deleted or moved metadata files, causing subsequent reads to hang in uninterruptible D-state due to 404 retry loops on the Rclone side:

1. **Rclone VFS Invalidation on Corrupted Metadata Moves & Zombie Cleanup**:
   - Invokes `NotifyRcloneVFS` in `moveMetadataToSafetyFolder` and `cleanupZombieRecord` so Rclone immediately executes `vfs/forget` + `vfs/refresh` on the parent directory when a `.meta` file is moved or deleted.

2. **Rclone VFS Invalidation on API Deletions**:
   - Calls `NotifyRcloneVFS` in `handleDeleteHealth` and `handleDeleteHealthBulk` when `delete_meta=true` successfully removes metadata files.

3. **Rclone VFS Invalidation on Library Sync Orphan Purging**:
   - Batches and refreshes directories of confirmed orphaned metadata files deleted during library sync cycles.

4. **Directory Deduplication**:
   - Added `NotifyRcloneVFSDirs` helper to filter and deduplicate concurrent directory invalidations.

## Testing
- Added unit tests in `internal/health/rclone_vfs_notify_test.go` verifying `NotifyRcloneVFS` and `NotifyRcloneVFSDirs` deduplication and async execution.
- Verified 100% test pass suite across all packages (`go test ./...`).