### PR TITLE
fix(importer): stop importer before other services during shutdown

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -330,6 +330,17 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// Start graceful shutdown sequence
 	logger.InfoContext(ctx, "Starting graceful shutdown sequence")
 
+	// Stop the importer first so it stops claiming and processing new queue
+	// items immediately. Without this, the importer keeps running (it was
+	// only ever closed via a deferred Close() after runServe returns) for
+	// the full duration of the remaining shutdown steps below, including
+	// the HTTP server's graceful-shutdown timeout.
+	if err := importerService.Stop(ctx); err != nil {
+		logger.ErrorContext(ctx, "Failed to stop importer service", "error", err)
+	} else {
+		logger.InfoContext(ctx, "Importer service stopped")
+	}
+
 	// Shutdown API server and its managed resources (like FUSE)
 	apiServer.Shutdown(ctx)
 


### PR DESCRIPTION
## Summary
- Fixes #850: on shutdown, the importer kept claiming and processing new queue items because it was only stopped via a deferred `Close()` that ran after `runServe` returned — after the health worker, ARR worker, mount service, and HTTP server graceful shutdown (up to 30s) had already completed.
- Calls `importerService.Stop(ctx)` explicitly as the first step of the shutdown sequence, so worker loops stop claiming immediately and in-flight items are cancelled/bounded.

## Test plan
- [x] `go build ./...` passes
- [ ] Manually verify via Docker restart with an active import queue that no new items are claimed after SIGTERM