### PR TITLE
fix(health): make acceptable-missing threshold trigger repair

### DIFF
--- a/docs/docs/3. Configuration/health-monitoring.md
+++ b/docs/docs/3. Configuration/health-monitoring.md
@@ -59,7 +59,18 @@ Expand **Performance & Deep Validation** for:
 | Verify Every Segment | Off | Check 100% of segments instead of sampling |
 | Ghost File Detection | Off | Verify actual content (uses bandwidth) |
 | Sampling Percentage | 5% | Segments to check when sampling (1-100%) |
-| Acceptable Missing | 0% | Missing segment tolerance (0-10%) |
+| Acceptable Missing | 2% | Missing segment tolerance (0-10%) |
+
+#### Acceptable Missing Threshold
+
+This is the single control for how much confirmed segment loss AltMount tolerates on a standalone video file before treating it as corrupted, both when a release is first imported and on every later health check:
+
+- **Missing fraction at or below the threshold** — the file imports/stays **degraded**: it plays with the small gap zero-filled, and no repair is triggered.
+- **Missing fraction above the threshold** — the file is marked **unhealthy**, which triggers a repair (re-download/blocklist-and-search via Sonarr/Radarr, if the Repair Engine is enabled).
+
+A file whose damage exceeds the hard-coded playback caps (a run longer than 4 consecutive missing segments, or over 64 missing segments total) always fails, regardless of this setting — the threshold only governs behavior *inside* those caps.
+
+**To make AltMount stricter** — repair on any missing segment, no degraded grace period — set **Acceptable Missing** to **0%**. This also applies at import time: a freshly grabbed release with even one confirmed missing segment is rejected immediately, so your ARR can search for an alternate release, instead of importing degraded.
 
 **Scheduling & Concurrency:**
 
@@ -280,7 +291,7 @@ health:
   resolve_repair_on_import: false
   verify_data: false
   check_all_segments: false
-  acceptable_missing_segments_percentage: 0.0
+  acceptable_missing_segments_percentage: 2.0 # 0 = strict (repair on any missing segment); 100 = disabled (never fail on this basis)
   read_timeout_seconds: 10
 
   repair:

--- a/internal/config/accessors.go
+++ b/internal/config/accessors.go
@@ -126,13 +126,20 @@ func (c *Config) GetMaxRepairRetries() int {
 	return c.Health.Repair.MaxRepairRetries
 }
 
-// Import config accessor methods.
-
-// GetImportDamagePolicyTolerant reports whether small confirmed damage on a
-// standalone video file should import as degraded (true, the default) instead
-// of failing the import (false, "strict").
-func (c *Config) GetImportDamagePolicyTolerant() bool {
-	return c.Import.DamagePolicy != "strict"
+// GetAcceptableMissingSegmentsPercentage returns the missing-segment
+// percentage a health check tolerates before failing a file (and triggering
+// repair) rather than leaving it degraded. Defaults to 2%; set to 0 to
+// disable tolerance entirely (any missing segment fails immediately), or to
+// 100 to disable failing on this basis altogether (always degraded, never
+// repaired for missing segments alone). The value is clamped to [0, 100].
+func (c *Config) GetAcceptableMissingSegmentsPercentage() float64 {
+	if c.Health.AcceptableMissingSegmentsPercentage < 0 {
+		return 0
+	}
+	if c.Health.AcceptableMissingSegmentsPercentage > 100 {
+		return 100
+	}
+	return c.Health.AcceptableMissingSegmentsPercentage
 }
 
 // TotalProviderConnections returns the pool's total connection capacity: the

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -463,13 +463,6 @@ type ImportConfig struct {
 	FilterSampleFiles        *bool          `yaml:"filter_sample_files" mapstructure:"filter_sample_files" json:"filter_sample_files,omitempty"`
 	FailedItemRetentionHours *int           `yaml:"failed_item_retention_hours" mapstructure:"failed_item_retention_hours" json:"failed_item_retention_hours,omitempty"`
 	HistoryRetentionDays     *int           `yaml:"history_retention_days" mapstructure:"history_retention_days" json:"history_retention_days,omitempty"`
-	// DamagePolicy governs standalone video files whose fast-fail sweep finds
-	// SMALL confirmed damage (within the playback padding caps, see
-	// internal/holes): "tolerant" (default) imports them as degraded so
-	// streaming zero-fills the gaps; "strict" fails the import so an ARR can
-	// grab a different release. Damage beyond the caps, archive-set members
-	// and non-video files fail either way.
-	DamagePolicy string `yaml:"damage_policy" mapstructure:"damage_policy" json:"damage_policy,omitempty"`
 }
 
 // LogConfig represents logging configuration with rotation support
@@ -1816,7 +1809,7 @@ func DefaultConfig(configDir ...string) *Config {
 			SegmentSamplePercentage:             5,                      // Default: 5% segment sampling
 			LibrarySyncIntervalMinutes:          360,                    // Default: sync every 6 hours
 			ResolveRepairOnImport:               &resolveRepairOnImport, // Enabled by default
-			AcceptableMissingSegmentsPercentage: 0,                      // Default: no missing segments allowed
+			AcceptableMissingSegmentsPercentage: 2,                      // Default: tolerate up to 2% missing segments
 			Repair: RepairConfig{
 				Enabled:            &repairEnabled,
 				IntervalMinutes:    60,

--- a/internal/health/holes.go
+++ b/internal/health/holes.go
@@ -59,6 +59,17 @@ func (hc *HealthChecker) classifyHoles(
 		}
 	}
 
+	// The configured acceptable-missing threshold is a user-tunable ceiling
+	// independent of the fixed padding caps above: below it a file stays
+	// healthy/degraded, at or above it the file is failed so the repair path
+	// (worker.go) kicks in instead of leaving it degraded forever.
+	if verdict != holes.VerdictFailed {
+		acceptable := hc.configGetter().GetAcceptableMissingSegmentsPercentage()
+		if holes.ExceedsAcceptableMissing(acc.Total(), totalSegments, acceptable) {
+			verdict = holes.VerdictFailed
+		}
+	}
+
 	// Persist newly observed holes so playback replay pre-pads them. Only on
 	// degraded verdicts: failed files head to repair/re-download anyway.
 	if verdict == holes.VerdictDegraded && acc.Total() > priorTotal {

--- a/internal/health/holes_test.go
+++ b/internal/health/holes_test.go
@@ -108,7 +108,11 @@ func TestHealthCheckCleanFileIsHealthy(t *testing.T) {
 
 func TestHealthCheckClassifiesSmallHoleAsDegraded(t *testing.T) {
 	env := newHoleTestEnv(t, "movie.mp4", 4*1024*1024, 1024)
-	// Two isolated missing segments — well within the pad caps.
+	// Raise the acceptable-missing threshold so these two isolated misses
+	// (well within the pad caps) stay degraded instead of failing outright —
+	// see TestHealthCheckAcceptableMissingThresholdTriggersRepair for the
+	// zero-tolerance default.
+	env.cfg.Health.AcceptableMissingSegmentsPercentage = 1
 	env.markSegmentMissing(10)
 	env.markSegmentMissing(30)
 
@@ -131,6 +135,30 @@ func TestHealthCheckClassifiesSmallHoleAsDegraded(t *testing.T) {
 	meta, err := env.ms.ReadFileMetadata(env.filePath)
 	require.NoError(t, err)
 	assert.NotEmpty(t, meta.KnownHoles, "degraded holes should be persisted")
+}
+
+// TestHealthCheckAcceptableMissingThresholdTriggersRepair covers issue #813:
+// with the threshold set to 0 (zero tolerance), even a single confirmed
+// missing segment must fail the file (not merely degrade it) so the repair
+// path (worker.go) picks it up instead of leaving it degraded forever.
+func TestHealthCheckAcceptableMissingThresholdTriggersRepair(t *testing.T) {
+	env := newHoleTestEnv(t, "movie.mp4", 4*1024*1024, 1024)
+	env.cfg.Health.AcceptableMissingSegmentsPercentage = 0
+	// A single isolated missing segment — within the pad caps, so only the
+	// acceptable-missing threshold (not the run/total caps) forces the fail.
+	env.markSegmentMissing(10)
+
+	event := env.checker.CheckFile(context.Background(), env.filePath)
+	require.Equal(t, EventTypeFileCorrupted, event.Type)
+	require.NotNil(t, event.Classification)
+	assert.Equal(t, holes.VerdictFailed, event.Classification.Verdict)
+
+	// Raising the threshold above the actual missing fraction keeps it degraded.
+	env.markSegmentMissing(20)
+	env.cfg.Health.AcceptableMissingSegmentsPercentage = 100
+	event = env.checker.CheckFile(context.Background(), env.filePath)
+	require.NotNil(t, event.Classification)
+	assert.Equal(t, holes.VerdictDegraded, event.Classification.Verdict)
 }
 
 func TestHealthCheckClassifiesLongRunAsFailed(t *testing.T) {
@@ -174,6 +202,9 @@ func TestHealthCheckSkipsClassificationForEncrypted(t *testing.T) {
 
 func TestHealthCheckMergesPersistedHoles(t *testing.T) {
 	env := newHoleTestEnv(t, "movie.mp4", 4*1024*1024, 1024)
+	// Raise the acceptable-missing threshold: this test is about merging
+	// persisted holes with newly observed ones, not the threshold itself.
+	env.cfg.Health.AcceptableMissingSegmentsPercentage = 1
 	// Seed a persisted hole (as if playback padded it earlier).
 	require.NoError(t, env.ms.AddKnownHoles(env.filePath, []holes.Run{{Start: 5, Count: 1}}))
 	// A fresh check finds a different missing segment.

--- a/internal/holes/holes.go
+++ b/internal/holes/holes.go
@@ -8,8 +8,8 @@
 //   - at PLAYBACK, the hole hooks decide per miss whether to zero-fill and
 //     keep streaming or to kill the stream and fail the file.
 //
-// Ported from AIOStreams' holes.ts. This package is imported by usenet,
-// importer, health and nzbfilesystem layers; it must stay dependency-free.
+// This package is imported by usenet, importer, health and nzbfilesystem
+// layers; it must stay dependency-free.
 package holes
 
 import (
@@ -167,6 +167,24 @@ func ClassifyProjected(hits, sampled, totalSegments, longestObservedRun int) Ver
 		}
 	}
 	return VerdictDegraded
+}
+
+// ExceedsAcceptableMissing reports whether a confirmed-missing fraction
+// exceeds a configured acceptable-missing percentage (0-100, see
+// HealthConfig.AcceptableMissingSegmentsPercentage). A percentage of 0 means
+// zero tolerance: any missing segment exceeds it. Used both at import time
+// (projected sample fraction) and at health check (measured fraction of the
+// whole file) so exceeding the same user-configured ceiling always escalates
+// past VerdictDegraded to VerdictFailed, triggering repair instead of
+// leaving the file degraded indefinitely.
+func ExceedsAcceptableMissing(missing, total int, acceptablePercent float64) bool {
+	if total <= 0 || missing <= 0 {
+		return false
+	}
+	if acceptablePercent >= 100 {
+		return false
+	}
+	return float64(missing)/float64(total)*100 > acceptablePercent
 }
 
 // Accumulator incrementally merges missing segments into maximal

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -279,7 +279,7 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 	brokenIdx := make(map[int]struct{})
 	missingIDs := make(map[string]struct{})
 	eligibleRegularCount := 0
-	tolerant := cfg.GetImportDamagePolicyTolerant()
+	acceptableMissingPercent := cfg.GetAcceptableMissingSegmentsPercentage()
 
 	for i, result := range results {
 		f := n.Files[i]
@@ -290,22 +290,25 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 		}
 
 		if result.Broken && !isPar2 {
-			// Tolerant damage policy: a standalone video file with SMALL
-			// confirmed damage imports as degraded rather than being dropped.
-			// Streaming zero-fills the gaps and the immediate post-import
-			// health check discovers + persists the holes and flags it
-			// degraded. Archive-set members (GroupKey != "") stay binary — a
-			// holed volume corrupts extraction and cannot be padded.
-			if tolerant && fastFailFiles[i].GroupKey == "" && holes.EligibleFile(f.Filename) {
+			// A standalone video file with SMALL confirmed damage, within the
+			// configured acceptable-missing threshold, imports as degraded
+			// rather than being dropped. Streaming zero-fills the gaps and
+			// the immediate post-import health check discovers + persists
+			// the holes and flags it degraded (or fails it, if the
+			// threshold changed since). Archive-set members (GroupKey != "")
+			// stay binary — a holed volume corrupts extraction and cannot be
+			// padded.
+			if acceptableMissingPercent > 0 && fastFailFiles[i].GroupKey == "" && holes.EligibleFile(f.Filename) {
 				verdict := holes.ClassifyProjected(
 					len(result.MissingSegmentIDs),
 					result.SampledCount,
 					len(f.Segments),
 					longestSampledRun(fastFailFiles[i].Segments, result.MissingSegmentIDs),
 				)
-				if verdict == holes.VerdictDegraded {
+				if verdict == holes.VerdictDegraded &&
+					!holes.ExceedsAcceptableMissing(len(result.MissingSegmentIDs), result.SampledCount, acceptableMissingPercent) {
 					if proc.log != nil {
-						proc.log.InfoContext(ctx, "Importing video file as degraded despite missing segments (tolerant damage policy)",
+						proc.log.InfoContext(ctx, "Importing video file as degraded despite missing segments (within acceptable-missing threshold)",
 							"file", f.Filename,
 							"missing_sampled", len(result.MissingSegmentIDs),
 							"sampled", result.SampledCount)

--- a/internal/importer/processor_test.go
+++ b/internal/importer/processor_test.go
@@ -606,31 +606,33 @@ func buildMultiSegmentNzb(client *fakepool.Client, fileName string, segCount int
 	}}}
 }
 
-// TestPreParseFastFailTolerantImportsDegradedVideo verifies a standalone video
-// file with a small hole imports (not broken) under the default tolerant policy.
-func TestPreParseFastFailTolerantImportsDegradedVideo(t *testing.T) {
+// TestPreParseFastFailAcceptableThresholdImportsDegradedVideo verifies a
+// standalone video file with a small hole imports (not broken) once the
+// acceptable-missing threshold is raised above the actual damage.
+func TestPreParseFastFailAcceptableThresholdImportsDegradedVideo(t *testing.T) {
 	client := fakepool.New()
 	proc := &Processor{
 		poolManager:       processorTestPoolManager{client: client},
 		validationTimeout: 100 * time.Millisecond,
 	}
-	// 200 segments, 1 missing (0.5%) — well within the pad caps.
+	// 50 segments, 1 missing (2%) — well within the pad caps.
 	n := buildMultiSegmentNzb(client, "Movie.2024.mkv", 50, 25)
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
+	cfg.Health.AcceptableMissingSegmentsPercentage = 5
 
 	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
 	if len(brokenIdx) != 0 {
-		t.Fatalf("brokenIdx = %v, want empty (tolerant policy imports degraded video)", brokenIdx)
+		t.Fatalf("brokenIdx = %v, want empty (within acceptable-missing threshold)", brokenIdx)
 	}
 }
 
-// TestPreParseFastFailStrictFailsDegradedVideo verifies the same file is broken
-// under the strict policy.
-func TestPreParseFastFailStrictFailsDegradedVideo(t *testing.T) {
+// TestPreParseFastFailZeroToleranceFailsDegradedVideo verifies the same file
+// is broken when the acceptable-missing threshold is set to 0 (issue #813).
+func TestPreParseFastFailZeroToleranceFailsDegradedVideo(t *testing.T) {
 	client := fakepool.New()
 	proc := &Processor{
 		poolManager:       processorTestPoolManager{client: client},
@@ -639,19 +641,20 @@ func TestPreParseFastFailStrictFailsDegradedVideo(t *testing.T) {
 	n := buildMultiSegmentNzb(client, "Movie.2024.mkv", 50, 25)
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
-	cfg.Import.DamagePolicy = "strict"
+	cfg.Health.AcceptableMissingSegmentsPercentage = 0
 
 	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
 		// Single file, and it's broken → all eligible broken → ErrNoFilesProcessed.
-		t.Fatalf("strict policy: err = %v, want ErrNoFilesProcessed", err)
+		t.Fatalf("zero tolerance: err = %v, want ErrNoFilesProcessed", err)
 	}
 	_ = brokenIdx
 }
 
-// TestPreParseFastFailTolerantStillFailsLongRun verifies tolerant policy does
-// NOT rescue a file whose missing run exceeds the pad cap.
-func TestPreParseFastFailTolerantStillFailsLongRun(t *testing.T) {
+// TestPreParseFastFailAcceptableThresholdStillFailsLongRun verifies a raised
+// acceptable-missing threshold does NOT rescue a file whose missing run
+// exceeds the pad cap.
+func TestPreParseFastFailAcceptableThresholdStillFailsLongRun(t *testing.T) {
 	client := fakepool.New()
 	proc := &Processor{
 		poolManager:       processorTestPoolManager{client: client},
@@ -661,10 +664,11 @@ func TestPreParseFastFailTolerantStillFailsLongRun(t *testing.T) {
 	n := buildMultiSegmentNzb(client, "Movie.2024.mkv", 50, 20, 21, 22, 23, 24)
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
+	cfg.Health.AcceptableMissingSegmentsPercentage = 100
 
 	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
 	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
-		t.Fatalf("tolerant policy with long run: err = %v, want ErrNoFilesProcessed", err)
+		t.Fatalf("raised threshold with long run: err = %v, want ErrNoFilesProcessed", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes #813: `Health.AcceptableMissingSegmentsPercentage` was never read anywhere, so it had no effect on health-check verdicts — files with small confirmed damage always stayed "degraded" and never escalated to a repair-triggering "failed" state, regardless of the configured threshold.
- Wires the threshold into `internal/health/holes.go`'s `classifyHoles` (via a new shared `holes.ExceedsAcceptableMissing` helper): exceeding the missing-segment percentage now forces `VerdictFailed`, which falls through the existing `worker.go` logic into the real repair/ARR-notify path.
- Applies the same threshold at import time in `internal/importer/processor.go`'s fast-fail sweep, replacing the separate `Import.DamagePolicy` (`tolerant`/`strict`) setting added in #856 — one knob now governs both import-time and health-check-time tolerance instead of two overlapping ones.
- Raises the default from 0% to 2% to preserve the previous tolerant-by-default playback behavior (small holes still degrade gracefully out of the box); set to `0` for zero tolerance (repair on any missing segment) or `100` to disable this check entirely.
- Adds `docs/docs/3. Configuration/health-monitoring.md` guidance on how to use and disable the threshold.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `bun run check` (biome) and `bun run build` (tsc + vite) in `frontend/`