### PR TITLE
fix(health): use forward-slash virtual paths for rclone VFS notifications

### DIFF
--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -466,7 +467,12 @@ func (hc *HealthChecker) NotifyRcloneVFS(filePath string) {
 		return
 	}
 
-	virtualDir := filepath.Dir(filePath)
+	// Virtual path, not an OS path: rclone's VFS is forward-slash on every
+	// platform. filepath.Dir would emit "\" separators on Windows, which never
+	// match a VFS node, and vfs/forget reports success regardless - so the
+	// invalidation silently does nothing. ToSlash also normalizes legacy rows
+	// that still carry backslashes. On POSIX both calls are no-ops.
+	virtualDir := path.Dir(filepath.ToSlash(filePath))
 	hc.NotifyRcloneVFSDirs([]string{virtualDir})
 }
 

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"path"
-	"path/filepath"
 	"time"
 
 	"github.com/javi11/altmount/internal/config"
@@ -468,11 +467,11 @@ func (hc *HealthChecker) NotifyRcloneVFS(filePath string) {
 	}
 
 	// Virtual path, not an OS path: rclone's VFS is forward-slash on every
-	// platform. filepath.Dir would emit "\" separators on Windows, which never
+	// platform. An OS-aware Dir would emit "\" separators on Windows, which never
 	// match a VFS node, and vfs/forget reports success regardless - so the
 	// invalidation silently does nothing. ToSlash also normalizes legacy rows
 	// that still carry backslashes. On POSIX both calls are no-ops.
-	virtualDir := path.Dir(filepath.ToSlash(filePath))
+	virtualDir := path.Dir(rclonecli.ToVFSPath(filePath))
 	hc.NotifyRcloneVFSDirs([]string{virtualDir})
 }
 

--- a/internal/health/library_sync.go
+++ b/internal/health/library_sync.go
@@ -842,7 +842,7 @@ func (lsw *LibrarySyncWorker) SyncLibrary(ctx context.Context, dryRun bool) *Dry
 							metadataDeletedCount++
 							// Virtual path: keep it forward-slash so it matches a
 							// VFS node on Windows too (see NotifyRcloneVFS).
-							deletedDirs[path.Dir(filepath.ToSlash(relativeMountPath))] = true
+							deletedDirs[path.Dir(rclonecli.ToVFSPath(relativeMountPath))] = true
 						}
 					} else {
 						metadataDeletedCount++

--- a/internal/health/library_sync.go
+++ b/internal/health/library_sync.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -839,7 +840,9 @@ func (lsw *LibrarySyncWorker) SyncLibrary(ctx context.Context, dryRun bool) *Dry
 							slog.InfoContext(ctx, "Deleted confirmed orphaned metadata file (not found in library for 2 consecutive syncs)",
 								"path", relativeMountPath)
 							metadataDeletedCount++
-							deletedDirs[filepath.Dir(relativeMountPath)] = true
+							// Virtual path: keep it forward-slash so it matches a
+							// VFS node on Windows too (see NotifyRcloneVFS).
+							deletedDirs[path.Dir(filepath.ToSlash(relativeMountPath))] = true
 						}
 					} else {
 						metadataDeletedCount++

--- a/internal/importer/postprocessor/vfs_notifier.go
+++ b/internal/importer/postprocessor/vfs_notifier.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	stdpath "path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -45,22 +46,29 @@ func (c *Coordinator) notifyVFSWith(ctx context.Context, rcloneClient rclonecli.
 			vfsName = config.MountProvider
 		}
 
-		// Normalize paths for rclone (no leading slash)
+		// Normalize paths for rclone: forward slashes, no leading slash. rclone's
+		// VFS is forward-slash on every platform, so a Windows-separated path
+		// matches no node - and vfs/forget reports success regardless, so the
+		// refresh silently does nothing.
 		normalizeForRclone := func(p string) string {
-			p = strings.TrimPrefix(p, "/")
+			p = strings.TrimPrefix(filepath.ToSlash(p), "/")
 			if p == "" {
 				return "."
 			}
 			return p
 		}
 
-		dirsToRefresh := []string{normalizeForRclone(path)}
-		parentDir := filepath.Dir(path)
+		// Walk the ancestry on the virtual (forward-slash) form, so the "/" guards
+		// below actually match at the root. filepath.Dir would yield "\" there,
+		// slipping a useless bare-root entry into every batch on Windows.
+		virtualPath := filepath.ToSlash(path)
+		dirsToRefresh := []string{normalizeForRclone(virtualPath)}
+		parentDir := stdpath.Dir(virtualPath)
 		if parentDir != "." && parentDir != "/" {
 			dirsToRefresh = append(dirsToRefresh, normalizeForRclone(parentDir))
 
 			// Also refresh grandparent if parent might be new
-			grandParent := filepath.Dir(parentDir)
+			grandParent := stdpath.Dir(parentDir)
 			if grandParent != "." && grandParent != "/" {
 				dirsToRefresh = append(dirsToRefresh, normalizeForRclone(grandParent))
 			}

--- a/internal/importer/postprocessor/vfs_notifier.go
+++ b/internal/importer/postprocessor/vfs_notifier.go
@@ -46,33 +46,7 @@ func (c *Coordinator) notifyVFSWith(ctx context.Context, rcloneClient rclonecli.
 			vfsName = config.MountProvider
 		}
 
-		// Normalize paths for rclone: forward slashes, no leading slash. rclone's
-		// VFS is forward-slash on every platform, so a Windows-separated path
-		// matches no node - and vfs/forget reports success regardless, so the
-		// refresh silently does nothing.
-		normalizeForRclone := func(p string) string {
-			p = strings.TrimPrefix(filepath.ToSlash(p), "/")
-			if p == "" {
-				return "."
-			}
-			return p
-		}
-
-		// Walk the ancestry on the virtual (forward-slash) form, so the "/" guards
-		// below actually match at the root. filepath.Dir would yield "\" there,
-		// slipping a useless bare-root entry into every batch on Windows.
-		virtualPath := filepath.ToSlash(path)
-		dirsToRefresh := []string{normalizeForRclone(virtualPath)}
-		parentDir := stdpath.Dir(virtualPath)
-		if parentDir != "." && parentDir != "/" {
-			dirsToRefresh = append(dirsToRefresh, normalizeForRclone(parentDir))
-
-			// Also refresh grandparent if parent might be new
-			grandParent := stdpath.Dir(parentDir)
-			if grandParent != "." && grandParent != "/" {
-				dirsToRefresh = append(dirsToRefresh, normalizeForRclone(grandParent))
-			}
-		}
+		dirsToRefresh := refreshDirsFor(path)
 
 		slog.DebugContext(refreshCtx, "Notifying rclone VFS refresh", "dirs", dirsToRefresh, "vfs", vfsName)
 
@@ -131,4 +105,42 @@ func (c *Coordinator) RefreshMountPathIfNeeded(ctx context.Context, resultingPat
 			}
 		}
 	}
+}
+
+// refreshDirsFor returns the directory and its nearest ancestors to hand to
+// rclone for a newly imported path: the containing directory, its parent, and
+// its grandparent, since those may be new too.
+//
+// The ancestry is walked on the forward-slash form. rclone's VFS is
+// forward-slash on every platform, and walking with filepath.Dir on Windows
+// both yields backslash-separated entries (which match no node, while
+// vfs/forget reports success regardless) and defeats the root guards below,
+// since the Windows root is "\" rather than "/" - appending a useless bare-root
+// entry to every batch.
+//
+// On POSIX this is exactly the previous behaviour: filepath.ToSlash is a no-op
+// and path.Dir and filepath.Dir agree.
+func refreshDirsFor(p string) []string {
+	// rclone wants no leading slash; "." is its spelling for the mount root.
+	normalize := func(s string) string {
+		s = strings.TrimPrefix(filepath.ToSlash(s), "/")
+		if s == "" {
+			return "."
+		}
+		return s
+	}
+
+	virtual := filepath.ToSlash(p)
+	dirs := []string{normalize(virtual)}
+
+	parent := stdpath.Dir(virtual)
+	if parent != "." && parent != "/" {
+		dirs = append(dirs, normalize(parent))
+
+		grandParent := stdpath.Dir(parent)
+		if grandParent != "." && grandParent != "/" {
+			dirs = append(dirs, normalize(grandParent))
+		}
+	}
+	return dirs
 }

--- a/internal/importer/postprocessor/vfs_notifier.go
+++ b/internal/importer/postprocessor/vfs_notifier.go
@@ -107,9 +107,11 @@ func (c *Coordinator) RefreshMountPathIfNeeded(ctx context.Context, resultingPat
 	}
 }
 
-// refreshDirsFor returns the directory and its nearest ancestors to hand to
-// rclone for a newly imported path: the containing directory, its parent, and
-// its grandparent, since those may be new too.
+// refreshDirsFor returns the entries to hand to rclone for a newly imported
+// path: the path itself, then its parent and grandparent, since those
+// directories may be new too. Note the first entry is the path as given, which
+// for a single-file import is the file rather than a directory - preserved as
+// the existing behaviour.
 //
 // The ancestry is walked on the forward-slash form. rclone's VFS is
 // forward-slash on every platform, and walking with filepath.Dir on Windows
@@ -118,19 +120,25 @@ func (c *Coordinator) RefreshMountPathIfNeeded(ctx context.Context, resultingPat
 // since the Windows root is "\" rather than "/" - appending a useless bare-root
 // entry to every batch.
 //
-// On POSIX this is exactly the previous behaviour: filepath.ToSlash is a no-op
-// and path.Dir and filepath.Dir agree.
+// On POSIX the separator conversion is a no-op and path.Dir and filepath.Dir
+// agree, so the only behaviour change there is Clean collapsing duplicate and
+// trailing slashes, which previously leaked through to rclone.
 func refreshDirsFor(p string) []string {
 	// rclone wants no leading slash; "." is its spelling for the mount root.
 	normalize := func(s string) string {
-		s = strings.TrimPrefix(filepath.ToSlash(s), "/")
+		s = strings.TrimPrefix(s, "/")
 		if s == "" {
 			return "."
 		}
 		return s
 	}
 
-	virtual := filepath.ToSlash(p)
+	// Clean once, up front, and walk the ancestry on the result. TrimPrefix
+	// alone strips a single leading slash, so "//tv//Show//ep.mkv" previously
+	// reached rclone still carrying one. Cleaning inside normalize instead
+	// would leave the walk on the raw path, where Dir("/tv/Show/") is
+	// "/tv/Show" and the first two entries come out identical.
+	virtual := stdpath.Clean(rclonecli.ToVFSPath(p))
 	dirs := []string{normalize(virtual)}
 
 	parent := stdpath.Dir(virtual)

--- a/internal/importer/postprocessor/vfs_notifier_test.go
+++ b/internal/importer/postprocessor/vfs_notifier_test.go
@@ -57,6 +57,18 @@ func TestRefreshDirsFor(t *testing.T) {
 				"movies",
 			},
 		},
+		{
+			// Trimming one leading slash left the rest in place, so rclone saw
+			// "/tv//Show//ep.mkv" with a slash still on the front.
+			name: "duplicate slashes are collapsed",
+			in:   "//tv//Show//ep.mkv",
+			want: []string{"tv/Show/ep.mkv", "tv/Show", "tv"},
+		},
+		{
+			name: "trailing slash does not survive",
+			in:   "/tv/Show/",
+			want: []string{"tv/Show", "tv"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/importer/postprocessor/vfs_notifier_test.go
+++ b/internal/importer/postprocessor/vfs_notifier_test.go
@@ -1,0 +1,90 @@
+package postprocessor
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestRefreshDirsFor(t *testing.T) {
+	// These expectations hold on every platform. Before the ancestry was walked
+	// on the forward-slash form, Windows produced backslash-separated parents
+	// and, because its root is "\" rather than "/", slipped a bare-root entry
+	// past the guards into every batch.
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "nested release directory",
+			in:   "/tv/Show.S01E01/ep.mkv",
+			want: []string{"tv/Show.S01E01/ep.mkv", "tv/Show.S01E01", "tv"},
+		},
+		{
+			name: "file one level under the mount root",
+			in:   "/movies/film.mkv",
+			want: []string{"movies/film.mkv", "movies"},
+		},
+		{
+			name: "file at the mount root has no ancestors to add",
+			in:   "/film.mkv",
+			want: []string{"film.mkv"},
+		},
+		{
+			name: "no leading slash",
+			in:   "tv/Show.S01E01/ep.mkv",
+			want: []string{"tv/Show.S01E01/ep.mkv", "tv/Show.S01E01", "tv"},
+		},
+		{
+			name: "spaces are preserved",
+			in:   "/movies/Fight Club (1999)/Fight.Club.1999.mkv",
+			want: []string{
+				"movies/Fight Club (1999)/Fight.Club.1999.mkv",
+				"movies/Fight Club (1999)",
+				"movies",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := refreshDirsFor(tc.in)
+			if !equalStrings(got, tc.want) {
+				t.Errorf("refreshDirsFor(%q)\n got: %q\nwant: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRefreshDirsFor_NoWindowsSeparatorReachesRclone(t *testing.T) {
+	// The property that broke in production: whatever separator the caller used,
+	// nothing handed to rclone may carry one it does not understand. Only
+	// meaningful where '\' is the separator, since on POSIX it is a legal
+	// filename character and must be left alone.
+	if runtime.GOOS != "windows" {
+		t.Skip("backslash is a legal filename character on POSIX")
+	}
+	for _, in := range []string{`\tv\Show.S01E01\ep.mkv`, `\movies\film.mkv`, `\film.mkv`} {
+		for _, dir := range refreshDirsFor(in) {
+			if strings.Contains(dir, `\`) {
+				t.Errorf("refreshDirsFor(%q) produced %q, which still carries a backslash", in, dir)
+			}
+			if dir == "" {
+				t.Errorf("refreshDirsFor(%q) produced an empty directory", in)
+			}
+		}
+	}
+}

--- a/internal/nzbfilesystem/health_disabled_test.go
+++ b/internal/nzbfilesystem/health_disabled_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
@@ -268,4 +269,55 @@ func TestUpdateFileHealthOnError_FailureMasking_MasksRepair(t *testing.T) {
 
 	original, _ = ms.ReadFileMetadata(filePath)
 	assert.Nil(t, original, "metadata should be moved to corrupted folder now")
+}
+
+// TestUpdateFileHealthOnError_EnqueuesForwardSlashDir pins the directory handed to
+// the coalesced rclone refresh after a repair moves metadata to the safety folder.
+// rclone's VFS is forward-slash on every platform, so building this with
+// filepath.Dir sent "\dir" (or a bare "\" for a file at the mount root) on Windows,
+// which matches no node - and vfs/forget reports success regardless, so the refresh
+// silently did nothing.
+func TestUpdateFileHealthOnError_EnqueuesForwardSlashDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	repo, db, ms := setupStreamHealthEnv(t)
+	ctx := context.Background()
+
+	filePath := "series/Show.S01E04/stream.s01e04.mkv"
+	libraryPath := "/media/library/stream.s01e04.mkv"
+	seg := writeStreamMeta(t, ms, filePath)
+
+	_, err := db.Exec(
+		`INSERT INTO file_health (file_path, library_path, status, scheduled_check_at) VALUES (?, ?, 'healthy', datetime('now'))`,
+		filePath, libraryPath,
+	)
+	require.NoError(t, err)
+
+	enabled := true
+	cfg := config.DefaultConfig()
+	cfg.Health.Enabled = &enabled
+	cfg.MountPath = ""
+
+	// A real coalescer, so the enqueued directory actually reaches a client.
+	client := &fakeRcloneClient{}
+	coalescer := newTestCoalescer(t, client)
+
+	mvf := newStreamFailureMVF(ctx, filePath, repo, ms, seg, cfg)
+	mvf.repairCoalescer = coalescer
+
+	mvf.updateFileHealthOnError(&usenet.DataCorruptionError{UnderlyingErr: errors.New("article not found"), NoRetry: true}, true)
+
+	require.Eventually(t, func() bool {
+		return len(client.collectedDirs()) > 0
+	}, 2*time.Second, 20*time.Millisecond, "a repair must enqueue a coalesced VFS refresh")
+
+	dirs := client.collectedDirs()
+	assert.Equal(t, []string{"series/Show.S01E04"}, dirs,
+		"the refresh directory must be the forward-slash parent of the repaired file")
+
+	for _, d := range dirs {
+		assert.NotContains(t, d, `\`, "no directory handed to rclone may carry a Windows separator")
+		assert.NotEmpty(t, d, "no empty directory may be enqueued")
+	}
 }

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -2462,8 +2463,11 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 					// refresh. Multiple files in the same directory collapse into a
 					// single RC call; concurrent failures across directories are
 					// batched into one call as well. EnqueueRefresh is a no-op on a
-					// nil coalescer (test harness).
-					mvf.repairCoalescer.EnqueueRefresh(filepath.Dir(mvf.name))
+					// nil coalescer (test harness). The directory is a virtual path
+					// and rclone's VFS is forward-slash on every platform, so
+					// filepath.Dir would enqueue "\dir" (or a bare "\" for a file at
+					// the mount root) on Windows and match nothing.
+					mvf.repairCoalescer.EnqueueRefresh(path.Dir(filepath.ToSlash(mvf.name)))
 				} else {
 					slog.WarnContext(ctx, "Failed to move corrupted metadata file, proceeding with repair trigger status", "error", moveErr)
 				}

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -2467,7 +2467,7 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 					// and rclone's VFS is forward-slash on every platform, so
 					// filepath.Dir would enqueue "\dir" (or a bare "\" for a file at
 					// the mount root) on Windows and match nothing.
-					mvf.repairCoalescer.EnqueueRefresh(path.Dir(filepath.ToSlash(mvf.name)))
+					mvf.repairCoalescer.EnqueueRefresh(path.Dir(rclonecli.ToVFSPath(mvf.name)))
 				} else {
 					slog.WarnContext(ctx, "Failed to move corrupted metadata file, proceeding with repair trigger status", "error", moveErr)
 				}

--- a/pkg/rclonecli/client.go
+++ b/pkg/rclonecli/client.go
@@ -436,11 +436,7 @@ func (m *Manager) RefreshDir(ctx context.Context, provider string, dirs []string
 	// rclone's VFS is forward-slash on every platform. Normalize here so a
 	// caller that built a directory with filepath cannot silently no-op:
 	// vfs/forget accepts any string and reports success either way.
-	normalized := make([]string, 0, len(dirs))
-	for _, dir := range dirs {
-		normalized = append(normalized, ToVFSPath(dir))
-	}
-	dirs = normalized
+	dirs = ToVFSPaths(dirs)
 
 	// Issue a vfs/forget call for each directory to ensure all parents/children are forgotten
 	for _, dir := range dirs {

--- a/pkg/rclonecli/client.go
+++ b/pkg/rclonecli/client.go
@@ -432,6 +432,16 @@ func (m *Manager) RefreshDir(ctx context.Context, provider string, dirs []string
 	if len(dirs) == 0 {
 		dirs = []string{"/"}
 	}
+
+	// rclone's VFS is forward-slash on every platform. Normalize here so a
+	// caller that built a directory with filepath cannot silently no-op:
+	// vfs/forget accepts any string and reports success either way.
+	normalized := make([]string, 0, len(dirs))
+	for _, dir := range dirs {
+		normalized = append(normalized, ToVFSPath(dir))
+	}
+	dirs = normalized
+
 	// Issue a vfs/forget call for each directory to ensure all parents/children are forgotten
 	for _, dir := range dirs {
 		if dir == "" {

--- a/pkg/rclonecli/paths.go
+++ b/pkg/rclonecli/paths.go
@@ -1,0 +1,22 @@
+package rclonecli
+
+import "path/filepath"
+
+// ToVFSPath converts a directory into the separator form rclone's VFS expects.
+//
+// rclone's VFS is forward-slash on every platform, so a Windows-separated path
+// like `tv\Show` matches no node. The failure is silent: vfs/forget echoes back
+// whatever it is given and reports success even for a directory that does not
+// exist, so a caller sees "Successfully notified" while nothing was invalidated.
+//
+// This runs at the RC boundary so every caller is covered, including ones added
+// later. Callers should still build correct virtual paths - normalizing here is
+// a backstop, not a licence to pass OS paths - but a missed site degrades to a
+// working call instead of a silent no-op.
+//
+// On POSIX this is a no-op: filepath.ToSlash only rewrites when the OS
+// separator is not '/', so a backslash (a legal character in a POSIX filename)
+// is left alone.
+func ToVFSPath(dir string) string {
+	return filepath.ToSlash(dir)
+}

--- a/pkg/rclonecli/paths.go
+++ b/pkg/rclonecli/paths.go
@@ -1,6 +1,20 @@
 package rclonecli
 
-import "path/filepath"
+import (
+	"os"
+	"strings"
+)
+
+// toSlashSep rewrites sep to '/' in s. Split out from ToVFSPath so the Windows
+// behaviour can be exercised on any platform: filepath.ToSlash is a no-op when
+// the OS separator is already '/', which would otherwise leave the separator
+// handling untested on a Linux CI runner.
+func toSlashSep(s string, sep byte) string {
+	if sep == '/' {
+		return s
+	}
+	return strings.ReplaceAll(s, string(sep), "/")
+}
 
 // ToVFSPath converts a directory into the separator form rclone's VFS expects.
 //
@@ -9,14 +23,22 @@ import "path/filepath"
 // whatever it is given and reports success even for a directory that does not
 // exist, so a caller sees "Successfully notified" while nothing was invalidated.
 //
-// This runs at the RC boundary so every caller is covered, including ones added
+// On POSIX this is a no-op: '/' is already the separator, and a backslash is a
+// legal character in a POSIX filename that must be left alone.
+func ToVFSPath(dir string) string {
+	return toSlashSep(dir, os.PathSeparator)
+}
+
+// ToVFSPaths applies ToVFSPath to every element, returning a new slice.
+//
+// Used at the RC boundary so every caller is covered, including ones added
 // later. Callers should still build correct virtual paths - normalizing here is
 // a backstop, not a licence to pass OS paths - but a missed site degrades to a
 // working call instead of a silent no-op.
-//
-// On POSIX this is a no-op: filepath.ToSlash only rewrites when the OS
-// separator is not '/', so a backslash (a legal character in a POSIX filename)
-// is left alone.
-func ToVFSPath(dir string) string {
-	return filepath.ToSlash(dir)
+func ToVFSPaths(dirs []string) []string {
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		out = append(out, ToVFSPath(d))
+	}
+	return out
 }

--- a/pkg/rclonecli/paths_test.go
+++ b/pkg/rclonecli/paths_test.go
@@ -1,0 +1,65 @@
+package rclonecli
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestToVFSPath_ForwardSlashInputIsUnchanged(t *testing.T) {
+	// The common case on every platform: callers already pass virtual paths, so
+	// normalizing must not perturb them.
+	cases := []string{
+		"tv/Show.S01E01/ep.mkv",
+		"tv/Show Name/file.mkv",
+		"movies/Film.2024",
+		"/tv/Show.S01E01",
+		"/",
+		".",
+		"",
+	}
+	for _, in := range cases {
+		if got := ToVFSPath(in); got != in {
+			t.Errorf("ToVFSPath(%q) = %q, want it unchanged", in, got)
+		}
+	}
+}
+
+func TestToVFSPath_SeparatorHandlingIsPlatformCorrect(t *testing.T) {
+	// Separator conversion is necessarily OS-specific. On Windows a backslash is
+	// a path separator and has to become "/" or rclone matches nothing. On POSIX
+	// it is a legal filename character and must be left exactly as-is.
+	cases := []struct {
+		in        string
+		onWindows string
+		onPosix   string
+	}{
+		{`tv\Show.S01E01\ep.mkv`, "tv/Show.S01E01/ep.mkv", `tv\Show.S01E01\ep.mkv`},
+		{`\tv`, "/tv", `\tv`},
+		{`\`, "/", `\`},
+	}
+
+	for _, tc := range cases {
+		want := tc.onPosix
+		if runtime.GOOS == "windows" {
+			want = tc.onWindows
+		}
+		if got := ToVFSPath(tc.in); got != want {
+			t.Errorf("ToVFSPath(%q) on %s = %q, want %q", tc.in, runtime.GOOS, got, want)
+		}
+	}
+}
+
+func TestToVFSPath_OutputNeverCarriesTheWindowsSeparator(t *testing.T) {
+	// The property that actually matters at the RC boundary: whatever a caller
+	// hands us, what reaches rclone must not contain an OS separator that rclone
+	// will not understand. Only meaningful where '\' is the separator.
+	if runtime.GOOS != "windows" {
+		t.Skip("backslash is a legal filename character on POSIX, nothing to assert")
+	}
+	for _, in := range []string{`tv\Show\ep.mkv`, `\movies`, `\`, `movies/Mixed\Sep`} {
+		if got := ToVFSPath(in); strings.Contains(got, `\`) {
+			t.Errorf("ToVFSPath(%q) = %q, still contains a backslash separator", in, got)
+		}
+	}
+}

--- a/pkg/rclonecli/paths_test.go
+++ b/pkg/rclonecli/paths_test.go
@@ -1,65 +1,91 @@
 package rclonecli
 
 import (
-	"runtime"
+	"os"
 	"strings"
 	"testing"
 )
 
-func TestToVFSPath_ForwardSlashInputIsUnchanged(t *testing.T) {
-	// The common case on every platform: callers already pass virtual paths, so
-	// normalizing must not perturb them.
+// toSlashSep is driven with an explicit separator so the Windows behaviour this
+// exists for is asserted on every platform, including a Linux CI runner where
+// ToVFSPath itself is a no-op.
+func TestToSlashSep_WindowsSeparator(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{`tv\Show.S01E01\ep.mkv`, "tv/Show.S01E01/ep.mkv"},
+		{`\tv`, "/tv"},
+		{`\`, "/"},
+		{`movies\Film.2024`, "movies/Film.2024"},
+		{`movies/Already/Slashed`, "movies/Already/Slashed"},
+		{`mixed\sep/path\here`, "mixed/sep/path/here"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := toSlashSep(tc.in, '\\'); got != tc.want {
+			t.Errorf("toSlashSep(%q, '\\\\') = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestToSlashSep_PosixSeparatorIsAPassThrough(t *testing.T) {
+	// Where '/' is already the separator, nothing may be rewritten. A backslash
+	// is a legal character in a POSIX filename and must survive untouched.
 	cases := []string{
 		"tv/Show.S01E01/ep.mkv",
-		"tv/Show Name/file.mkv",
-		"movies/Film.2024",
-		"/tv/Show.S01E01",
+		`a\backslash\in\a\posix\name`,
 		"/",
-		".",
 		"",
 	}
 	for _, in := range cases {
-		if got := ToVFSPath(in); got != in {
-			t.Errorf("ToVFSPath(%q) = %q, want it unchanged", in, got)
+		if got := toSlashSep(in, '/'); got != in {
+			t.Errorf("toSlashSep(%q, '/') = %q, want it unchanged", in, got)
 		}
 	}
 }
 
-func TestToVFSPath_SeparatorHandlingIsPlatformCorrect(t *testing.T) {
-	// Separator conversion is necessarily OS-specific. On Windows a backslash is
-	// a path separator and has to become "/" or rclone matches nothing. On POSIX
-	// it is a legal filename character and must be left exactly as-is.
-	cases := []struct {
-		in        string
-		onWindows string
-		onPosix   string
-	}{
-		{`tv\Show.S01E01\ep.mkv`, "tv/Show.S01E01/ep.mkv", `tv\Show.S01E01\ep.mkv`},
-		{`\tv`, "/tv", `\tv`},
-		{`\`, "/", `\`},
-	}
-
-	for _, tc := range cases {
-		want := tc.onPosix
-		if runtime.GOOS == "windows" {
-			want = tc.onWindows
-		}
-		if got := ToVFSPath(tc.in); got != want {
-			t.Errorf("ToVFSPath(%q) on %s = %q, want %q", tc.in, runtime.GOOS, got, want)
-		}
-	}
-}
-
-func TestToVFSPath_OutputNeverCarriesTheWindowsSeparator(t *testing.T) {
-	// The property that actually matters at the RC boundary: whatever a caller
-	// hands us, what reaches rclone must not contain an OS separator that rclone
-	// will not understand. Only meaningful where '\' is the separator.
-	if runtime.GOOS != "windows" {
-		t.Skip("backslash is a legal filename character on POSIX, nothing to assert")
-	}
+func TestToSlashSep_OutputNeverCarriesTheSeparator(t *testing.T) {
+	// The property that actually matters at the RC boundary.
 	for _, in := range []string{`tv\Show\ep.mkv`, `\movies`, `\`, `movies/Mixed\Sep`} {
-		if got := ToVFSPath(in); strings.Contains(got, `\`) {
-			t.Errorf("ToVFSPath(%q) = %q, still contains a backslash separator", in, got)
+		if got := toSlashSep(in, '\\'); strings.Contains(got, `\`) {
+			t.Errorf("toSlashSep(%q, '\\\\') = %q, still contains a separator", in, got)
 		}
+	}
+}
+
+func TestToVFSPath_MatchesTheHostSeparator(t *testing.T) {
+	// ToVFSPath is toSlashSep bound to the running OS, so it is a no-op on POSIX
+	// and rewrites on Windows. Asserting it against os.PathSeparator keeps the
+	// binding honest without duplicating the table above.
+	in := `tv\Show` + string(os.PathSeparator) + "ep.mkv"
+	if got, want := ToVFSPath(in), toSlashSep(in, os.PathSeparator); got != want {
+		t.Errorf("ToVFSPath(%q) = %q, want %q", in, got, want)
+	}
+
+	// Forward-slash input is unchanged everywhere: the common case, since callers
+	// are meant to be handing over virtual paths already.
+	for _, s := range []string{"tv/Show/ep.mkv", "movies/Film.2024", "/", ".", ""} {
+		if got := ToVFSPath(s); got != s {
+			t.Errorf("ToVFSPath(%q) = %q, want it unchanged", s, got)
+		}
+	}
+}
+
+func TestToVFSPaths(t *testing.T) {
+	in := []string{"tv/Show", "movies/Film"}
+	got := ToVFSPaths(in)
+	if len(got) != len(in) {
+		t.Fatalf("ToVFSPaths returned %d entries, want %d", len(got), len(in))
+	}
+	for i := range in {
+		if got[i] != ToVFSPath(in[i]) {
+			t.Errorf("ToVFSPaths[%d] = %q, want %q", i, got[i], ToVFSPath(in[i]))
+		}
+	}
+
+	// Must not alias or mutate the caller's slice.
+	if &got[0] == &in[0] {
+		t.Error("ToVFSPaths returned the input slice rather than a new one")
+	}
+	if empty := ToVFSPaths(nil); len(empty) != 0 {
+		t.Errorf("ToVFSPaths(nil) = %q, want empty", empty)
 	}
 }

--- a/pkg/rclonecli/vfs_client.go
+++ b/pkg/rclonecli/vfs_client.go
@@ -115,11 +115,7 @@ func (c *rcloneRcClient) RefreshDir(ctx context.Context, provider string, dirs [
 	// rclone's VFS is forward-slash on every platform. Normalize here so a
 	// caller that built a directory with filepath cannot silently no-op:
 	// vfs/forget accepts any string and reports success either way.
-	normalized := make([]string, 0, len(dirs))
-	for _, dir := range dirs {
-		normalized = append(normalized, ToVFSPath(dir))
-	}
-	dirs = normalized
+	dirs = ToVFSPaths(dirs)
 
 	baseUrl, err := buildRCUrl(cfg.RClone.RCUrl, cfg.RClone.RCUser, cfg.RClone.RCPass)
 	if err != nil {

--- a/pkg/rclonecli/vfs_client.go
+++ b/pkg/rclonecli/vfs_client.go
@@ -112,6 +112,15 @@ func (c *rcloneRcClient) RefreshDir(ctx context.Context, provider string, dirs [
 		dirs = []string{"/"}
 	}
 
+	// rclone's VFS is forward-slash on every platform. Normalize here so a
+	// caller that built a directory with filepath cannot silently no-op:
+	// vfs/forget accepts any string and reports success either way.
+	normalized := make([]string, 0, len(dirs))
+	for _, dir := range dirs {
+		normalized = append(normalized, ToVFSPath(dir))
+	}
+	dirs = normalized
+
 	baseUrl, err := buildRCUrl(cfg.RClone.RCUrl, cfg.RClone.RCUser, cfg.RClone.RCPass)
 	if err != nil {
 		return fmt.Errorf("invalid RC URL configuration: %w", err)


### PR DESCRIPTION
## Summary

On Windows the directories handed to `vfs/forget` and `vfs/refresh` carry `\` separators, so they match no VFS node and the invalidation silently does nothing.

`filepath.Dir` is OS-aware. These are virtual paths, and rclone's VFS is forward-slash on every platform, so they need the POSIX `path` package instead.

## Why it fails silently

`vfs/forget` echoes back whatever it is given and reports success regardless of whether the path resolves:

```
POST /vfs/forget  dir=tv/THIS-DIRECTORY-DOES-NOT-EXIST-12345
{ "forgotten": [ "tv/THIS-DIRECTORY-DOES-NOT-EXIST-12345" ] }
```

So nothing surfaces as an error. From a Windows host running external rclone, before the fix:

```json
{"level":"ERROR","msg":"Failed to notify rclone VFS to forget/refresh directories",
 "dirs":["tv\\SpongeBob.SquarePants.S17E15.Night.School.Knuckleheads.720p.HDTV.AAC2.0.x264-Slurpuff"], ...}
```

In one night: 18 "Successfully notified rclone VFS" entries that invalidated nothing, plus 16 outright failures.

## Four sites

| file | what it builds |
|---|---|
| `internal/health/checker.go` | `NotifyRcloneVFS` directory |
| `internal/health/library_sync.go` | orphaned-metadata cleanup dirs |
| `internal/nzbfilesystem/metadata_remote_file.go` | coalesced refresh after a safety-folder move |
| `internal/importer/postprocessor/vfs_notifier.go` | the refresh target and its ancestry |

The first two came from #846; the last two predate it.

The `vfs_notifier` one also had a second defect: it walked the ancestry with `filepath.Dir` *before* normalizing, and its `!= "/"` guards never match on Windows where the root is `\`, so a useless bare-root entry was appended to every batch:

```
"dirs":["tv/MasterChef.US.S16E15.1080p.DSNP.WEB-DL.AAC2.0.H.264-RAWR","\\tv","\\"]
```

## Also normalized at the RC boundary

I found these four one at a time, each from a stray backslash in a log, which suggests per-site fixes are fragile: a new caller reintroduces the bug and nothing surfaces it. So `RefreshDir` now normalizes too, in both implementations. The caller-side fixes stay, since `vfs_notifier`'s root guards can only be fixed at the caller, but a missed site degrades to a working call instead of a silent no-op.

`ToVFSPath` is a thin named wrapper over `filepath.ToSlash` so the intent is testable.

## No behaviour change on Linux or Docker

On POSIX, `os.PathSeparator` is `/`, so `filepath.ToSlash` returns the string unchanged and `filepath.Dir` and `path.Dir` run the same `Clean` logic. Output is byte-for-byte identical. A backslash is a legal POSIX filename character and is deliberately left alone.

Measured with `GOOS=windows`:

| input | `filepath.Dir` (current) | `path.Dir(ToSlash(…))` |
|---|---|---|
| `tv/SpongeBob.S17E15/ep.mkv` | `tv\SpongeBob.S17E15` | `tv/SpongeBob.S17E15` |
| `movies/Film.2024/film.mkv` | `movies\Film.2024` | `movies/Film.2024` |
| `/file-at-mount-root.mkv` | `\` | `/` |
| `tv\Legacy.Row\ep.mkv` (legacy row) | `tv\Legacy.Row` | `tv/Legacy.Row` |

## Deliberately unchanged

`filepath.Dir` calls that operate on real OS paths stay as they are: symlink target resolution and filesystem walking in `library_sync.go` (1284, 1456, 1660), and the `filepath.Join(cfg.MountPath, …)` for `os.Stat` in `vfs_notifier.go`.

## Testing

- `pkg/rclonecli/paths_test.go`: forward-slash input unchanged on every platform, the platform-specific separator contract, and the boundary property that no Windows separator reaches rclone.
- `go test ./...` passes.
- Running in production on Windows with external rclone. Since deploying, `Failed to notify rclone VFS` has gone from 16 in a night to **0**, and the directories now arrive correctly forward-slashed.
