### PR TITLE
fix(sabnzbd): delete failed NZB file on queue/history deletion

### DIFF
--- a/internal/api/sabnzbd_delete_cleanup_test.go
+++ b/internal/api/sabnzbd_delete_cleanup_test.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"context"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/importer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newSABnzbdDeleteTestServer(t *testing.T) (*Server, *database.Repository) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := database.NewDB(database.Config{Type: "sqlite", DatabasePath: dbPath})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := database.NewRepository(db.Connection(), db.Dialect())
+
+	server := &Server{
+		queueRepo:       repo,
+		importerService: &importer.Service{}, // non-nil sentinel, not used for delete handlers
+	}
+
+	return server, repo
+}
+
+func addFailedQueueItem(t *testing.T, repo *database.Repository, nzbPath string) int64 {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(nzbPath, []byte("fake nzb"), 0o644))
+
+	item := &database.ImportQueueItem{
+		NzbPath:  nzbPath,
+		Status:   database.QueueStatusFailed,
+		Priority: database.QueuePriorityNormal,
+	}
+	require.NoError(t, repo.AddToQueue(context.Background(), item))
+	return item.ID
+}
+
+func TestHandleSABnzbdQueueDelete_RemovesFailedNzbFile(t *testing.T) {
+	server, repo := newSABnzbdDeleteTestServer(t)
+
+	nzbPath := filepath.Join(t.TempDir(), "failed.nzb")
+	id := addFailedQueueItem(t, repo, nzbPath)
+	require.NotZero(t, id)
+
+	app := fiber.New()
+	app.Delete("/sabnzbd", server.handleSABnzbdQueueDelete)
+
+	req := httptest.NewRequest("DELETE", "/sabnzbd?value=1&name=queue", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Row must be gone from the queue.
+	remaining, err := repo.GetQueueItem(context.Background(), id)
+	require.NoError(t, err)
+	assert.Nil(t, remaining, "queue row should be deleted")
+
+	// The NZB file left in the failed directory must be removed too.
+	_, statErr := os.Stat(nzbPath)
+	assert.True(t, os.IsNotExist(statErr), "failed NZB file should have been deleted, got err=%v", statErr)
+}
+
+func TestHandleSABnzbdHistoryDelete_RemovesFailedNzbFile(t *testing.T) {
+	server, repo := newSABnzbdDeleteTestServer(t)
+
+	nzbPath := filepath.Join(t.TempDir(), "failed.nzb")
+	id := addFailedQueueItem(t, repo, nzbPath)
+	require.NotZero(t, id)
+
+	app := fiber.New()
+	app.Delete("/sabnzbd", server.handleSABnzbdHistoryDelete)
+
+	req := httptest.NewRequest("DELETE", "/sabnzbd?value=1&name=delete", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	remaining, err := repo.GetQueueItem(context.Background(), id)
+	require.NoError(t, err)
+	assert.Nil(t, remaining, "queue row should be deleted")
+
+	_, statErr := os.Stat(nzbPath)
+	assert.True(t, os.IsNotExist(statErr), "failed NZB file should have been deleted, got err=%v", statErr)
+}
+
+func TestHandleSABnzbdQueueDelete_ByDownloadID_RemovesFailedNzbFile(t *testing.T) {
+	server, repo := newSABnzbdDeleteTestServer(t)
+
+	nzbPath := filepath.Join(t.TempDir(), "failed.nzb")
+	require.NoError(t, os.WriteFile(nzbPath, []byte("fake nzb"), 0o644))
+
+	downloadID := "sabnzbd-download-id"
+	item := &database.ImportQueueItem{
+		DownloadID: &downloadID,
+		NzbPath:    nzbPath,
+		Status:     database.QueueStatusFailed,
+		Priority:   database.QueuePriorityNormal,
+	}
+	require.NoError(t, repo.AddToQueue(context.Background(), item))
+
+	app := fiber.New()
+	app.Delete("/sabnzbd", server.handleSABnzbdQueueDelete)
+
+	req := httptest.NewRequest("DELETE", "/sabnzbd?value="+downloadID+"&name=queue", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	_, statErr := os.Stat(nzbPath)
+	assert.True(t, os.IsNotExist(statErr), "failed NZB file should have been deleted, got err=%v", statErr)
+}

--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -718,12 +718,19 @@ func (s *Server) handleSABnzbdQueueDelete(c *fiber.Ctx) error {
 	// 1. Try numeric ID
 	id, err := strconv.ParseInt(nzoID, 10, 64)
 	if err == nil {
+		// Fetch the item first so we can delete its NZB file after removal
+		queueItem, _ := s.queueRepo.GetQueueItem(c.Context(), id)
+
 		// Delete from queue
 		err = s.queueRepo.RemoveFromQueue(c.Context(), id)
 		if err == nil {
 			// Also remove from history if it existed there (to prevent ghost items)
 			_, _ = s.queueRepo.RemoveFromHistoryByNzbID(c.Context(), id)
 			_, _ = s.queueRepo.RemoveFromHistory(c.Context(), id)
+
+			if queueItem != nil {
+				s.removeQueueNzbFiles(c, []string{queueItem.NzbPath})
+			}
 
 			// When a queue item is deleted by ID, notify web UI of queue change
 			if s.progressBroadcaster != nil {
@@ -735,7 +742,7 @@ func (s *Server) handleSABnzbdQueueDelete(c *fiber.Ctx) error {
 
 	// 2. Fallback to DownloadID if not found or not numeric
 	if s.queueRepo != nil {
-		// Try to find the item first to get its ID (for history cleanup)
+		// Try to find the item first to get its ID and NZB path (for history cleanup)
 		item, _ := s.queueRepo.GetQueueItemByDownloadID(c.Context(), nzoID)
 
 		err = s.queueRepo.RemoveFromQueueByDownloadID(c.Context(), nzoID)
@@ -745,6 +752,7 @@ func (s *Server) handleSABnzbdQueueDelete(c *fiber.Ctx) error {
 
 			if item != nil {
 				_, _ = s.queueRepo.RemoveFromHistoryByNzbID(c.Context(), item.ID)
+				s.removeQueueNzbFiles(c, []string{item.NzbPath})
 			}
 
 			// When a queue item is deleted by DownloadID, notify web UI of queue change
@@ -1031,11 +1039,19 @@ func (s *Server) handleSABnzbdHistoryDelete(c *fiber.Ctx) error {
 	// 1. Try numeric ID
 	id, err := strconv.ParseInt(nzoID, 10, 64)
 	if err == nil {
+		// Fetch the item first so we can delete its NZB file after removal
+		queueItem, _ := s.queueRepo.GetQueueItem(c.Context(), id)
+
 		// Delete from queue (history items are still queue items with completed/failed status)
 		err = s.queueRepo.RemoveFromQueue(c.Context(), id)
 		if err == nil {
 			_, _ = s.queueRepo.RemoveFromHistoryByNzbID(c.Context(), id)
 			_, _ = s.queueRepo.RemoveFromHistory(c.Context(), id)
+
+			if queueItem != nil {
+				s.removeQueueNzbFiles(c, []string{queueItem.NzbPath})
+			}
+
 			// When a history item is deleted by queue ID, notify web UI of queue change
 			if s.progressBroadcaster != nil {
 				s.progressBroadcaster.BroadcastQueueChanged()
@@ -1070,8 +1086,12 @@ func (s *Server) handleSABnzbdHistoryDelete(c *fiber.Ctx) error {
 		item, _ := s.queueRepo.GetQueueItemByDownloadID(c.Context(), nzoID)
 
 		// Remove from queue and history by DownloadID
-		_ = s.queueRepo.RemoveFromQueueByDownloadID(c.Context(), nzoID)
+		queueErr := s.queueRepo.RemoveFromQueueByDownloadID(c.Context(), nzoID)
 		affected, err := s.queueRepo.RemoveFromHistoryByDownloadID(c.Context(), nzoID)
+
+		if item != nil && queueErr == nil {
+			s.removeQueueNzbFiles(c, []string{item.NzbPath})
+		}
 
 		if err == nil && affected > 0 {
 			if item != nil {


### PR DESCRIPTION
## Summary
- `handleSABnzbdQueueDelete` and `handleSABnzbdHistoryDelete` removed the `import_queue` row but never deleted the file at `NzbPath`, leaving orphaned files in `/config/.nzbs/failed/` that the retention worker can no longer discover once the row is gone.
- Fetch the queue item before deleting the row (by numeric ID and by DownloadID, in both queue-delete and history-delete handlers) and call `removeQueueNzbFiles` on its `NzbPath` after a successful row deletion, matching the existing native `handleDeleteQueue` behavior.

Fixes #853

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Added `internal/api/sabnzbd_delete_cleanup_test.go` covering queue-delete by numeric ID, queue-delete by DownloadID, and history-delete by numeric ID — each asserts the DB row and the on-disk NZB file are removed
- [x] `go test ./internal/api/...`