### PR TITLE
fix(nzbfilesystem): stop reading a file that repair removed underneath it

### DIFF
--- a/internal/nzbfilesystem/constants.go
+++ b/internal/nzbfilesystem/constants.go
@@ -69,7 +69,8 @@ var (
 	// streaming.read_timeout_seconds. Deliberately not a context error: the
 	// FUSE handles map context errors to EINTR (a retryable interruption),
 	// whereas a timed-out read is a genuine failure and must surface as EIO.
-	ErrReadTimeout = errors.New("read timed out")
+	ErrReadTimeout  = errors.New("read timed out")
+	ErrMetadataGone = errors.New("file metadata was removed underneath this handle by a repair")
 )
 
 // Database operation error message templates

--- a/internal/nzbfilesystem/health_disabled_test.go
+++ b/internal/nzbfilesystem/health_disabled_test.go
@@ -161,6 +161,51 @@ func TestUpdateFileHealthOnError_HealthEnabled_TriggersRepair(t *testing.T) {
 	assert.Nil(t, original, "health enabled must move metadata to the corrupted folder")
 }
 
+// TestUpdateFileHealthOnError_RepairLatchesHandleClosed pins the orphaned-reader fix:
+// once a repair has moved a file's metadata to the corrupted safety folder, the handle
+// that hit the failure must refuse further reads. Otherwise its prefetch pipeline keeps
+// fetching segments for a path that no longer exists and the client keeps reading
+// against it until the mount is restarted (issue #539).
+func TestUpdateFileHealthOnError_RepairLatchesHandleClosed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	repo, db, ms := setupStreamHealthEnv(t)
+	ctx := context.Background()
+
+	filePath := "series/stream.s01e04.mkv"
+	libraryPath := "/media/library/stream.s01e04.mkv"
+	seg := writeStreamMeta(t, ms, filePath)
+
+	_, err := db.Exec(
+		`INSERT INTO file_health (file_path, library_path, status, scheduled_check_at) VALUES (?, ?, 'healthy', datetime('now'))`,
+		filePath, libraryPath,
+	)
+	require.NoError(t, err)
+
+	enabled := true
+	cfg := config.DefaultConfig()
+	cfg.Health.Enabled = &enabled
+	cfg.MountPath = ""
+
+	mvf := newStreamFailureMVF(ctx, filePath, repo, ms, seg, cfg)
+	require.False(t, mvf.metadataGone.Load(), "handle must start out readable")
+
+	mvf.updateFileHealthOnError(&usenet.DataCorruptionError{UnderlyingErr: errors.New("article not found"), NoRetry: true}, true)
+
+	require.True(t, mvf.metadataGone.Load(), "moving the metadata away must latch the handle closed")
+
+	// Both read entry points must refuse: Read goes through ensureReader, while
+	// ReadAtContext's ephemeral path builds readers without it.
+	err = mvf.ensureReader()
+	require.Error(t, err, "ensureReader must not rebuild a reader for a file that was moved away")
+	assert.ErrorIs(t, err, ErrMetadataGone)
+
+	_, err = mvf.ReadAtContext(ctx, make([]byte, 16), 0)
+	require.Error(t, err, "ReadAtContext must refuse reads after the metadata is gone")
+	assert.ErrorIs(t, err, ErrMetadataGone)
+}
+
 // TestUpdateFileHealthOnError_FailureMasking_MasksRepair verifies that when failure masking
 // is enabled, a streaming failure below the threshold does not immediately trigger a repair
 // or move the metadata, but increments the failure count instead.
@@ -224,4 +269,3 @@ func TestUpdateFileHealthOnError_FailureMasking_MasksRepair(t *testing.T) {
 	original, _ = ms.ReadFileMetadata(filePath)
 	assert.Nil(t, original, "metadata should be moved to corrupted folder now")
 }
-

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -2314,6 +2314,13 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 	// inside the debounce window. ShouldTrigger handles a nil coalescer
 	// (test harness) by returning true.
 	if !mvf.repairCoalescer.ShouldTrigger(mvf.name) {
+		// Another handle on this path may already have had the metadata taken
+		// away. Only that handle latched itself, so without this a second handle
+		// failing inside the debounce window keeps rebuilding readers for a file
+		// that is gone - exactly the wedge the latch exists to prevent.
+		if mvf.repairCoalescer.WasRemoved(mvf.name) {
+			mvf.metadataGone.Store(true)
+		}
 		slog.DebugContext(mvf.ctx, "Streaming failure repair already triggered recently, debouncing",
 			"file", mvf.name)
 		return
@@ -2415,8 +2422,10 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 			slog.ErrorContext(ctx, "Failed to delete corrupted file after streaming failure", "file", mvf.name, "error", err)
 		} else {
 			// The file this handle is reading no longer exists; latch it closed,
-			// same as the repair path below.
+			// same as the repair path below, and publish the removal so other
+			// handles on this path latch too even if their failure is debounced.
 			mvf.metadataGone.Store(true)
+			mvf.repairCoalescer.MarkRemoved(mvf.name)
 
 			if err := mvf.healthRepository.DeleteHealthRecord(ctx, mvf.name); err != nil {
 				slog.ErrorContext(ctx, "Failed to delete health record after deleting corrupted file", "file", mvf.name, "error", err)
@@ -2445,6 +2454,10 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 					// fetching segments for a path that no longer exists and the
 					// client keeps reading against it (see issue #539).
 					mvf.metadataGone.Store(true)
+					// Publish the removal so other handles on this path latch
+					// themselves even if their own failure lands inside the
+					// debounce window and returns early above.
+					mvf.repairCoalescer.MarkRemoved(mvf.name)
 					// Successfully moved metadata, enqueue a coalesced rclone VFS
 					// refresh. Multiple files in the same directory collapse into a
 					// single RC call; concurrent failures across directories are

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -869,6 +869,17 @@ type MetadataVirtualFile struct {
 	// consecutive misses the player has genuinely moved and we tear down.
 	ephemeralStreak int
 
+	// metadataGone is set once a streaming failure caused this file's metadata to
+	// be removed underneath the open handle (moved to the corrupted safety folder
+	// by a repair, or deleted by delete-on-corruption). The path this handle
+	// refers to no longer exists, so every subsequent read must fail instead of
+	// rebuilding a reader against segments already known to be missing.
+	//
+	// Atomic rather than mu-guarded: it is set from updateFileHealthOnError,
+	// which is reached both from the mu-holding read paths and from
+	// createUsenetReader closures that run on background goroutines.
+	metadataGone atomic.Bool
+
 	// Segment offset index for O(1) offset→segment lookup
 	segmentIndex *segmentOffsetIndex
 
@@ -1223,6 +1234,12 @@ func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte,
 	}
 	if off >= mvf.meta.FileSize {
 		return 0, io.EOF
+	}
+
+	// The ephemeral path below builds its own reader without going through
+	// ensureReader, so it needs this guard of its own.
+	if err := mvf.metadataGoneErr(); err != nil {
+		return 0, err
 	}
 
 	// Determine whether this offset can reuse the shared reader.
@@ -1826,8 +1843,29 @@ func (mvf *MetadataVirtualFile) enqueueCloser(r io.Closer) {
 	}
 }
 
+// metadataGoneErr returns the terminal error for a handle whose file was removed
+// underneath it, tearing the reader down on first observation, or nil while the
+// handle is still valid. Doing the teardown here rather than at the point the
+// flag is set keeps it on a path that provably holds mvf.mu.
+//
+// Caller must hold mvf.mu.
+func (mvf *MetadataVirtualFile) metadataGoneErr() error {
+	if !mvf.metadataGone.Load() {
+		return nil
+	}
+	mvf.closeCurrentReader()
+	return &CorruptedFileError{
+		TotalExpected: mvf.meta.FileSize,
+		UnderlyingErr: ErrMetadataGone,
+	}
+}
+
 // ensureReader ensures we have a reader initialized for the current position with range support
 func (mvf *MetadataVirtualFile) ensureReader() error {
+	if err := mvf.metadataGoneErr(); err != nil {
+		return err
+	}
+
 	if mvf.readerInitialized {
 		return nil
 	}
@@ -2375,8 +2413,14 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 
 		if err := mvf.metadataService.DeleteCorruptedFile(ctx, mvf.name, cfg.Metadata.ShouldDeleteSourceNzb(), physicalPath, rootPath); err != nil {
 			slog.ErrorContext(ctx, "Failed to delete corrupted file after streaming failure", "file", mvf.name, "error", err)
-		} else if err := mvf.healthRepository.DeleteHealthRecord(ctx, mvf.name); err != nil {
-			slog.ErrorContext(ctx, "Failed to delete health record after deleting corrupted file", "file", mvf.name, "error", err)
+		} else {
+			// The file this handle is reading no longer exists; latch it closed,
+			// same as the repair path below.
+			mvf.metadataGone.Store(true)
+
+			if err := mvf.healthRepository.DeleteHealthRecord(ctx, mvf.name); err != nil {
+				slog.ErrorContext(ctx, "Failed to delete health record after deleting corrupted file", "file", mvf.name, "error", err)
+			}
 		}
 		return
 	} else if healthEnabled && shouldRepair {
@@ -2396,6 +2440,11 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 				relativePath = strings.TrimPrefix(relativePath, "/")
 				slog.InfoContext(ctx, "Moving metadata file for corrupted item to safety folder to trigger replacement", "file_path", mvf.name)
 				if moveErr := mvf.metadataService.MoveToCorrupted(ctx, relativePath); moveErr == nil {
+					// This handle is streaming the file that was just moved away, so
+					// latch it closed. Without this its prefetch pipeline keeps
+					// fetching segments for a path that no longer exists and the
+					// client keeps reading against it (see issue #539).
+					mvf.metadataGone.Store(true)
 					// Successfully moved metadata, enqueue a coalesced rclone VFS
 					// refresh. Multiple files in the same directory collapse into a
 					// single RC call; concurrent failures across directories are

--- a/internal/nzbfilesystem/repair_coalescer.go
+++ b/internal/nzbfilesystem/repair_coalescer.go
@@ -28,13 +28,19 @@ type RepairCoalescer struct {
 	rclone       rclonecli.RcloneRcClient
 	configGetter config.ConfigGetter
 
-	debounceTTL  time.Duration
-	flushDelay   time.Duration
-	refreshTO    time.Duration
+	debounceTTL time.Duration
+	flushDelay  time.Duration
+	refreshTO   time.Duration
 
 	mu      sync.Mutex
 	seen    map[string]time.Time
 	pending map[string]struct{}
+	// removed records paths whose metadata a repair has actually taken away, so
+	// that other handles on the same path can latch themselves closed even when
+	// their own failure is debounced. Same TTL as seen: once the debounce window
+	// lapses a handle takes the full path again, and MoveToCorrupted succeeds
+	// (it treats an already-moved source as a no-op), which sets the latch anyway.
+	removed map[string]time.Time
 
 	wakeCh chan struct{}
 	stopCh chan struct{}
@@ -59,12 +65,56 @@ func NewRepairCoalescer(rclone rclonecli.RcloneRcClient, configGetter config.Con
 		refreshTO:    defaultRefreshTimeout,
 		seen:         make(map[string]time.Time),
 		pending:      make(map[string]struct{}),
+		removed:      make(map[string]time.Time),
 		wakeCh:       make(chan struct{}, 1),
 		stopCh:       make(chan struct{}),
 	}
 	c.stopWg.Add(1)
 	go c.run()
 	return c
+}
+
+// MarkRemoved records that a repair has taken the metadata for path away. Safe
+// on a nil coalescer (test harness).
+func (c *RepairCoalescer) MarkRemoved(path string) {
+	if c == nil {
+		return
+	}
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.removed[path] = now
+
+	if len(c.removed) > 1024 {
+		cutoff := now.Add(-c.debounceTTL)
+		for k, t := range c.removed {
+			if t.Before(cutoff) {
+				delete(c.removed, k)
+			}
+		}
+	}
+}
+
+// WasRemoved reports whether a repair took path away inside the current
+// debounce window. A handle whose own failure was debounced uses this to latch
+// itself closed, since the handle that did the removal only latched itself.
+func (c *RepairCoalescer) WasRemoved(path string) bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	t, ok := c.removed[path]
+	if !ok {
+		return false
+	}
+	if time.Since(t) >= c.debounceTTL {
+		delete(c.removed, path)
+		return false
+	}
+	return true
 }
 
 // ShouldTrigger reports whether a streaming-failure repair should be fired for

--- a/internal/nzbfilesystem/repair_coalescer_test.go
+++ b/internal/nzbfilesystem/repair_coalescer_test.go
@@ -157,3 +157,59 @@ func TestRepairCoalescer_NilClient_NoPanic(t *testing.T) {
 	c.EnqueueRefresh("/foo")
 	time.Sleep(50 * time.Millisecond)
 }
+
+func TestRepairCoalescer_RemovalIsVisibleToOtherHandles(t *testing.T) {
+	c := newTestCoalescer(t, &fakeRcloneClient{})
+	const p = "/tv/Show.S01E01/ep.mkv"
+
+	if c.WasRemoved(p) {
+		t.Fatal("nothing removed yet")
+	}
+
+	// First handle wins the debounce and removes the file.
+	if !c.ShouldTrigger(p) {
+		t.Fatal("first trigger must win")
+	}
+	c.MarkRemoved(p)
+
+	// Second handle on the same path fails inside the debounce window: it gets
+	// no trigger of its own, but must still be able to see that the file is gone
+	// so it can latch itself closed.
+	if c.ShouldTrigger(p) {
+		t.Fatal("second trigger must be debounced")
+	}
+	if !c.WasRemoved(p) {
+		t.Fatal("debounced handle must observe the removal")
+	}
+
+	// An unrelated path is unaffected.
+	if c.WasRemoved("/tv/Other.S01E01/ep.mkv") {
+		t.Fatal("removal must be scoped to the path")
+	}
+}
+
+func TestRepairCoalescer_RemovalExpiresWithDebounceWindow(t *testing.T) {
+	c := newTestCoalescer(t, &fakeRcloneClient{}) // debounceTTL = 100ms
+	const p = "/movies/a.mkv"
+
+	c.MarkRemoved(p)
+	if !c.WasRemoved(p) {
+		t.Fatal("removal must be visible immediately")
+	}
+
+	// Once the window lapses a handle takes the full repair path again, where
+	// MoveToCorrupted no-ops on an already-moved source and sets the latch, so
+	// the recorded removal is no longer needed.
+	time.Sleep(150 * time.Millisecond)
+	if c.WasRemoved(p) {
+		t.Fatal("removal must expire with the debounce window")
+	}
+}
+
+func TestRepairCoalescer_RemovalNilReceiverIsSafe(t *testing.T) {
+	var c *RepairCoalescer
+	c.MarkRemoved("/x.mkv") // must not panic
+	if c.WasRemoved("/x.mkv") {
+		t.Fatal("nil coalescer must report nothing removed")
+	}
+}


### PR DESCRIPTION
## Summary

When a streaming failure triggers an immediate ARR repair, the file's metadata is moved to the corrupted safety folder while the handle that hit the failure is still open. Nothing tears that handle down, so `ensureReader` keeps rebuilding readers from the in-memory `fileHandleMeta` and the prefetch pipeline goes on fetching segments already known to be missing.

This adds a `metadataGone` latch. Once a repair (or delete-on-corruption) has removed the file underneath an open handle, every subsequent read fails terminally with `CorruptedFileError{UnderlyingErr: ErrMetadataGone}` and the current reader is torn down, instead of the handle spinning against a path that no longer exists.

Refs #539.

## Why this matters, reproduced end to end

I traced a full incident on a Windows host (external rclone into WinFsp). The un-terminated handle is the first domino in a chain that ends with the machine needing a hard reset:

| time | event |
|---|---|
| 17:37:45 | client starts direct-playing a file, 8677 kbps, open read handle |
| 17:56:17 | 47 × `zero-filling missing segment` (articles gone: `nntp: 430 no such article`) |
| 17:56:19 | `Missing segment exceeds padding caps, failing stream` |
| 17:56:19 | `Moved corrupted metadata to safety folder`, handle still open, nothing tears it down |
| 17:59:34 | Plex blocks terminating the transcode session, which closes that handle. Last line it ever logs. |
| 18:02:14 | watchdog cannot stop rclone gracefully because Plex holds an unreleasable handle |
| 18:06:48 | unclean shutdown, Kernel-Power 41 |

The handle can never be closed, so the process holding it wedges in the kernel and everything downstream inherits that.

Correlating two months of logs, 18 of 26 rclone CPU-spin onsets were preceded within 20 minutes by a file vanishing from the VFS. On FUSE, #539 reports the same trigger chain ending in a ghost mount whose reads block indefinitely.

Since deploying this build I have had one recovery under exactly the conditions that previously required a reset. It completed gracefully in 15 seconds, with the client releasing its handles in 5.

## Implementation notes

- `metadataGone` is an `atomic.Bool` rather than `mu`-guarded because it is set from `updateFileHealthOnError`, which is reachable both from the `mu`-holding read paths and from `createUsenetReader` closures running on background goroutines.
- The teardown happens in `metadataGoneErr()` (called from `ensureReader` and the ephemeral path in `ReadAtContext`) rather than at the point the flag is set, so `closeCurrentReader()` always runs on a path that provably holds `mvf.mu`.
- Both entry points already return `ErrFileClosed` on `mvf.meta == nil` under the same lock before reaching this, so the `mvf.meta.FileSize` read is safe against a concurrent `Close()`. That is the race #774 addressed in this file.
- `delete-on-corruption` has the same exposure and is latched on the same terminal condition.
- Errors surface as `CorruptedFileError`, which the WebDAV handler maps to a 500 and the hanwen FUSE backend maps to EIO.

## Scope

Deliberately narrow. This only latches handles whose own read definitively failed and was acted on. It does not attempt to reach into handles from the health worker's independent `MoveToCorrupted` path, because an already-open handle streams from `mvf.meta` in memory and never re-reads the `.meta` file, so a background move does not affect it.

This is orthogonal to #846. That PR invalidates rclone's directory cache so the next lookup is correct, which by design never touches open file handles. The two are complementary, and I have been running both together with no file overlap and green CI on the combination.

## Testing

- `internal/nzbfilesystem/health_disabled_test.go` covers the health-disabled path.
- `go test ./...` passes.
- Running in production on Windows since 2026-08-25.
