### PR TITLE
Mark files as corrupted/degraded on yEnc CRC mismatch

### DIFF
--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -103,6 +103,16 @@ func (e *DataCorruptionError) Unwrap() error {
 	return e.UnderlyingErr
 }
 
+// isCorruptionError reports whether err indicates the article body itself is
+// corrupt (as opposed to a transient network/pool failure), so it should be
+// wrapped as a DataCorruptionError and routed into the health/repair pipeline
+// instead of surfacing as an anonymous read error.
+func isCorruptionError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "data corruption detected") ||
+		strings.Contains(msg, "crc mismatch")
+}
+
 type UsenetReader struct {
 	log            *slog.Logger
 	wg             sync.WaitGroup
@@ -473,7 +483,7 @@ func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segmen
 					bytesWritten = int64(result.BytesDecoded)
 				}
 
-				if strings.Contains(err.Error(), "data corruption detected") {
+				if isCorruptionError(err) {
 					return &DataCorruptionError{
 						UnderlyingErr: err,
 						BytesRead:     bytesWritten,

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -107,7 +107,17 @@ func (e *DataCorruptionError) Unwrap() error {
 // corrupt (as opposed to a transient network/pool failure), so it should be
 // wrapped as a DataCorruptionError and routed into the health/repair pipeline
 // instead of surfacing as an anonymous read error.
+//
+// nntppool.ErrCRCMismatch is checked by identity since it's an exported
+// sentinel (errors.New("nntp: yEnc CRC mismatch")), returned unwrapped from
+// finishBody. The substring fallback covers "data corruption detected",
+// rapidyenc's own corruption sentinel text, in case a future nntppool version
+// starts propagating it (today it does not: the decode error is discarded in
+// nntppool's reader).
 func isCorruptionError(err error) bool {
+	if errors.Is(err, nntppool.ErrCRCMismatch) {
+		return true
+	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "data corruption detected") ||
 		strings.Contains(msg, "crc mismatch")

--- a/internal/usenet/usenet_reader_retry_test.go
+++ b/internal/usenet/usenet_reader_retry_test.go
@@ -3,6 +3,7 @@ package usenet
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"sync"
@@ -191,6 +192,80 @@ func TestMissingSegment_EmitsDebugLog(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "expected 'missing segment' debug log for segment_id=%q, got: %+v", segments.MessageID(0), captured)
+}
+
+// TestRetry_YEncCRCMismatch_ClassifiedAsCorruption pins the fix for a bug
+// where a yEnc CRC mismatch surviving all retries came back as a bare,
+// unclassified error instead of *DataCorruptionError. Only DataCorruptionError
+// routes into MetadataVirtualFile's health/repair pipeline (classifyReadError
+// / updateFileHealthOnError): an unclassified error left the file looking
+// healthy, so nothing ever marked it corrupted or queued a repair, and every
+// subsequent playback attempt re-fetched the same permanently-corrupt article
+// and failed the same way, forever.
+func TestRetry_YEncCRCMismatch_ClassifiedAsCorruption(t *testing.T) {
+	t.Parallel()
+	const (
+		segCount    = 1
+		segSize     = 16
+		maxPrefetch = 1
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// The real sentinel nntppool returns on a CRC mismatch (errors.go:44),
+	// unwrapped, from finishBody — exactly what surfaces in the "segment
+	// download retry" log lines this test is guarding against.
+	crcErr := nntppool.ErrCRCMismatch
+
+	fp := fakepool.New()
+	fp.SetBehavior(segments.MessageID(0), fakepool.SegmentBehavior{Err: crcErr})
+
+	rg := buildEagerRange(ctx, t, segCount, segSize)
+	ur := newReaderForTest(t, ctx, fp, rg, maxPrefetch)
+	ur.Start()
+
+	_, err := io.ReadAll(ur)
+
+	var dcErr *DataCorruptionError
+	if !errors.As(err, &dcErr) {
+		t.Fatalf("expected *DataCorruptionError for exhausted yEnc CRC mismatch, got %v (%T)", err, err)
+	}
+	if !errors.Is(dcErr.UnderlyingErr, crcErr) {
+		t.Errorf("DataCorruptionError.UnderlyingErr = %v, want %v", dcErr.UnderlyingErr, crcErr)
+	}
+
+	// retry.Attempts(2): both attempts must be exhausted before the error
+	// surfaces classified — this must not short-circuit like ErrArticleNotFound.
+	if got := fp.PerMessageCalls(segments.MessageID(0)); got != 2 {
+		t.Errorf("segment 0 issued %d calls, want exactly 2 (retry.Attempts(2) exhausted)", got)
+	}
+}
+
+// TestIsCorruptionError pins which error strings downloadSegmentWithRetry
+// classifies as article-body corruption (and therefore wraps as
+// DataCorruptionError) versus a plain, unclassified failure.
+func TestIsCorruptionError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nntppool.ErrCRCMismatch sentinel", nntppool.ErrCRCMismatch, true},
+		{"wrapped ErrCRCMismatch", fmt.Errorf("fetch failed: %w", nntppool.ErrCRCMismatch), true},
+		{"data corruption detected", errors.New("data corruption detected: short read"), true},
+		{"crc mismatch lowercase, different instance", errors.New("crc mismatch"), true},
+		{"CRC MISMATCH uppercase, different instance", errors.New("CRC MISMATCH"), true},
+		{"generic transient error", errors.New("connection reset by peer"), false},
+		{"article not found", nntppool.ErrArticleNotFound, false},
+		{"context deadline exceeded", context.DeadlineExceeded, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isCorruptionError(tc.err); got != tc.want {
+				t.Errorf("isCorruptionError(%q) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
 }
 
 // captureLogHandler is a minimal slog.Handler that invokes onHandle for


### PR DESCRIPTION
**Summary**
I had a run away download, endlessly reading the same segment over and over because 'nntp: yEnc CRC mismatch' is not raised as corruption. I had 28TB of usenet traffic over 7 days due to this.

Trivial patch to allow multiple failures modes to be flagged as corruption.

This combined with https://github.com/javi11/altmount/pull/848 now triggers clear IO error on reader (in my case it was plex transcoder) and correct retry/repair logic. 

Following log repeated every 800ms:
```
[20:16:42.256] DEBUG WebDAV basic auth succeeded  {"user":"usenet"}
[20:16:42.256] DEBUG WebDAV stream registered  {"path":"/webdav/complete/TV/<redacted>","stream_id":"1234a69d-67fb-437c-b93b-f8db93965732"}
[20:16:42.257] DEBUG WebDAV GET  {"path":"/complete/TV/<redacted>"}
[20:16:42.257] DEBUG WebDAV GET stat  {"is_dir":false,"path":"/complete/TV/<redacted>","size":1047756037}
[20:16:42.257] DEBUG WebDAV opening file  {"name":"/complete/TV/<redacted>"}
[20:16:42.258] DEBUG WebDAV monitored OpenFile  {"monitored":true,"name":"/complete/TV/<redacted>","total_size":1047756037}
[20:16:42.538] DEBUG segment download retry  {"attempt":1,"component":"usenet-reader","elapsed":279402770,"error":"nntp: yEnc CRC mismatch","file_name":"/complete/TV/<redacted>","segment_id":"<redacted>","segment_idx":0}
[20:16:42.706] DEBUG segment download retry  {"attempt":1,"component":"usenet-reader","elapsed":447549546,"error":"nntp: yEnc CRC mismatch","file_name":"/complete/TV/<redacted>","segment_id":"<redacted>","segment_idx":1}
[20:16:42.968] DEBUG segment download retry  {"attempt":2,"component":"usenet-reader","elapsed":709719684,"error":"nntp: yEnc CRC mismatch","file_name":"/complete/TV/<redacted>","segment_id":"<redacted>","segment_idx":1}
[20:16:43.002] DEBUG segment download retry  {"attempt":2,"component":"usenet-reader","elapsed":743167057,"error":"nntp: yEnc CRC mismatch","file_name":"/complete/TV/<redacted>","segment_id":"<redacted>","segment_idx":0}
```