### PR TITLE
fix(scanner): send trigger=manual on Sonarr/Radarr repair searches

### DIFF
--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -799,12 +800,7 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 	}
 
 	// Step 3: Trigger targeted search for the missing movie
-	searchCmd := &radarr.CommandRequest{
-		Name:     "MoviesSearch",
-		MovieIDs: []int64{targetMovie.ID},
-	}
-
-	response, err := client.SendCommandContext(ctx, searchCmd)
+	response, err := sendManualRadarrSearch(ctx, client, "MoviesSearch", []int64{targetMovie.ID})
 	if err != nil {
 		return fmt.Errorf("failed to trigger Radarr search for movie ID %d: %w", targetMovie.ID, err)
 	}
@@ -1053,12 +1049,7 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 	}
 
 	// Trigger targeted episode search for the remaining episodes in this file
-	searchCmd := &sonarr.CommandRequest{
-		Name:       "EpisodeSearch",
-		EpisodeIDs: searchIDs,
-	}
-
-	response, err := client.SendCommandContext(ctx, searchCmd)
+	response, err := sendManualSonarrSearch(ctx, client, "EpisodeSearch", searchIDs)
 	if err != nil {
 		return fmt.Errorf("failed to trigger Sonarr episode search: %w", err)
 	}
@@ -1450,4 +1441,56 @@ func (m *Manager) blocklistReadarrBookFile(ctx context.Context, client *readarr.
 		}
 	}
 	return nil
+}
+
+// sendManualRadarrSearch triggers a Radarr search command with trigger set to
+// "manual". golift.io/starr's radarr.CommandRequest doesn't expose a Trigger
+// field, so the request is built and posted manually. Sonarr/Radarr's
+// DelaySpecification only bypasses the configured usenet delay profile when
+// searchCriteria.UserInvokedSearch is true, which the *Arr sets from
+// trigger=="manual" (see altmount#847); an unspecified trigger evaluates the
+// delay profile against a stale, just-deleted file reference and rejects
+// every candidate release.
+func sendManualRadarrSearch(ctx context.Context, client *radarr.Radarr, name string, movieIDs []int64) (*radarr.CommandResponse, error) {
+	cmd := struct {
+		Name     string  `json:"name"`
+		MovieIDs []int64 `json:"movieIds,omitempty"`
+		Trigger  string  `json:"trigger"`
+	}{Name: name, MovieIDs: movieIDs, Trigger: "manual"}
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(cmd); err != nil {
+		return nil, fmt.Errorf("failed to encode Radarr command: %w", err)
+	}
+
+	var output radarr.CommandResponse
+	req2 := starr.Request{URI: radarr.APIver + "/command", Body: &body}
+	if err := client.PostInto(ctx, req2, &output); err != nil {
+		return nil, fmt.Errorf("failed to send Radarr command: %w", err)
+	}
+
+	return &output, nil
+}
+
+// sendManualSonarrSearch triggers a Sonarr search command with trigger set to
+// "manual". See sendManualRadarrSearch for why this is necessary.
+func sendManualSonarrSearch(ctx context.Context, client *sonarr.Sonarr, name string, episodeIDs []int64) (*sonarr.CommandResponse, error) {
+	cmd := struct {
+		Name       string  `json:"name"`
+		EpisodeIDs []int64 `json:"episodeIds,omitempty"`
+		Trigger    string  `json:"trigger"`
+	}{Name: name, EpisodeIDs: episodeIDs, Trigger: "manual"}
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(cmd); err != nil {
+		return nil, fmt.Errorf("failed to encode Sonarr command: %w", err)
+	}
+
+	var output sonarr.CommandResponse
+	req2 := starr.Request{URI: sonarr.APIver + "/command", Body: &body}
+	if err := client.PostInto(ctx, req2, &output); err != nil {
+		return nil, fmt.Errorf("failed to send Sonarr command: %w", err)
+	}
+
+	return &output, nil
 }

--- a/internal/arrs/scanner/manual_search_test.go
+++ b/internal/arrs/scanner/manual_search_test.go
@@ -1,0 +1,80 @@
+package scanner
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"golift.io/starr"
+	"golift.io/starr/radarr"
+	"golift.io/starr/sonarr"
+)
+
+// TestSendManualSonarrSearch_SetsManualTrigger verifies AltMount asks Sonarr
+// to bypass DelaySpecification by sending trigger=="manual" on repair
+// searches. Without it, Sonarr evaluates the usenet delay profile against the
+// just-deleted episode file and rejects every candidate release
+// (altmount#847).
+func TestSendManualSonarrSearch_SetsManualTrigger(t *testing.T) {
+	var received map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"name":"EpisodeSearch","trigger":"manual"}`))
+	}))
+	defer server.Close()
+
+	client := sonarr.New(&starr.Config{URL: server.URL, APIKey: "test"})
+
+	resp, err := sendManualSonarrSearch(t.Context(), client, "EpisodeSearch", []int64{1703})
+	if err != nil {
+		t.Fatalf("sendManualSonarrSearch returned error: %v", err)
+	}
+
+	if trigger, _ := received["trigger"].(string); trigger != "manual" {
+		t.Fatalf("expected request trigger %q, got %q (body: %+v)", "manual", trigger, received)
+	}
+
+	if name, _ := received["name"].(string); name != "EpisodeSearch" {
+		t.Fatalf("expected request name %q, got %q", "EpisodeSearch", name)
+	}
+
+	if resp.Trigger != "manual" {
+		t.Fatalf("expected response trigger %q, got %q", "manual", resp.Trigger)
+	}
+}
+
+// TestSendManualRadarrSearch_SetsManualTrigger mirrors the Sonarr case for
+// Radarr, keeping repair-search semantics consistent across the two targets
+// (altmount#847).
+func TestSendManualRadarrSearch_SetsManualTrigger(t *testing.T) {
+	var received map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"name":"MoviesSearch","trigger":"manual"}`))
+	}))
+	defer server.Close()
+
+	client := radarr.New(&starr.Config{URL: server.URL, APIKey: "test"})
+
+	resp, err := sendManualRadarrSearch(t.Context(), client, "MoviesSearch", []int64{42})
+	if err != nil {
+		t.Fatalf("sendManualRadarrSearch returned error: %v", err)
+	}
+
+	if trigger, _ := received["trigger"].(string); trigger != "manual" {
+		t.Fatalf("expected request trigger %q, got %q (body: %+v)", "manual", trigger, received)
+	}
+
+	if resp.Trigger != "manual" {
+		t.Fatalf("expected response trigger %q, got %q", "manual", resp.Trigger)
+	}
+}


### PR DESCRIPTION
## Summary
- Repair searches for Sonarr (`EpisodeSearch`) and Radarr (`MoviesSearch`) now set `trigger: "manual"` on the command request, sent via a small manual JSON encode + `PostInto` since `golift.io/starr`'s `CommandRequest` doesn't expose a `trigger` field.
- Without this, Sonarr evaluates `DelaySpecification` against the just-deleted `EpisodeFile` reference and throws a `NullReferenceException` for every candidate release when the instance has a non-zero usenet delay profile, so repairs processed hundreds of releases but downloaded zero.

Fixes #847

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/arrs/...`
- [x] Added `internal/arrs/scanner/manual_search_test.go` with httptest-backed assertions that the outgoing Sonarr/Radarr command body includes `trigger: "manual"`