### PR TITLE
fix(health): never treat transient STAT failures as missing segments

### DIFF
--- a/internal/config/accessors.go
+++ b/internal/config/accessors.go
@@ -22,10 +22,13 @@ func (c *Config) GetMaxConcurrentJobs() int {
 	return c.Health.MaxConcurrentJobs
 }
 
-// GetMaxConnectionsForHealthChecks returns max connections for health checks with a default fallback.
+// GetMaxConnectionsForHealthChecks returns how many STATs a health sweep keeps
+// in flight. Despite the name this is a STAT concurrency, not a connection
+// count. When unset it follows the providers' configured stat_inflight_requests
+// (see StatConcurrency) so all STAT paths scale off the same knob.
 func (c *Config) GetMaxConnectionsForHealthChecks() int {
 	if c.Health.MaxConnectionsForHealthChecks <= 0 {
-		return 100 // Default: 100 concurrent STAT checks
+		return c.StatConcurrency()
 	}
 	return c.Health.MaxConnectionsForHealthChecks
 }
@@ -164,6 +167,51 @@ func (c *Config) TotalProviderConnections() int {
 		return primary
 	}
 	return backup
+}
+
+// defaultStatInflightRequests mirrors the per-provider default applied in
+// (*Manager) config normalization, so StatConcurrency reports the depth the
+// pool will actually use for providers that leave the field unset.
+const defaultStatInflightRequests = 100
+
+// maxStatConcurrency caps StatConcurrency. The chunked STAT sweeps use this
+// number as their chunk size, and a chunk boundary is the only place a file
+// can be dropped from the remaining work — so an unbounded value would erase
+// early-termination granularity and make one chunk deadline cover the entire
+// sweep.
+const maxStatConcurrency = 500
+
+// StatConcurrency returns how many STATs to keep in flight during an
+// availability sweep. STAT carries no body, so nntppool pipelines it down a
+// connection to Provider.StatInflight depth rather than spending one
+// connection per check (see NNTPConnection.inflightSem) — connection count is
+// the wrong ceiling.
+//
+// The value is the deepest stat_inflight_requests among enabled providers, not
+// the sum of connections × depth. A single provider's pipeline depth is the
+// conservative read: it is what one connection alone can sustain, so the sweep
+// stays within reach even when the pool is busy serving streams.
+func (c *Config) StatConcurrency() int {
+	depth := 0
+	for _, p := range c.Providers {
+		if p.Enabled != nil && !*p.Enabled {
+			continue
+		}
+		d := p.StatInflightRequests
+		if d <= 0 {
+			d = defaultStatInflightRequests
+		}
+		if d > depth {
+			depth = d
+		}
+	}
+	if depth <= 0 {
+		depth = defaultStatInflightRequests
+	}
+	if depth > maxStatConcurrency {
+		depth = maxStatConcurrency
+	}
+	return depth
 }
 
 // GetMaxConcurrentImports returns the global cap on concurrent NZB imports.

--- a/internal/config/accessors_test.go
+++ b/internal/config/accessors_test.go
@@ -161,3 +161,86 @@ func TestValidate_HealthVerifyContentTimeoutSeconds(t *testing.T) {
 		})
 	}
 }
+
+func TestStatConcurrency(t *testing.T) {
+	enabled := true
+	disabled := false
+
+	tests := []struct {
+		name string
+		cfg  *Config
+		want int
+	}{
+		{
+			name: "no providers falls back to the stat_inflight_requests default",
+			cfg:  &Config{},
+			want: 100,
+		},
+		{
+			name: "unset depth falls back to the same default applied at normalization",
+			cfg:  &Config{Providers: []ProviderConfig{{MaxConnections: 10, Enabled: &enabled}}},
+			want: 100,
+		},
+		{
+			name: "connection count does not bound STAT concurrency",
+			cfg: &Config{Providers: []ProviderConfig{
+				{MaxConnections: 2, StatInflightRequests: 100, Enabled: &enabled},
+			}},
+			want: 100,
+		},
+		{
+			name: "follows the configured depth below the default",
+			cfg: &Config{Providers: []ProviderConfig{
+				{MaxConnections: 50, StatInflightRequests: 20, Enabled: &enabled},
+			}},
+			want: 20,
+		},
+		{
+			name: "takes the deepest enabled provider",
+			cfg: &Config{Providers: []ProviderConfig{
+				{MaxConnections: 10, StatInflightRequests: 20, Enabled: &enabled},
+				{MaxConnections: 10, StatInflightRequests: 200, Enabled: &enabled},
+			}},
+			want: 200,
+		},
+		{
+			name: "ignores disabled providers",
+			cfg: &Config{Providers: []ProviderConfig{
+				{MaxConnections: 10, StatInflightRequests: 20, Enabled: &enabled},
+				{MaxConnections: 10, StatInflightRequests: 400, Enabled: &disabled},
+			}},
+			want: 20,
+		},
+		{
+			name: "caps so a chunked sweep keeps its early-termination boundaries",
+			cfg: &Config{Providers: []ProviderConfig{
+				{MaxConnections: 10, StatInflightRequests: 5000, Enabled: &enabled},
+			}},
+			want: maxStatConcurrency,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.StatConcurrency(); got != tt.want {
+				t.Fatalf("StatConcurrency() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetMaxConnectionsForHealthChecks_FollowsStatConcurrencyWhenUnset(t *testing.T) {
+	enabled := true
+	cfg := &Config{Providers: []ProviderConfig{
+		{MaxConnections: 10, StatInflightRequests: 250, Enabled: &enabled},
+	}}
+
+	if got := cfg.GetMaxConnectionsForHealthChecks(); got != 250 {
+		t.Fatalf("GetMaxConnectionsForHealthChecks() = %d, want 250 (derived from stat_inflight_requests)", got)
+	}
+
+	cfg.Health.MaxConnectionsForHealthChecks = 30
+	if got := cfg.GetMaxConnectionsForHealthChecks(); got != 30 {
+		t.Fatalf("GetMaxConnectionsForHealthChecks() = %d, want 30 (explicit setting wins)", got)
+	}
+}

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -1389,6 +1389,21 @@ func (r *HealthRepository) UpdateHealthStatusBulk(ctx context.Context, updates [
 	}
 	defer stmtDegraded.Close()
 
+	// stmtInconclusive re-arms a check that produced no evidence: the record
+	// keeps its previous status and both retry counters, and is simply due
+	// again later. Counting an outage as a failed check burned the retry
+	// budget and eventually escalated healthy files into repair (#861).
+	stmtInconclusive, err := tx.PrepareContext(ctx, `
+		UPDATE file_health
+		SET status = ?, last_error = ?, error_details = ?, scheduled_check_at = ?,
+		    updated_at = datetime('now'), last_checked = datetime('now')
+		WHERE file_path = ? AND (status = ? OR ? = '')
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare inconclusive statement: %w", err)
+	}
+	defer stmtInconclusive.Close()
+
 	for _, update := range updates {
 		if update.Skip {
 			continue
@@ -1413,6 +1428,8 @@ func (r *HealthRepository) UpdateHealthStatusBulk(ctx context.Context, updates [
 			_, err = stmtCorrupted.ExecContext(ctx, update.ErrorMessage, update.ErrorDetails, filePath, expected, expected)
 		case UpdateTypeDegraded:
 			_, err = stmtDegraded.ExecContext(ctx, update.ErrorMessage, update.ErrorDetails, update.ScheduledCheckAt, filePath, expected, expected)
+		case UpdateTypeInconclusive:
+			_, err = stmtInconclusive.ExecContext(ctx, string(update.Status), update.ErrorMessage, update.ErrorDetails, update.ScheduledCheckAt, filePath, expected, expected)
 		}
 
 		if err != nil {
@@ -1433,6 +1450,12 @@ const (
 	UpdateTypeCorrupted     UpdateType = 4
 	UpdateTypeRepairTrigger UpdateType = 5 // first-time trigger; does not increment repair_retry_count
 	UpdateTypeDegraded      UpdateType = 6 // playable with glitches; no repair, periodic re-check
+	// UpdateTypeInconclusive records a check that reached no verdict (provider
+	// outage, timeouts, truncated sweep). It only moves scheduled_check_at and
+	// the error text: neither retry counter advances, and Status carries the
+	// status the record must be restored to (it was set to 'checking' for the
+	// duration of the cycle).
+	UpdateTypeInconclusive UpdateType = 7
 )
 
 // HealthStatusUpdate represents a single update request for batch processing

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -26,6 +26,11 @@ const (
 	EventTypeFileCorrupted EventType = "file_corrupted"
 	EventTypeCheckFailed   EventType = "check_failed"
 	EventTypeFileRemoved   EventType = "file_removed"
+	// EventTypeCheckInconclusive means the check reached the network but the
+	// providers could not answer for at least one segment (outage, timeout,
+	// quota, auth, truncated sweep). It carries no verdict: the file keeps the
+	// status it had and is simply re-checked later.
+	EventTypeCheckInconclusive EventType = "check_inconclusive"
 )
 
 // HealthEvent represents a health check event
@@ -239,10 +244,27 @@ func (hc *HealthChecker) prepareCheck(ctx context.Context, filePath string, opts
 func (hc *HealthChecker) judgeValidation(ctx context.Context, prep preparedCheck, result usenet.ValidationResult, valErr error) HealthEvent {
 	event := baseResultEvent(prep.filePath, prep.sourceNzbPath)
 
-	if valErr != nil {
-		event.Type = EventTypeCheckFailed
-		event.Status = database.HealthStatusCorrupted
-		event.Error = fmt.Errorf("failed to validate segments: %w", valErr)
+	// An inconclusive sweep proves nothing. Reading a transient provider
+	// failure as a missing article marked files degraded and wrote their
+	// segment ids into the permanent hole map, which no later clean check
+	// clears (#861) — so this check must come before the missing-count
+	// verdict, even when the sweep also found genuine misses.
+	if valErr != nil || result.Inconclusive() {
+		event.Type = EventTypeCheckInconclusive
+		event.Status = database.HealthStatusPending
+		if valErr != nil {
+			event.Error = fmt.Errorf("segment check inconclusive: %w", valErr)
+		} else {
+			event.Error = fmt.Errorf("segment check inconclusive: %d of %d checked segments could not be verified: %w",
+				result.ErrorCount, result.TotalChecked, result.Err)
+		}
+		details := database.HealthErrorDetails{
+			ErrorType:     "check_inconclusive",
+			Message:       event.Error.Error(),
+			TotalArticles: prep.totalSegments,
+			Sampled:       result.TotalChecked,
+		}
+		event.Details = details.Marshal()
 		return event
 	}
 

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -282,8 +282,11 @@ func (hc *HealthChecker) judgeValidation(ctx context.Context, prep preparedCheck
 		if valErr != nil {
 			event.Error = fmt.Errorf("segment check inconclusive: %w", valErr)
 		} else {
-			event.Error = fmt.Errorf("segment check inconclusive: %d of %d checked segments could not be verified: %w",
-				result.UnresolvedCount, result.TotalChecked, result.Err)
+			// TotalChecked counts only resolved segments, so the sampled total
+			// is the two buckets summed — otherwise a sweep where nothing
+			// resolved reports "1 of 0".
+			event.Error = fmt.Errorf("segment check inconclusive: %d of %d sampled segments could not be verified: %w",
+				result.UnresolvedCount, result.TotalChecked+result.UnresolvedCount, result.Err)
 		}
 		details := database.HealthErrorDetails{
 			ErrorType:          "check_inconclusive",

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -268,10 +268,14 @@ func (hc *HealthChecker) judgeValidation(ctx context.Context, prep preparedCheck
 	event := baseResultEvent(prep.filePath, prep.sourceNzbPath)
 
 	// An inconclusive sweep proves nothing. Reading a transient provider
-	// failure as a missing article marked files degraded and wrote their
-	// segment ids into the permanent hole map, which no later clean check
-	// clears (#861) — so this check must come before the missing-count
-	// verdict, even when the sweep also found genuine misses.
+	// failure — whether the whole pool was unreachable or just a handful of
+	// segments hit a connection blip mid-sweep — as a missing article marked
+	// files degraded and wrote their segment ids into the permanent hole map,
+	// which no later clean check clears; treating it as a failed attempt
+	// instead still burned the retry budget and could escalate a perfectly
+	// good file into repair (#861). So this check must come before the
+	// missing-count verdict, even when the sweep also found genuine misses,
+	// and it must not consume a retry.
 	if valErr != nil || result.Inconclusive() {
 		event.Type = EventTypeCheckInconclusive
 		event.Status = database.HealthStatusPending
@@ -279,32 +283,11 @@ func (hc *HealthChecker) judgeValidation(ctx context.Context, prep preparedCheck
 			event.Error = fmt.Errorf("segment check inconclusive: %w", valErr)
 		} else {
 			event.Error = fmt.Errorf("segment check inconclusive: %d of %d checked segments could not be verified: %w",
-				result.ErrorCount, result.TotalChecked, result.Err)
+				result.UnresolvedCount, result.TotalChecked, result.Err)
 		}
 		details := database.HealthErrorDetails{
-			ErrorType:     "check_inconclusive",
-			Message:       event.Error.Error(),
-			TotalArticles: prep.totalSegments,
-			Sampled:       result.TotalChecked,
-		}
-		event.Details = details.Marshal()
-		return event
-	}
-
-	// Segments whose availability was never established make the sweep
-	// inconclusive: the file can be neither cleared nor condemned on evidence
-	// that was not gathered. A settled verdict wins over that noise — once the
-	// missing-segment threshold is irreversibly exceeded, no amount of further
-	// checking could change the outcome.
-	if result.UnresolvedCount > 0 && !result.TerminatedEarly {
-		event.Type = EventTypeCheckFailed
-		event.Status = database.HealthStatusCorrupted
-		event.Error = fmt.Errorf("%d of %d segments could not be checked (provider or connection failure)",
-			result.UnresolvedCount, result.UnresolvedCount+result.TotalChecked)
-		details := database.HealthErrorDetails{
-			ErrorType:          "segments_unresolved",
+			ErrorType:          "check_inconclusive",
 			Message:            event.Error.Error(),
-			MissingArticles:    result.MissingCount,
 			TotalArticles:      prep.totalSegments,
 			Sampled:            result.TotalChecked,
 			UnresolvedSegments: result.UnresolvedCount,

--- a/internal/health/checker_batch_test.go
+++ b/internal/health/checker_batch_test.go
@@ -147,6 +147,7 @@ func TestCheckFilesBatch(t *testing.T) {
 			&mockPoolManager{},
 			env.hw.configGetter,
 			&MockRcloneClient{},
+			nil,
 		)
 
 		paths := []string{"complete/a.mkv", "complete/b.mkv"}
@@ -177,7 +178,7 @@ func TestCheckFilesBatch(t *testing.T) {
 		client.SetBehavior(flakyID, fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
 		client.SetBehavior(goneID, fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
 
-		events := env.healthChecker.CheckFilesBatch(context.Background(), paths)
+		events := env.healthChecker.CheckFilesBatch(context.Background(), paths, nil)
 		require.Len(t, events, 3)
 
 		assert.Equal(t, EventTypeFileHealthy, events[0].Type)
@@ -200,7 +201,7 @@ func TestCheckFilesBatch(t *testing.T) {
 		segID := writeHealthyFile(t, env, path)
 		client.SetBehavior(segID, fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
 
-		events := env.healthChecker.CheckFilesBatch(context.Background(), []string{path})
+		events := env.healthChecker.CheckFilesBatch(context.Background(), []string{path}, nil)
 		require.Len(t, events, 1)
 		require.Equal(t, EventTypeCheckInconclusive, events[0].Type)
 

--- a/internal/health/checker_batch_test.go
+++ b/internal/health/checker_batch_test.go
@@ -133,8 +133,19 @@ func TestCheckFilesBatch(t *testing.T) {
 		assert.Nil(t, fh)
 	})
 
-	t.Run("pool down fails all non-early files", func(t *testing.T) {
-		env := newRepairTestEnv(t, t.TempDir(), nil) // mockPoolManager: GetPool errors
+	// A pool that cannot be reached is an outage, not corruption: the sweep
+	// produced no evidence about these files, so they must come back later
+	// rather than burn retries toward a repair (#861).
+	t.Run("pool down leaves all non-early files inconclusive", func(t *testing.T) {
+		env := newRepairTestEnv(t, t.TempDir(), nil)
+		// mockPoolManager: GetPool errors — the sweep never reaches a provider.
+		env.healthChecker = NewHealthChecker(
+			env.healthRepo,
+			env.metadataService,
+			&mockPoolManager{},
+			env.hw.configGetter,
+			&MockRcloneClient{},
+		)
 
 		paths := []string{"complete/a.mkv", "complete/b.mkv"}
 		for _, p := range paths {
@@ -144,10 +155,57 @@ func TestCheckFilesBatch(t *testing.T) {
 		events := env.healthChecker.CheckFilesBatch(context.Background(), paths)
 		require.Len(t, events, 2)
 		for i, ev := range events {
-			assert.Equal(t, EventTypeCheckFailed, ev.Type, "file %d", i)
+			assert.Equal(t, EventTypeCheckInconclusive, ev.Type, "file %d", i)
 			require.Error(t, ev.Error, "file %d", i)
-			assert.Contains(t, ev.Error.Error(), "failed to validate segments", "file %d", i)
+			assert.Contains(t, ev.Error.Error(), "inconclusive", "file %d", i)
+			assert.Nil(t, ev.Classification, "file %d", i)
 		}
+	})
+
+	// Regression for #861: a transient provider failure on one file must not
+	// be read as a missing article, and must not taint its batch siblings.
+	t.Run("transient provider error is inconclusive, not corrupted", func(t *testing.T) {
+		client := fakepool.New()
+		env := newBatchTestEnv(t, t.TempDir(), client)
+
+		paths := []string{"complete/good.mkv", "complete/flaky.mkv", "complete/gone.mkv"}
+		writeHealthyFile(t, env, paths[0])
+		flakyID := writeHealthyFile(t, env, paths[1])
+		goneID := writeHealthyFile(t, env, paths[2])
+		client.SetBehavior(flakyID, fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
+		client.SetBehavior(goneID, fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+		events := env.healthChecker.CheckFilesBatch(context.Background(), paths)
+		require.Len(t, events, 3)
+
+		assert.Equal(t, EventTypeFileHealthy, events[0].Type)
+
+		assert.Equal(t, EventTypeCheckInconclusive, events[1].Type)
+		require.Error(t, events[1].Error)
+		assert.Contains(t, events[1].Error.Error(), "inconclusive")
+		assert.Nil(t, events[1].Classification, "an inconclusive check must not classify holes")
+
+		assert.Equal(t, EventTypeFileCorrupted, events[2].Type)
+	})
+
+	// The hole map is permanent — a clean check never clears it — so an
+	// inconclusive sweep must never write into it (#861).
+	t.Run("inconclusive check persists no known holes", func(t *testing.T) {
+		client := fakepool.New()
+		env := newBatchTestEnv(t, t.TempDir(), client)
+
+		path := "complete/flaky.mkv"
+		segID := writeHealthyFile(t, env, path)
+		client.SetBehavior(segID, fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
+
+		events := env.healthChecker.CheckFilesBatch(context.Background(), []string{path})
+		require.Len(t, events, 1)
+		require.Equal(t, EventTypeCheckInconclusive, events[0].Type)
+
+		meta, err := env.metadataService.ReadFileMetadata(path)
+		require.NoError(t, err)
+		require.NotNil(t, meta)
+		assert.Empty(t, meta.KnownHoles, "no holes may be persisted from an inconclusive sweep")
 	})
 
 	t.Run("empty input", func(t *testing.T) {

--- a/internal/health/checker_fastfail_test.go
+++ b/internal/health/checker_fastfail_test.go
@@ -51,8 +51,8 @@ func parseDetails(t *testing.T, ev HealthEvent) database.HealthErrorDetails {
 
 // TestCheckFilesBatch_TransportErrorIsNotCorruption is the correctness fix the
 // issue calls for: a connection failure must neither condemn a file nor let it
-// pass as healthy. It is a failed attempt, which the existing retry ladder
-// re-runs later.
+// pass as healthy, and must not consume a retry either — it proves nothing,
+// so the existing retry ladder must not advance on its account (#861).
 func TestCheckFilesBatch_TransportErrorIsNotCorruption(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlinks not supported on Windows")
@@ -66,11 +66,11 @@ func TestCheckFilesBatch_TransportErrorIsNotCorruption(t *testing.T) {
 	writeHealthyFile(t, env, paths[1])
 	client.SetBehavior(flakyID, fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
 
-	events := env.healthChecker.CheckFilesBatch(context.Background(), paths)
+	events := env.healthChecker.CheckFilesBatch(context.Background(), paths, nil)
 	require.Len(t, events, 2)
 
-	assert.Equal(t, EventTypeCheckFailed, events[0].Type,
-		"a transport error is an inconclusive attempt, not corruption")
+	assert.Equal(t, EventTypeCheckInconclusive, events[0].Type,
+		"a transport error proves nothing, so it must not be read as corruption or burn a retry")
 	assert.NotEqual(t, EventTypeFileHealthy, events[0].Type,
 		"a segment we never resolved must not pass as available")
 	assert.Equal(t, EventTypeFileHealthy, events[1].Type, "sibling unaffected")
@@ -96,9 +96,9 @@ func TestCheckFilesBatch_TransportErrorPersistsNoHoles(t *testing.T) {
 	ids := writeMultiSegmentFile(t, env, path, 20)
 	client.SetBehavior(ids[3], fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
 
-	events := env.healthChecker.CheckFilesBatch(context.Background(), []string{path})
+	events := env.healthChecker.CheckFilesBatch(context.Background(), []string{path}, nil)
 	require.Len(t, events, 1)
-	assert.Equal(t, EventTypeCheckFailed, events[0].Type)
+	assert.Equal(t, EventTypeCheckInconclusive, events[0].Type)
 
 	meta, err := env.metadataService.ReadFileMetadata(path)
 	require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestCheckFilesBatch_FastFailStopsDoomedFileOnly(t *testing.T) {
 	writeMultiSegmentFile(t, env, paths[1], segCount)
 	client.SetBehavior(doomedIDs[0], fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
 
-	events := env.healthChecker.CheckFilesBatch(context.Background(), paths)
+	events := env.healthChecker.CheckFilesBatch(context.Background(), paths, nil)
 	require.Len(t, events, 2)
 
 	assert.Equal(t, EventTypeFileCorrupted, events[0].Type)
@@ -163,7 +163,7 @@ func TestCheckFilesBatch_NoFastFailWhenToleranceUnreached(t *testing.T) {
 	ids := writeMultiSegmentFile(t, env, path, segCount)
 	client.SetBehavior(ids[0], fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
 
-	events := env.healthChecker.CheckFilesBatch(context.Background(), []string{path})
+	events := env.healthChecker.CheckFilesBatch(context.Background(), []string{path}, nil)
 	require.Len(t, events, 1)
 
 	d := parseDetails(t, events[0])

--- a/internal/health/manual_recheck_verify_content_test.go
+++ b/internal/health/manual_recheck_verify_content_test.go
@@ -44,6 +44,9 @@ func TestPerformBackgroundCheck_ThreadsVerifyContentOverride(t *testing.T) {
 	env.hw.mu.Unlock()
 
 	force := true
+	// Mirror handleDirectHealthCheck: the API transitions the row to Checking
+	// before dispatching the background worker while passing the prior status.
+	require.NoError(t, env.hw.healthRepo.SetFileChecking(context.Background(), path))
 	require.NoError(t, env.hw.PerformBackgroundCheck(context.Background(), path, database.HealthStatusDegraded, &force))
 
 	// A definitive content failure routes through the same retry-before-repair

--- a/internal/health/repair_e2e_test.go
+++ b/internal/health/repair_e2e_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/javi11/altmount/internal/metadata"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/pool"
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
 	nntppool "github.com/javi11/nntppool/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -91,6 +92,7 @@ func (m *mockImportService) RegenerateMetadata(_ context.Context, _ string) erro
 // repairTestEnv holds all the pieces needed for repair e2e tests.
 type repairTestEnv struct {
 	db              *sql.DB
+	client          *fakepool.Client
 	healthRepo      *database.HealthRepository
 	metadataService *metadata.MetadataService
 	healthChecker   *HealthChecker
@@ -162,10 +164,16 @@ func newRepairTestEnv(t *testing.T, tempDir string, arrsErr error, configure ...
 	mockARRs := &mockARRsService{returnErr: arrsErr}
 	mockImporter := &mockImportService{}
 
+	// Default pool: every STAT answers 430 (article genuinely gone), which is
+	// what the repair e2e flows are about. Transient/pool-down failures are
+	// deliberately NOT the default — they are inconclusive, not corruption.
+	client := fakepool.New()
+	client.SetDefaultBehavior(fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
 	healthChecker := NewHealthChecker(
 		healthRepo,
 		metadataService,
-		&mockPoolManager{},
+		&fakeClientPoolManager{client: client},
 		configManager.GetConfig,
 		&MockRcloneClient{},
 	)
@@ -182,6 +190,7 @@ func newRepairTestEnv(t *testing.T, tempDir string, arrsErr error, configure ...
 
 	return &repairTestEnv{
 		db:              db,
+		client:          client,
 		healthRepo:      healthRepo,
 		metadataService: metadataService,
 		healthChecker:   healthChecker,
@@ -191,7 +200,8 @@ func newRepairTestEnv(t *testing.T, tempDir string, arrsErr error, configure ...
 }
 
 // validSegmentMeta creates a FileMetadata with one segment that covers the full fileSize,
-// so CheckMetadataIntegrity passes. Pool failure then causes EventTypeCheckFailed.
+// so CheckMetadataIntegrity passes. The env's default pool then answers 430 for that
+// segment, producing EventTypeFileCorrupted.
 func validSegmentMeta(ms *metadata.MetadataService, fileSize int64) *metapb.FileMetadata {
 	seg := &metapb.SegmentData{
 		Id:          "test-article-001@test.example.com",

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -384,6 +384,14 @@ func (hw *HealthWorker) PerformBackgroundCheck(ctx context.Context, filePath str
 	return nil
 }
 
+// inconclusiveRecheckDelay is how long a file waits after a health check that
+// reached no verdict — a provider outage, timeouts, or a sweep truncated
+// before every segment answered. Such a check produces no evidence, so the
+// record is left exactly as it was and only its next check is pushed out; the
+// delay keeps a provider-wide outage from turning into a tight recheck loop
+// across the whole library.
+const inconclusiveRecheckDelay = 30 * time.Minute
+
 // prepareUpdateForResult decides what DB update and side effects are needed based on the check result.
 func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database.FileHealth, event HealthEvent) (*database.HealthStatusUpdate, func() error) {
 	update := &database.HealthStatusUpdate{
@@ -419,6 +427,38 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 			return hw.metadataService.UpdateFileStatus(fh.FilePath, metapb.FileStatus_FILE_STATUS_HEALTHY)
 		}
 
+		return update, sideEffect
+	}
+
+	// An inconclusive check says nothing about the file: the providers never
+	// answered for at least one segment. Restore the status the record held
+	// before the cycle set it to 'checking', push the next check out, and
+	// leave both retry counters alone — an outage must not consume the retry
+	// budget or escalate the file into repair (#861).
+	if event.Type == EventTypeCheckInconclusive {
+		status := fh.Status
+		if status == database.HealthStatusChecking || status == "" {
+			status = database.HealthStatusPending
+		}
+		nextCheck := time.Now().UTC().Add(inconclusiveRecheckDelay)
+
+		update.Type = database.UpdateTypeInconclusive
+		update.Status = status
+		update.ScheduledCheckAt = nextCheck
+		if event.Error != nil {
+			text := event.Error.Error()
+			update.ErrorMessage = &text
+		}
+		update.ErrorDetails = event.Details
+
+		sideEffect = func() error {
+			slog.WarnContext(ctx, "Health check inconclusive, rescheduling without counting a retry",
+				"file_path", fh.FilePath,
+				"status", status,
+				"next_check", nextCheck,
+				"error", event.Error)
+			return nil
+		}
 		return update, sideEffect
 	}
 

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -85,6 +85,10 @@ type HealthWorker struct {
 	activeChecks   map[string]*activeCheck // filePath -> in-flight check
 	activeChecksMu sync.RWMutex
 
+	// directCheckTimeout bounds a single manual recheck. Overridable so tests
+	// can exercise the timeout path without waiting out the real budget.
+	directCheckTimeout time.Duration
+
 	// Statistics
 	stats   WorkerStats
 	statsMu sync.RWMutex
@@ -114,6 +118,7 @@ func NewHealthWorker(
 		status:              WorkerStatusStopped,
 		stopChan:            make(chan struct{}),
 		activeChecks:        make(map[string]*activeCheck),
+		directCheckTimeout:  defaultDirectCheckTimeout,
 		stats: WorkerStats{
 			Status: WorkerStatusStopped,
 		},
@@ -352,6 +357,9 @@ func (hw *HealthWorker) AddToHealthCheck(ctx context.Context, filePath string, s
 	return nil
 }
 
+// defaultDirectCheckTimeout bounds a single manual recheck.
+const defaultDirectCheckTimeout = 10 * time.Minute
+
 // PerformBackgroundCheck starts a manual recheck of filePath in the
 // background. currentStatus must be the file's HealthStatus as it was BEFORE
 // the caller transitioned the row to Checking (e.g. via SetFileCheckingByID);
@@ -366,29 +374,53 @@ func (hw *HealthWorker) PerformBackgroundCheck(ctx context.Context, filePath str
 		return fmt.Errorf("health worker is not running")
 	}
 
+	timeout := hw.directCheckTimeout
+	if timeout <= 0 {
+		timeout = defaultDirectCheckTimeout
+	}
+
 	// Start health check in background
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
 		checkErr := hw.performDirectCheck(ctx, filePath, currentStatus, verifyContentOverride)
 		if checkErr != nil {
+			if errors.Is(checkErr, context.Canceled) {
+				// CancelHealthCheck already parked the record on Pending on the
+				// user's behalf; re-writing it here would undo that decision.
+				slog.InfoContext(ctx, "Background health check cancelled", "file_path", filePath)
+				return
+			}
+
 			if errors.Is(checkErr, context.DeadlineExceeded) {
-				slog.ErrorContext(ctx, "Background health check timed out after 10 minutes", "file_path", filePath)
+				slog.ErrorContext(ctx, "Background health check timed out", "file_path", filePath, "timeout", timeout)
 			} else {
 				slog.ErrorContext(ctx, "Background health check failed", "file_path", filePath, "error", checkErr)
 			}
 
+			// ctx is already expired on the timeout path, so the recovery write
+			// needs a live context of its own.
+			recoverCtx, recoverCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer recoverCancel()
+
 			// Get current health record to preserve source NZB path
-			fileHealth, getErr := hw.healthRepo.GetFileHealth(ctx, filePath)
+			fileHealth, getErr := hw.healthRepo.GetFileHealth(recoverCtx, filePath)
 			var sourceNzb *string
 			if getErr == nil && fileHealth != nil {
 				sourceNzb = fileHealth.SourceNzbPath
 			}
 
-			// Set status back to pending if the check failed
+			// A check that never reached a verdict says nothing about the file:
+			// restore the status captured before the row was set to 'checking'
+			// rather than demoting a degraded/repair_triggered record to pending.
+			restored := currentStatus
+			if restored == database.HealthStatusChecking || restored == "" {
+				restored = database.HealthStatusPending
+			}
+
 			errorMsg := checkErr.Error()
-			updateErr := hw.healthRepo.UpdateFileHealth(ctx, filePath, database.HealthStatusPending, &errorMsg, sourceNzb, nil, false)
+			updateErr := hw.healthRepo.UpdateFileHealth(recoverCtx, filePath, restored, &errorMsg, sourceNzb, nil, false)
 			if updateErr != nil {
 				slog.ErrorContext(ctx, "Failed to update status after failed check", "file_path", filePath, "error", updateErr)
 			}
@@ -836,7 +868,24 @@ func (hw *HealthWorker) performDirectCheck(ctx context.Context, filePath string,
 	default:
 	}
 
-	updatePtr, sideEffect := hw.prepareUpdateForResult(ctx, fh, event)
+	// The row is deliberately 'checking' while a manual recheck runs, but an
+	// inconclusive result says nothing about the file and must restore the state
+	// captured before that transition. Keep definitive-result handling unchanged:
+	// those paths can perform repair/delete side effects and need a broader
+	// ownership protocol before they can safely use a guarded write.
+	decisionHealth := *fh
+	if event.Type == EventTypeCheckInconclusive {
+		decisionHealth.Status = currentStatus
+	}
+	updatePtr, sideEffect := hw.prepareUpdateForResult(ctx, &decisionHealth, event)
+
+	if event.Type == EventTypeCheckInconclusive {
+		// A webhook or re-import may have changed the row while the NNTP sweep
+		// was running. Only restore the prior state if this check still owns the
+		// transient 'checking' row; otherwise the concurrent decision wins.
+		checkingStatus := database.HealthStatusChecking
+		updatePtr.ExpectedStatus = &checkingStatus
+	}
 	if sideEffect != nil {
 		if err := sideEffect(); err != nil {
 			slog.ErrorContext(ctx, "Side effect failed in direct check", "file_path", filePath, "error", err)

--- a/internal/health/worker_direct_check_failure_test.go
+++ b/internal/health/worker_direct_check_failure_test.go
@@ -1,0 +1,121 @@
+package health
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/pool"
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/nntppool/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stallingClient parks StatMany long enough for the manual recheck's own
+// deadline to expire, so the check returns an error instead of a verdict.
+type stallingClient struct {
+	pool.NntpClient
+	delay time.Duration
+}
+
+func (c *stallingClient) StatMany(ctx context.Context, ids []string, opts nntppool.StatManyOptions) <-chan nntppool.StatManyResult {
+	select {
+	case <-ctx.Done():
+	case <-time.After(c.delay):
+	}
+	return c.NntpClient.StatMany(ctx, ids, opts)
+}
+
+// TestManualRecheckTimeoutRestoresPreCheckStatus covers the recovery path that
+// runs when the check errors out rather than producing an event: a timed-out
+// manual recheck is no more evidence than an inconclusive one, so the status
+// captured before the row went to 'checking' must be restored instead of the
+// record being demoted to Pending.
+func TestManualRecheckTimeoutRestoresPreCheckStatus(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+
+	for _, originalStatus := range []database.HealthStatus{
+		database.HealthStatusDegraded,
+		database.HealthStatusRepairTriggered,
+	} {
+		t.Run(string(originalStatus), func(t *testing.T) {
+			base := fakepool.New()
+			env := newBatchTestEnv(t, t.TempDir(), &stallingClient{NntpClient: base, delay: time.Minute})
+
+			filePath := "complete/stalled-" + string(originalStatus) + ".mkv"
+			writeHealthyFile(t, env, filePath)
+
+			_, err := env.db.Exec(`
+				INSERT INTO file_health (file_path, status, retry_count, max_retries, repair_retry_count, max_repair_retries, scheduled_check_at)
+				VALUES (?, ?, 1, 3, 1, 3, datetime('now', '-1 second'))
+			`, filePath, originalStatus)
+			require.NoError(t, err)
+			require.NoError(t, env.healthRepo.SetFileChecking(context.Background(), filePath))
+
+			env.hw.mu.Lock()
+			env.hw.running = true
+			env.hw.mu.Unlock()
+			env.hw.directCheckTimeout = 50 * time.Millisecond
+
+			require.NoError(t, env.hw.PerformBackgroundCheck(context.Background(), filePath, originalStatus, nil))
+
+			require.Eventually(t, func() bool {
+				fh, err := env.healthRepo.GetFileHealth(context.Background(), filePath)
+				return err == nil && fh != nil && fh.Status != database.HealthStatusChecking
+			}, 5*time.Second, 10*time.Millisecond, "the timed-out check must release the 'checking' row")
+
+			fh, err := env.healthRepo.GetFileHealth(context.Background(), filePath)
+			require.NoError(t, err)
+			require.NotNil(t, fh)
+			assert.Equal(t, originalStatus, fh.Status,
+				"a timed-out recheck proves nothing and must not demote the record")
+			assert.Equal(t, 1, fh.RetryCount, "a timed-out recheck must not consume a health retry")
+			assert.Equal(t, 1, fh.RepairRetryCount, "a timed-out recheck must not consume a repair retry")
+		})
+	}
+}
+
+// TestManualRecheckCancellationLeavesPendingIntact verifies the deliberate
+// Pending written by CancelHealthCheck survives: the recovery path must not
+// restore the pre-check status over a user's explicit cancellation.
+func TestManualRecheckCancellationLeavesPendingIntact(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+
+	base := fakepool.New()
+	env := newBatchTestEnv(t, t.TempDir(), &stallingClient{NntpClient: base, delay: time.Minute})
+
+	filePath := "complete/cancelled.mkv"
+	writeHealthyFile(t, env, filePath)
+
+	_, err := env.db.Exec(`
+		INSERT INTO file_health (file_path, status, retry_count, max_retries, repair_retry_count, max_repair_retries, scheduled_check_at)
+		VALUES (?, 'degraded', 1, 3, 1, 3, datetime('now', '-1 second'))
+	`, filePath)
+	require.NoError(t, err)
+	require.NoError(t, env.healthRepo.SetFileChecking(context.Background(), filePath))
+
+	env.hw.mu.Lock()
+	env.hw.running = true
+	env.hw.mu.Unlock()
+
+	require.NoError(t, env.hw.PerformBackgroundCheck(context.Background(), filePath, database.HealthStatusDegraded, nil))
+
+	require.Eventually(t, func() bool {
+		return env.hw.IsCheckActive(filePath)
+	}, 5*time.Second, 10*time.Millisecond, "the check must register itself before it can be cancelled")
+
+	require.NoError(t, env.hw.CancelHealthCheck(context.Background(), filePath))
+
+	require.Never(t, func() bool {
+		fh, err := env.healthRepo.GetFileHealth(context.Background(), filePath)
+		return err == nil && fh != nil && fh.Status != database.HealthStatusPending
+	}, 500*time.Millisecond, 25*time.Millisecond,
+		"cancellation parks the record on Pending on the user's behalf; the recovery path must not undo it")
+}

--- a/internal/health/worker_inconclusive_test.go
+++ b/internal/health/worker_inconclusive_test.go
@@ -1,0 +1,131 @@
+package health
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/nntppool/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPrepareUpdateForResultInconclusive covers the worker's half of #861: a
+// check that could not reach a verdict must reschedule the file without
+// burning a retry, changing its status, or escalating it into repair.
+func TestPrepareUpdateForResultInconclusive(t *testing.T) {
+	env := newRepairTestEnv(t, t.TempDir(), nil)
+
+	filePath := "/movies/movie.mp4"
+	meta := validSegmentMeta(env.metadataService, 1024)
+	require.NoError(t, env.metadataService.WriteFileMetadata(filePath, meta))
+
+	event := HealthEvent{
+		Type:     EventTypeCheckInconclusive,
+		FilePath: filePath,
+		Status:   database.HealthStatusPending,
+		Error:    errors.New("segment check inconclusive: nntp: connection died"),
+	}
+
+	t.Run("reschedules without consuming a retry", func(t *testing.T) {
+		fh := database.FileHealth{
+			FilePath:   filePath,
+			Status:     database.HealthStatusPending,
+			RetryCount: 2,
+			CreatedAt:  time.Now().UTC(),
+		}
+		update, sideEffect := env.hw.prepareUpdateForResult(context.Background(), &fh, event)
+
+		assert.Equal(t, database.UpdateTypeInconclusive, update.Type)
+		assert.Equal(t, database.HealthStatusPending, update.Status)
+		assert.False(t, update.ScheduledCheckAt.IsZero())
+		assert.True(t, update.ScheduledCheckAt.After(time.Now().UTC()))
+		require.NotNil(t, update.ErrorMessage)
+		assert.Contains(t, *update.ErrorMessage, "inconclusive")
+
+		require.NoError(t, sideEffect())
+		assert.Empty(t, env.mockARRs.calls, "an inconclusive check must not trigger an ARR rescan")
+	})
+
+	t.Run("exhausted retries still do not trigger repair", func(t *testing.T) {
+		fh := database.FileHealth{
+			FilePath:   filePath,
+			Status:     database.HealthStatusPending,
+			RetryCount: 99,
+			CreatedAt:  time.Now().UTC(),
+		}
+		update, sideEffect := env.hw.prepareUpdateForResult(context.Background(), &fh, event)
+
+		assert.Equal(t, database.UpdateTypeInconclusive, update.Type)
+		require.NoError(t, sideEffect())
+		assert.Empty(t, env.mockARRs.calls)
+	})
+
+	t.Run("restores the status the record had before the check", func(t *testing.T) {
+		for _, status := range []database.HealthStatus{
+			database.HealthStatusDegraded,
+			database.HealthStatusRepairTriggered,
+		} {
+			fh := database.FileHealth{FilePath: filePath, Status: status, CreatedAt: time.Now().UTC()}
+			update, _ := env.hw.prepareUpdateForResult(context.Background(), &fh, event)
+			assert.Equal(t, database.UpdateTypeInconclusive, update.Type)
+			assert.Equal(t, status, update.Status, "status %q must survive an inconclusive check", status)
+		}
+	})
+
+	t.Run("a record still marked checking falls back to pending", func(t *testing.T) {
+		fh := database.FileHealth{
+			FilePath:  filePath,
+			Status:    database.HealthStatusChecking,
+			CreatedAt: time.Now().UTC(),
+		}
+		update, _ := env.hw.prepareUpdateForResult(context.Background(), &fh, event)
+		assert.Equal(t, database.HealthStatusPending, update.Status,
+			"'checking' is transient — never persist it as the resting status")
+	})
+}
+
+// TestInconclusiveCycleLeavesRecordIntact drives a full health-check cycle
+// against a provider that fails transiently and asserts the persisted record
+// is untouched apart from being pushed to a later check.
+func TestInconclusiveCycleLeavesRecordIntact(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+
+	client := fakepool.New()
+	env := newBatchTestEnv(t, t.TempDir(), client)
+
+	filePath := "complete/flaky.mkv"
+	segID := writeHealthyFile(t, env, filePath)
+	client.SetBehavior(segID, fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
+	insertFileHealth(t, env.db, filePath, "", 1, 3)
+
+	require.NoError(t, env.hw.runHealthCheckCycle(context.Background()))
+
+	var status string
+	var retryCount, repairRetryCount int
+	var scheduled sql.NullString
+	require.NoError(t, env.db.QueryRow(`
+		SELECT status, retry_count, repair_retry_count, scheduled_check_at
+		FROM file_health WHERE file_path = ?`, filePath,
+	).Scan(&status, &retryCount, &repairRetryCount, &scheduled))
+
+	assert.Equal(t, string(database.HealthStatusPending), status)
+	assert.Equal(t, 1, retryCount, "an inconclusive check must not consume a retry")
+	assert.Equal(t, 0, repairRetryCount)
+	assert.True(t, scheduled.Valid, "the file must stay on the check schedule")
+
+	var future int
+	require.NoError(t, env.db.QueryRow(
+		`SELECT scheduled_check_at > datetime('now') FROM file_health WHERE file_path = ?`, filePath,
+	).Scan(&future))
+	assert.Equal(t, 1, future, "the next check must be pushed into the future")
+
+	assert.Empty(t, env.mockARRs.calls)
+}

--- a/internal/health/worker_inconclusive_test.go
+++ b/internal/health/worker_inconclusive_test.go
@@ -5,15 +5,28 @@ import (
 	"database/sql"
 	"errors"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/pool"
 	"github.com/javi11/altmount/internal/testsupport/fakepool"
 	"github.com/javi11/nntppool/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type beforeStatManyClient struct {
+	pool.NntpClient
+	once   sync.Once
+	before func()
+}
+
+func (c *beforeStatManyClient) StatMany(ctx context.Context, ids []string, opts nntppool.StatManyOptions) <-chan nntppool.StatManyResult {
+	c.once.Do(c.before)
+	return c.NntpClient.StatMany(ctx, ids, opts)
+}
 
 // TestPrepareUpdateForResultInconclusive covers the worker's half of #861: a
 // check that could not reach a verdict must reschedule the file without
@@ -128,4 +141,78 @@ func TestInconclusiveCycleLeavesRecordIntact(t *testing.T) {
 	assert.Equal(t, 1, future, "the next check must be pushed into the future")
 
 	assert.Empty(t, env.mockARRs.calls)
+}
+
+func TestInconclusiveManualRecheckRestoresPreCheckStatus(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+
+	for _, originalStatus := range []database.HealthStatus{
+		database.HealthStatusDegraded,
+		database.HealthStatusRepairTriggered,
+	} {
+		t.Run(string(originalStatus), func(t *testing.T) {
+			client := fakepool.New()
+			env := newBatchTestEnv(t, t.TempDir(), client)
+			filePath := "complete/" + string(originalStatus) + ".mkv"
+			segID := writeHealthyFile(t, env, filePath)
+			client.SetBehavior(segID, fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
+
+			_, err := env.db.Exec(`
+				INSERT INTO file_health (file_path, status, retry_count, max_retries, repair_retry_count, max_repair_retries, scheduled_check_at)
+				VALUES (?, ?, 1, 3, 1, 3, datetime('now', '-1 second'))
+			`, filePath, originalStatus)
+			require.NoError(t, err)
+			require.NoError(t, env.healthRepo.SetFileChecking(context.Background(), filePath))
+
+			require.NoError(t, env.hw.performDirectCheck(context.Background(), filePath, originalStatus, nil))
+
+			fh, err := env.healthRepo.GetFileHealth(context.Background(), filePath)
+			require.NoError(t, err)
+			require.NotNil(t, fh)
+			assert.Equal(t, originalStatus, fh.Status)
+			assert.Equal(t, 1, fh.RetryCount, "inconclusive manual recheck must not consume a health retry")
+			assert.Equal(t, 1, fh.RepairRetryCount, "inconclusive manual recheck must not consume a repair retry")
+		})
+	}
+}
+
+func TestManualRecheckDoesNotOverwriteConcurrentStatusChange(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+
+	baseClient := fakepool.New()
+	env := newBatchTestEnv(t, t.TempDir(), baseClient)
+	filePath := "complete/concurrent.mkv"
+	segID := writeHealthyFile(t, env, filePath)
+	baseClient.SetBehavior(segID, fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
+
+	_, err := env.db.Exec(`
+		INSERT INTO file_health (file_path, status, retry_count, max_retries, repair_retry_count, max_repair_retries, scheduled_check_at)
+		VALUES (?, 'degraded', 1, 3, 0, 3, datetime('now', '-1 second'))
+	`, filePath)
+	require.NoError(t, err)
+	require.NoError(t, env.healthRepo.SetFileChecking(context.Background(), filePath))
+
+	client := &beforeStatManyClient{
+		NntpClient: baseClient,
+		before: func() {
+			require.NoError(t, env.healthRepo.UpdateFileHealth(
+				context.Background(), filePath, database.HealthStatusHealthy, nil, nil, nil, false,
+			))
+		},
+	}
+	env.healthChecker.poolManager = &fakeClientPoolManager{client: client}
+
+	require.NoError(t, env.hw.performDirectCheck(
+		context.Background(), filePath, database.HealthStatusDegraded, nil,
+	))
+
+	fh, err := env.healthRepo.GetFileHealth(context.Background(), filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	assert.Equal(t, database.HealthStatusHealthy, fh.Status,
+		"a webhook or re-import status change during a manual check must win")
 }

--- a/internal/importer/handle_failure_test.go
+++ b/internal/importer/handle_failure_test.go
@@ -3,6 +3,7 @@ package importer
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/importer/validation"
 )
 
 // newMoveToFailedTestService builds a minimal *Service with a real SQLite DB so that
@@ -151,6 +153,29 @@ func TestHandleFailure_SourceMissing_IsNoop(t *testing.T) {
 
 	err := svc.MoveToFailedFolder(context.Background(), item)
 	assert.NoError(t, err, "missing source NZB should not be treated as an error")
+}
+
+func TestHandleFailure_FastFailInconclusiveSkipsDefinitiveFailureHandling(t *testing.T) {
+	svc := newMoveToFailedTestService(t)
+	ctx := context.Background()
+	item := &database.ImportQueueItem{
+		NzbPath: filepath.Join(t.TempDir(), "inconclusive.nzb"),
+		Status:  database.QueueStatusPending,
+	}
+	require.NoError(t, os.WriteFile(item.NzbPath, []byte("<nzb/>"), 0644))
+	require.NoError(t, svc.database.Repository.AddToQueue(ctx, item))
+
+	// postProcessor is deliberately nil: reaching definitive fallback/ARR
+	// handling would panic, while an inconclusive validation must stop before it.
+	svc.HandleFailure(ctx, item, fmt.Errorf("fast-fail check: %w", validation.ErrFastFailInconclusive))
+
+	dbItem, err := svc.database.Repository.GetQueueItem(ctx, item.ID)
+	require.NoError(t, err)
+	require.NotNil(t, dbItem)
+	assert.Equal(t, database.QueueStatusFailed, dbItem.Status)
+	require.NotNil(t, dbItem.ErrorMessage)
+	assert.Contains(t, *dbItem.ErrorMessage, validation.ErrFastFailInconclusive.Error())
+	assert.FileExists(t, item.NzbPath, "inconclusive validation must retain the NZB for manual retry")
 }
 
 // TestCleanupFailedItems_RemovesNzbFile verifies that cleanupFailedItems deletes the

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -35,6 +35,16 @@ import (
 
 const (
 	strmFileExtension = ".strm"
+
+	// fastFailStatConcurrency bounds STATs in flight for the fast-fail sweeps.
+	// STAT carries no body, so nntppool pipelines many of them down a single
+	// connection (Provider.StatInflight, defaulted to 100 in config.Manager)
+	// instead of spending one connection per check — connection count is the
+	// wrong ceiling. Deriving this from TotalProviderConnections throttled a
+	// 10-connection pool to 10 in-flight STATs when the pool could carry far
+	// more. 100 matches both the StatInflight default and health's own
+	// max_connections_for_health_checks default.
+	fastFailStatConcurrency = 100
 )
 
 // Processor handles the processing and storage of parsed NZB files using metadata storage
@@ -206,9 +216,8 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 	}
 
 	// Stat is a cheap single round-trip on the pool's normal lane; excess
-	// requests queue and yield to streaming (priority lane). Run sweeps at the
-	// pool's full connection capacity so multi-part releases don't crawl.
-	concurrency := fastFailConcurrency(cfg)
+	// requests queue and yield to streaming (priority lane).
+	concurrency := fastFailStatConcurrency
 
 	// Phase 1: cheap release-level probe. Sample the whole release once
 	// (segment_sample_percentage of it) and fail fast. Healthy releases — the
@@ -375,22 +384,6 @@ func longestSampledRun(segments []*metapb.SegmentData, missingIDs []string) int 
 		}
 	}
 	return acc.LongestRun()
-}
-
-// fastFailConcurrency returns the goroutine cap for the fast-fail Stat sweep.
-// Stats are cheap and queue on the pool's normal lane, so we use the pool's
-// full connection capacity, bounded to keep goroutine counts sane.
-func fastFailConcurrency(cfg *config.Config) int {
-	const maxConcurrency = 100
-
-	capacity := cfg.TotalProviderConnections()
-	if capacity <= 0 {
-		capacity = 1
-	}
-	if capacity > maxConcurrency {
-		capacity = maxConcurrency
-	}
-	return capacity
 }
 
 // ProcessNzbFile processes an NZB or STRM file maintaining the folder structure relative to relative path.

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -458,6 +458,9 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 		var fastFailErr error
 		brokenIdx, missingIDs, fastFailErr = proc.preParseFastFail(ctx, n, cfg, queueID, category, downloadID)
 		if fastFailErr != nil {
+			if errors.Is(fastFailErr, validation.ErrFastFailInconclusive) {
+				return "", nil, fmt.Errorf("fast-fail segment check inconclusive: %w", fastFailErr)
+			}
 			return "", nil, NewNonRetryableError("fast-fail segment check failed", fastFailErr)
 		}
 

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -35,16 +35,6 @@ import (
 
 const (
 	strmFileExtension = ".strm"
-
-	// fastFailStatConcurrency bounds STATs in flight for the fast-fail sweeps.
-	// STAT carries no body, so nntppool pipelines many of them down a single
-	// connection (Provider.StatInflight, defaulted to 100 in config.Manager)
-	// instead of spending one connection per check — connection count is the
-	// wrong ceiling. Deriving this from TotalProviderConnections throttled a
-	// 10-connection pool to 10 in-flight STATs when the pool could carry far
-	// more. 100 matches both the StatInflight default and health's own
-	// max_connections_for_health_checks default.
-	fastFailStatConcurrency = 100
 )
 
 // Processor handles the processing and storage of parsed NZB files using metadata storage
@@ -216,8 +206,10 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 	}
 
 	// Stat is a cheap single round-trip on the pool's normal lane; excess
-	// requests queue and yield to streaming (priority lane).
-	concurrency := fastFailStatConcurrency
+	// requests queue and yield to streaming (priority lane). Size the sweep by
+	// the providers' STAT pipeline depth, not their connection count — STAT is
+	// bodyless, so nntppool pipelines many per connection.
+	concurrency := cfg.StatConcurrency()
 
 	// Phase 1: cheap release-level probe. Sample the whole release once
 	// (segment_sample_percentage of it) and fail fast. Healthy releases — the

--- a/internal/importer/processor_test.go
+++ b/internal/importer/processor_test.go
@@ -248,41 +248,19 @@ func TestPreParseFastFailHealthyReleaseSkipsPerFileSweep(t *testing.T) {
 	}
 }
 
-func TestFastFailConcurrency(t *testing.T) {
-	enabled := true
-	disabled := false
-	tests := []struct {
-		name string
-		cfg  *config.Config
-		want int
-	}{
-		{
-			name: "sums enabled providers (nil Enabled counts as enabled)",
-			cfg:  &config.Config{Providers: []config.ProviderConfig{{MaxConnections: 10, Enabled: &enabled}, {MaxConnections: 20}}},
-			want: 30,
-		},
-		{
-			name: "skips disabled providers",
-			cfg:  &config.Config{Providers: []config.ProviderConfig{{MaxConnections: 10, Enabled: &disabled}, {MaxConnections: 20, Enabled: &enabled}}},
-			want: 20,
-		},
-		{
-			name: "floors at 1 when no capacity configured",
-			cfg:  &config.Config{},
-			want: 1,
-		},
-		{
-			name: "caps at 100",
-			cfg:  &config.Config{Providers: []config.ProviderConfig{{MaxConnections: 500, Enabled: &enabled}}},
-			want: 100,
-		},
+// TestFastFailStatConcurrencyIndependentOfConnections pins the STAT sweep's
+// concurrency to the pipeline depth nntppool can actually sustain rather than
+// to the pool's connection count: STAT carries no body, so many pipeline down
+// one connection (Provider.StatInflight). A small pool must not throttle it.
+func TestFastFailStatConcurrencyIndependentOfConnections(t *testing.T) {
+	if fastFailStatConcurrency != 100 {
+		t.Fatalf("fastFailStatConcurrency = %d, want 100 (matches the StatInflight default)", fastFailStatConcurrency)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := fastFailConcurrency(tt.cfg); got != tt.want {
-				t.Fatalf("fastFailConcurrency = %d, want %d", got, tt.want)
-			}
-		})
+
+	enabled := true
+	tiny := &config.Config{Providers: []config.ProviderConfig{{MaxConnections: 2, Enabled: &enabled}}}
+	if got := tiny.TotalProviderConnections(); got >= fastFailStatConcurrency {
+		t.Fatalf("test fixture is not a small pool: TotalProviderConnections = %d", got)
 	}
 }
 

--- a/internal/importer/processor_test.go
+++ b/internal/importer/processor_test.go
@@ -248,19 +248,22 @@ func TestPreParseFastFailHealthyReleaseSkipsPerFileSweep(t *testing.T) {
 	}
 }
 
-// TestFastFailStatConcurrencyIndependentOfConnections pins the STAT sweep's
-// concurrency to the pipeline depth nntppool can actually sustain rather than
-// to the pool's connection count: STAT carries no body, so many pipeline down
-// one connection (Provider.StatInflight). A small pool must not throttle it.
-func TestFastFailStatConcurrencyIndependentOfConnections(t *testing.T) {
-	if fastFailStatConcurrency != 100 {
-		t.Fatalf("fastFailStatConcurrency = %d, want 100 (matches the StatInflight default)", fastFailStatConcurrency)
-	}
-
+// TestFastFailUsesStatPipelineDepthNotConnections pins the fast-fail sweep's
+// concurrency to the providers' STAT pipeline depth rather than their
+// connection count: STAT carries no body, so nntppool pipelines many per
+// connection (Provider.StatInflight). A two-connection pool must not throttle
+// the sweep to two in-flight STATs.
+func TestFastFailUsesStatPipelineDepthNotConnections(t *testing.T) {
 	enabled := true
-	tiny := &config.Config{Providers: []config.ProviderConfig{{MaxConnections: 2, Enabled: &enabled}}}
-	if got := tiny.TotalProviderConnections(); got >= fastFailStatConcurrency {
-		t.Fatalf("test fixture is not a small pool: TotalProviderConnections = %d", got)
+	cfg := &config.Config{Providers: []config.ProviderConfig{
+		{MaxConnections: 2, StatInflightRequests: 100, Enabled: &enabled},
+	}}
+
+	if got := cfg.TotalProviderConnections(); got != 2 {
+		t.Fatalf("fixture TotalProviderConnections = %d, want 2", got)
+	}
+	if got := cfg.StatConcurrency(); got != 100 {
+		t.Fatalf("StatConcurrency = %d, want 100 (the configured pipeline depth)", got)
 	}
 }
 

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -28,6 +29,7 @@ import (
 	"github.com/javi11/altmount/internal/importer/queue"
 	"github.com/javi11/altmount/internal/importer/scanner"
 	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
+	"github.com/javi11/altmount/internal/importer/validation"
 	"github.com/javi11/altmount/internal/metadata"
 	"github.com/javi11/altmount/internal/nzbfile"
 	"github.com/javi11/altmount/internal/pool"
@@ -1454,6 +1456,31 @@ func (s *Service) cleanupHealthRecords(ctx context.Context, itemID int64, virtua
 // handleProcessingFailure handles when processing fails
 func (s *Service) handleProcessingFailure(ctx context.Context, item *database.ImportQueueItem, processingErr error) {
 	errorMessage := processingErr.Error()
+	if errors.Is(processingErr, validation.ErrFastFailInconclusive) {
+		// The provider never produced a conclusive answer within the validator's
+		// bounded retry budget. Keep this distinct from a bad release: do not log
+		// an indexer failure, notify/blocklist in ARR, invoke fallback, or move the
+		// NZB away. The retained failed item can be retried manually once the
+		// provider is healthy again.
+		s.log.WarnContext(ctx, "Import stopped because segment availability was inconclusive",
+			"queue_id", item.ID,
+			"file", item.NzbPath,
+			"error", processingErr)
+		if err := s.database.Repository.UpdateQueueItemStatus(ctx, item.ID, database.QueueStatusFailed, &errorMessage); err != nil {
+			s.log.ErrorContext(ctx, "Failed to mark inconclusive import as failed", "queue_id", item.ID, "error", err)
+		}
+		if s.database.MigrationRepo != nil {
+			if err := s.database.MigrationRepo.MarkFailed(ctx, item.ID, errorMessage); err != nil {
+				s.log.WarnContext(ctx, "Failed to mark inconclusive import migration as failed",
+					"queue_id", item.ID, "error", err)
+			}
+		}
+		if s.broadcaster != nil {
+			s.broadcaster.NotifyComplete(int(item.ID), "failed")
+			s.broadcaster.BroadcastQueueChanged()
+		}
+		return
+	}
 
 	// Log persistent indexer statistic
 	indexerName := database.IndexerUnknown
@@ -1996,4 +2023,3 @@ func joinPathsMergingOverlap(parent, child string) string {
 	}
 	return result
 }
-

--- a/internal/importer/validation/fast_fail.go
+++ b/internal/importer/validation/fast_fail.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/rand"
@@ -13,6 +14,132 @@ import (
 	"github.com/javi11/altmount/internal/usenet"
 	"github.com/javi11/nntppool/v4"
 )
+
+const (
+	fastFailStatMaxAttempts = 3
+	fastFailRetryBaseDelay  = 100 * time.Millisecond
+)
+
+var (
+	// ErrFastFailInconclusive means bounded retries could not establish whether
+	// one or more sampled articles exist. It is deliberately distinct from a
+	// definitive NNTP 430/423 miss so callers do not discard files as broken.
+	ErrFastFailInconclusive = errors.New("fast-fail validation inconclusive")
+	errFastFailUnreported   = errors.New("STAT result was not reported")
+)
+
+func isDefinitiveFastFailMiss(err error) bool {
+	return errors.Is(err, nntppool.ErrArticleNotFound)
+}
+
+// statIDsWithBoundedRetries checks ids up to fastFailStatMaxAttempts times.
+// Successful and definitively missing ids leave the retry set immediately;
+// only operational errors and unreported ids are retried. The returned map
+// contains only definitive misses. When stopOnMissing is true the first such
+// miss ends the sweep, preserving the release probe's fast-fail behavior.
+func statIDsWithBoundedRetries(
+	ctx context.Context,
+	client pool.NntpClient,
+	ids []string,
+	maxConnections int,
+	timeout time.Duration,
+	stopOnMissing bool,
+) (map[string]error, error) {
+	remaining := make([]string, 0, len(ids))
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		remaining = append(remaining, id)
+	}
+
+	missing := make(map[string]error)
+	var lastErr error
+
+	for attempt := 1; attempt <= fastFailStatMaxAttempts && len(remaining) > 0; attempt++ {
+		statCtx, cancel := context.WithTimeout(ctx, pool.StatManyTimeout(len(remaining), maxConnections, timeout))
+		reported := make(map[string]bool, len(remaining))
+		transient := make(map[string]error, len(remaining))
+
+		for result := range client.StatMany(statCtx, remaining, nntppool.StatManyOptions{Concurrency: maxConnections}) {
+			if _, wanted := seen[result.MessageID]; !wanted {
+				continue
+			}
+			reported[result.MessageID] = true
+			if result.Err == nil {
+				continue
+			}
+			if isDefinitiveFastFailMiss(result.Err) {
+				missing[result.MessageID] = result.Err
+				if stopOnMissing {
+					if ctxErr := ctx.Err(); ctxErr != nil {
+						cancel()
+						return nil, ctxErr
+					}
+					cancel()
+					return missing, nil
+				}
+				continue
+			}
+			transient[result.MessageID] = result.Err
+			lastErr = result.Err
+		}
+
+		statErr := statCtx.Err()
+		cancel()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+
+		next := make([]string, 0, len(remaining))
+		for _, id := range remaining {
+			if _, definitive := missing[id]; definitive {
+				continue
+			}
+			if err, failed := transient[id]; failed {
+				lastErr = err
+				next = append(next, id)
+				continue
+			}
+			if !reported[id] {
+				if statErr != nil {
+					lastErr = statErr
+				} else {
+					lastErr = errFastFailUnreported
+				}
+				next = append(next, id)
+			}
+		}
+		remaining = next
+
+		if len(remaining) == 0 {
+			return missing, nil
+		}
+		if attempt == fastFailStatMaxAttempts {
+			return missing, fmt.Errorf("%w: %d segment(s) remained unverified after %d attempts: %w",
+				ErrFastFailInconclusive, len(remaining), attempt, lastErr)
+		}
+
+		delay := fastFailRetryBaseDelay << (attempt - 1)
+		slog.WarnContext(ctx, "Retrying inconclusive fast-fail STATs",
+			"attempt", attempt+1,
+			"remaining", len(remaining),
+			"delay", delay,
+			"error", lastErr,
+		)
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	return missing, nil
+}
 
 // selectFastFailSegments picks a lightweight per-file sample for the fast-fail
 // reachability gate: always the first and last segment (DMCA/truncation
@@ -70,15 +197,17 @@ type FastFailFile struct {
 // It flattens all candidate segments across the release and Stats a single
 // sample (usenet.SelectSegmentsForValidation: first 3 + last 2 + random middle,
 // min 5 for the whole release), cancelling the remaining Stats on the
-// first miss.
+// first definitive miss. Operational errors are retried before the probe is
+// declared inconclusive.
 //
 // Returns (missing, err):
-//   - err is reserved for infrastructure failures (pool unavailable/nil).
-//   - missing reports whether any sampled segment was unreachable. A 430 / Stat
-//     failure / timeout yields (true, nil) — not an error — so the caller can
-//     escalate to the per-file FastFailCheckFiles sweep to map exactly which
-//     files are broken. A clean release returns (false, nil) and the caller
-//     proceeds straight to parsing, paying only this sample's worth of Stats.
+//   - err reports infrastructure failures, caller cancellation, or operational
+//     STAT failures that remain inconclusive after bounded retries.
+//   - missing reports whether any sampled segment returned a definitive 430/423,
+//     so the caller can escalate to the per-file FastFailCheckFiles sweep to map
+//     exactly which files are broken. Operational errors and timeouts are retried;
+//     exhaustion returns ErrFastFailInconclusive. A clean release returns
+//     (false, nil) and proceeds straight to parsing.
 func FastFailReleaseProbe(
 	ctx context.Context,
 	files []FastFailFile,
@@ -125,49 +254,18 @@ func FastFailReleaseProbe(
 		ids[i] = seg.Id
 	}
 
-	// Stat the sample via a single bulk sweep, cancelling the rest on the
-	// first miss. Infrastructure failures are handled above, so any error
-	// streamed back here indicates an unreachable segment. Cap probe timeout to
-	// 2 seconds per item so probe sweeps on dead releases finish rapidly.
+	// Stat the sample via a bulk sweep, cancelling the rest on the first
+	// definitive miss. Operational errors retry only the affected IDs. Cap each
+	// attempt's probe timeout to 2 seconds per item so dead releases stay bounded.
 	probeTimeout := timeout
 	if probeTimeout > 2*time.Second {
 		probeTimeout = 2 * time.Second
 	}
-	statCtx, cancel := context.WithTimeout(ctx, pool.StatManyTimeout(len(ids), maxConnections, probeTimeout))
-	defer cancel()
-
-	// Count confirmed-reachable segments rather than trusting the stream to
-	// report every failure: StatMany abandons pending sends once its context is
-	// done, so a deadline expiry closes the channel silently instead of
-	// surfacing an error per segment. Only a full set of successful Stats proves
-	// the sample reachable.
-	reachable := 0
-	for r := range usenetPool.StatMany(statCtx, ids, nntppool.StatManyOptions{Concurrency: maxConnections}) {
-		if r.Err != nil {
-			// Only the caller giving up is an error. statCtx carries the probe's
-			// own short deadline, so an expiry there is a reachability signal.
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				return false, ctxErr
-			}
-			slog.WarnContext(ctx, "FastFailReleaseProbe segment stat failed", "segment_id", r.MessageID, "error", r.Err)
-			cancel()
-			return true, nil
-		}
-		reachable++
+	missing, err := statIDsWithBoundedRetries(ctx, usenetPool, ids, maxConnections, probeTimeout, true)
+	if err != nil {
+		return false, err
 	}
-
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		return false, ctxErr
-	}
-	if reachable < len(ids) {
-		// The probe's own deadline expired before every sampled segment was
-		// confirmed. Reachability is unproven, so report missing and let the
-		// caller escalate to the per-file sweep.
-		slog.WarnContext(ctx, "FastFailReleaseProbe timed out before confirming sample",
-			"confirmed", reachable, "sampled", len(ids))
-		return true, nil
-	}
-	return false, nil
+	return len(missing) > 0, nil
 }
 
 // FastFailFileResult records the reachability outcome for a single FastFailFile.
@@ -188,8 +286,10 @@ type FastFailFileResult struct {
 // index alignment while avoiding wasted Stat round-trips.
 // Returns one result per input file (index-aligned). Files with no segments
 // are skipped. Infrastructure failures (pool unavailable) are returned as an
-// error; per-segment Stat failures mark the owning file Broken. progressTracker
-// may be nil; when set it reports completed Stats as work progresses.
+// error; definitive article-not-found results mark the owning file Broken.
+// Operational failures are retried, and exhaustion returns
+// ErrFastFailInconclusive without marking files broken. progressTracker may be
+// nil; when set it reports completed Stats as work progresses.
 func FastFailCheckFiles(
 	ctx context.Context,
 	files []FastFailFile,
@@ -307,25 +407,13 @@ func FastFailCheckFiles(
 			ids[i] = job.segID
 		}
 
-		statCtx, cancel := context.WithTimeout(ctx, pool.StatManyTimeout(len(ids), maxConnections, timeout))
-		errByID := make(map[string]error, len(ids))
-		for r := range usenetPool.StatMany(statCtx, ids, nntppool.StatManyOptions{Concurrency: maxConnections}) {
-			errByID[r.MessageID] = r.Err
-		}
-		cancel()
-
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
+		missingByID, err := statIDsWithBoundedRetries(ctx, usenetPool, ids, maxConnections, timeout, false)
+		if err != nil {
+			return nil, err
 		}
 
 		for _, job := range toCheck {
-			// Caller cancellation was already handled above, so anything left
-			// here is a reachability signal for the owning file, not a reason
-			// to abandon the sweep. A stat that reports an error — or never
-			// reports at all because the chunk deadline expired before it was
-			// dispatched — means reachability was never proven.
-			statErr, reported := errByID[job.segID]
-			if !reported || statErr != nil {
+			if _, missing := missingByID[job.segID]; missing {
 				results[job.fileIdx].Broken = true
 				results[job.fileIdx].MissingSegmentIDs = append(results[job.fileIdx].MissingSegmentIDs, job.segID)
 				if job.groupKey != "" {

--- a/internal/importer/validation/fast_fail_test.go
+++ b/internal/importer/validation/fast_fail_test.go
@@ -2,7 +2,9 @@ package validation
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,7 +15,7 @@ import (
 )
 
 type fastFailPoolManager struct {
-	client *fakepool.Client
+	client pool.NntpClient
 }
 
 func (m fastFailPoolManager) GetPool() (pool.NntpClient, error) { return m.client, nil }
@@ -46,6 +48,198 @@ func (m fastFailPoolManager) SetImportConnCapacity(int)                 {}
 func (m fastFailPoolManager) ImportConnCapacity() int                   { return 0 }
 func (m fastFailPoolManager) SetStreamSource(pool.StreamActivitySource) {}
 func (m fastFailPoolManager) NotifyStreamChange()                       {}
+
+// scriptedStatClient returns a configured sequence of STAT errors per
+// message ID. Once a sequence is exhausted, its final outcome repeats.
+type scriptedStatClient struct {
+	pool.NntpClient
+	mu       sync.Mutex
+	outcomes map[string][]error
+	calls    map[string]int
+}
+
+type uncancelableStatClient struct {
+	pool.NntpClient
+	result nntppool.StatManyResult
+}
+
+func (c uncancelableStatClient) StatMany(context.Context, []string, nntppool.StatManyOptions) <-chan nntppool.StatManyResult {
+	out := make(chan nntppool.StatManyResult, 1)
+	out <- c.result
+	close(out)
+	return out
+}
+
+func newScriptedStatClient(outcomes map[string][]error) *scriptedStatClient {
+	return &scriptedStatClient{
+		NntpClient: fakepool.New(),
+		outcomes:   outcomes,
+		calls:      make(map[string]int),
+	}
+}
+
+func (c *scriptedStatClient) StatMany(ctx context.Context, ids []string, _ nntppool.StatManyOptions) <-chan nntppool.StatManyResult {
+	out := make(chan nntppool.StatManyResult, len(ids))
+	go func() {
+		defer close(out)
+		for _, id := range ids {
+			c.mu.Lock()
+			attempt := c.calls[id]
+			c.calls[id]++
+			sequence := c.outcomes[id]
+			var err error
+			if len(sequence) > 0 {
+				idx := min(attempt, len(sequence)-1)
+				err = sequence[idx]
+			}
+			c.mu.Unlock()
+
+			result := nntppool.StatManyResult{MessageID: id, Err: err}
+			if err == nil {
+				result.Result = &nntppool.StatResult{MessageID: id}
+			}
+			select {
+			case out <- result:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out
+}
+
+func (c *scriptedStatClient) callCount(id string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls[id]
+}
+
+func TestFastFailReleaseProbeRetriesTransientFailure(t *testing.T) {
+	client := newScriptedStatClient(map[string][]error{
+		"flaky-0": {nntppool.ErrConnectionDied, nil},
+	})
+
+	missing, err := FastFailReleaseProbe(
+		context.Background(),
+		[]FastFailFile{{Filename: "movie.mkv", Segments: makeTestSegments("flaky", 1)}},
+		fastFailPoolManager{client: client},
+		100,
+		1,
+		100*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("FastFailReleaseProbe error = %v, want nil after transient recovery", err)
+	}
+	if missing {
+		t.Fatal("missing = true, want false after transient recovery")
+	}
+	if got := client.callCount("flaky-0"); got != 2 {
+		t.Fatalf("STAT attempts = %d, want 2", got)
+	}
+}
+
+func TestFastFailReleaseProbeDoesNotRetryDefinitiveMiss(t *testing.T) {
+	client := newScriptedStatClient(map[string][]error{
+		"gone-0": {nntppool.ErrArticleNotFound},
+	})
+
+	missing, err := FastFailReleaseProbe(
+		context.Background(),
+		[]FastFailFile{{Filename: "movie.mkv", Segments: makeTestSegments("gone", 1)}},
+		fastFailPoolManager{client: client},
+		100,
+		1,
+		100*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("FastFailReleaseProbe error = %v, want nil for definitive miss", err)
+	}
+	if !missing {
+		t.Fatal("missing = false, want true for definitive miss")
+	}
+	if got := client.callCount("gone-0"); got != 1 {
+		t.Fatalf("STAT attempts = %d, want 1 for definitive miss", got)
+	}
+}
+
+func TestFastFailReleaseProbeCancellationWinsOverDefinitiveMiss(t *testing.T) {
+	client := uncancelableStatClient{
+		NntpClient: fakepool.New(),
+		result:     nntppool.StatManyResult{MessageID: "gone-0", Err: nntppool.ErrArticleNotFound},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	missing, err := FastFailReleaseProbe(
+		ctx,
+		[]FastFailFile{{Filename: "movie.mkv", Segments: makeTestSegments("gone", 1)}},
+		fastFailPoolManager{client: client},
+		100,
+		1,
+		100*time.Millisecond,
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("FastFailReleaseProbe error = %v, want context.Canceled", err)
+	}
+	if missing {
+		t.Fatal("missing = true, want cancellation to take precedence")
+	}
+}
+
+func TestFastFailCheckFilesRetriesOnlyTransientIDs(t *testing.T) {
+	client := newScriptedStatClient(map[string][]error{
+		"flaky-0": {nntppool.ErrServiceUnavailable, nil},
+	})
+	files := []FastFailFile{
+		{Filename: "good.mkv", Segments: makeTestSegments("good", 1)},
+		{Filename: "flaky.mkv", Segments: makeTestSegments("flaky", 1)},
+	}
+
+	results, err := FastFailCheckFiles(
+		context.Background(), files, fastFailPoolManager{client: client},
+		100, 2, 100*time.Millisecond, nil,
+	)
+	if err != nil {
+		t.Fatalf("FastFailCheckFiles error = %v, want nil after transient recovery", err)
+	}
+	if results[0].Broken || results[1].Broken {
+		t.Fatalf("results = %+v, want both files healthy after transient recovery", results)
+	}
+	if got := client.callCount("good-0"); got != 1 {
+		t.Fatalf("good STAT attempts = %d, want 1", got)
+	}
+	if got := client.callCount("flaky-0"); got != 2 {
+		t.Fatalf("flaky STAT attempts = %d, want 2", got)
+	}
+}
+
+func TestFastFailCheckFilesTransientExhaustionIsInconclusive(t *testing.T) {
+	client := newScriptedStatClient(map[string][]error{
+		"down-0": {nntppool.ErrConnectionDied},
+	})
+
+	results, err := FastFailCheckFiles(
+		context.Background(),
+		[]FastFailFile{{Filename: "movie.mkv", Segments: makeTestSegments("down", 1)}},
+		fastFailPoolManager{client: client},
+		100, 1, 100*time.Millisecond, nil,
+	)
+	if err == nil {
+		t.Fatal("FastFailCheckFiles error = nil, want inconclusive error after retries are exhausted")
+	}
+	if !errors.Is(err, ErrFastFailInconclusive) {
+		t.Fatalf("FastFailCheckFiles error = %v, want ErrFastFailInconclusive", err)
+	}
+	if !errors.Is(err, nntppool.ErrConnectionDied) {
+		t.Fatalf("FastFailCheckFiles error = %v, want wrapped connection error", err)
+	}
+	if results != nil {
+		t.Fatalf("results = %+v, want nil when validation is inconclusive", results)
+	}
+	if got := client.callCount("down-0"); got != 3 {
+		t.Fatalf("STAT attempts = %d, want bounded maximum of 3", got)
+	}
+}
 
 func TestFastFailReleaseProbeUsesSegmentSamplePercentage(t *testing.T) {
 	client := fakepool.New()
@@ -531,12 +725,9 @@ func TestFastFailCheckFilesIndexAligned(t *testing.T) {
 	}
 }
 
-// TestFastFailReleaseProbeTimeoutReportsMissing pins the documented contract
-// that a probe timeout yields (true, nil) so the caller escalates to the
-// per-file sweep. The probe derives its own short deadline from the caller's
-// context, so an expiry there must not be mistaken for caller cancellation —
-// which would report the release as healthy and swallow the signal entirely.
-func TestFastFailReleaseProbeTimeoutReportsMissing(t *testing.T) {
+// TestFastFailReleaseProbeTimeoutIsInconclusive verifies a probe timeout is
+// retried but never converted into a definitive missing-segment verdict.
+func TestFastFailReleaseProbeTimeoutIsInconclusive(t *testing.T) {
 	client := fakepool.New()
 	// Every Stat outlives the probe's own deadline.
 	client.SetDefaultBehavior(fakepool.SegmentBehavior{Latency: 2 * time.Second})
@@ -549,11 +740,17 @@ func TestFastFailReleaseProbeTimeoutReportsMissing(t *testing.T) {
 		1,
 		10*time.Millisecond,
 	)
-	if err != nil {
-		t.Fatalf("FastFailReleaseProbe error = %v, want nil (a probe timeout is not an infrastructure error)", err)
+	if err == nil {
+		t.Fatal("FastFailReleaseProbe error = nil, want inconclusive error after retries")
 	}
-	if !missing {
-		t.Fatal("missing = false, want true (probe timed out, so reachability is unproven)")
+	if !errors.Is(err, ErrFastFailInconclusive) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("FastFailReleaseProbe error = %v, want inconclusive deadline error", err)
+	}
+	if missing {
+		t.Fatal("missing = true, want false when reachability is inconclusive")
+	}
+	if got := client.StatCalls(); got != fastFailStatMaxAttempts {
+		t.Fatalf("StatCalls = %d, want bounded maximum of %d", got, fastFailStatMaxAttempts)
 	}
 }
 
@@ -583,11 +780,9 @@ func TestFastFailReleaseProbeCallerCancellationReturnsError(t *testing.T) {
 	}
 }
 
-// TestFastFailCheckFilesTimeoutMarksFileBroken verifies that a Stat which
-// exceeds the sweep's own per-chunk deadline is mapped to the owning file
-// rather than aborting the whole sweep. Abandoning the sweep would discard the
-// per-file mapping this function exists to produce.
-func TestFastFailCheckFilesTimeoutMarksFileBroken(t *testing.T) {
+// TestFastFailCheckFilesTimeoutIsInconclusive verifies timeout exhaustion
+// aborts validation without marking the owning file definitively broken.
+func TestFastFailCheckFilesTimeoutIsInconclusive(t *testing.T) {
 	client := fakepool.New()
 	client.SetDefaultBehavior(fakepool.SegmentBehavior{Latency: 2 * time.Second})
 
@@ -604,13 +799,16 @@ func TestFastFailCheckFilesTimeoutMarksFileBroken(t *testing.T) {
 		10*time.Millisecond,
 		nil,
 	)
-	if err != nil {
-		t.Fatalf("FastFailCheckFiles error = %v, want nil (a stat timeout is a per-file signal)", err)
+	if err == nil {
+		t.Fatal("FastFailCheckFiles error = nil, want inconclusive error after retries")
 	}
-	if len(results) != 1 {
-		t.Fatalf("len(results) = %d, want 1", len(results))
+	if !errors.Is(err, ErrFastFailInconclusive) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("FastFailCheckFiles error = %v, want inconclusive deadline error", err)
 	}
-	if !results[0].Broken {
-		t.Error("results[0].Broken = false, want true (its segments never proved reachable)")
+	if results != nil {
+		t.Fatalf("results = %+v, want nil when validation is inconclusive", results)
+	}
+	if got := client.StatCalls(); got != fastFailStatMaxAttempts {
+		t.Fatalf("StatCalls = %d, want bounded maximum of %d", got, fastFailStatMaxAttempts)
 	}
 }

--- a/internal/usenet/validation.go
+++ b/internal/usenet/validation.go
@@ -2,6 +2,7 @@ package usenet
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/rand"
@@ -38,6 +39,43 @@ type ValidationResult struct {
 	MissingCount    int
 	MissingIDs      []string
 	MissingSegments []MissingSegment // same 50-entry cap as MissingIDs
+	// ErrorCount counts checked segments whose availability could not be
+	// determined: an operational STAT failure, or no result at all because
+	// the sweep was truncated. Those segments are unknown, never missing.
+	ErrorCount int
+	// Err is the first such failure. Non-nil marks the whole result
+	// inconclusive.
+	Err error
+}
+
+// Inconclusive reports whether the sweep failed to reach a definitive answer
+// for at least one checked segment. An inconclusive result is not evidence of
+// anything — neither of missing articles nor of a healthy file — so callers
+// must retry rather than record a verdict from it.
+func (r ValidationResult) Inconclusive() bool { return r.Err != nil }
+
+// errSegmentUnreported marks segments the pool never answered for. StatMany
+// stops dispatching and drops in-flight results when its context ends, so a
+// cancelled or timed-out sweep silently returns fewer results than ids.
+var errSegmentUnreported = errors.New("segment availability not reported by the STAT sweep")
+
+// isDefinitiveMiss reports whether a STAT error proves the article is gone.
+// Only NNTP 430/423 does. Every other error — dead connection, timeout,
+// context cancellation, authentication failure, quota exceeded, service
+// unavailable, exhausted pool — means the check could not answer, and
+// counting it as a miss persisted false holes that no later clean check
+// could clear (issue #861).
+func isDefinitiveMiss(err error) bool {
+	return errors.Is(err, nntppool.ErrArticleNotFound)
+}
+
+// unreportedErr wraps the sweep's context error (when there is one) so the
+// caller can tell a truncated sweep from a per-segment failure.
+func unreportedErr(ctxErr error) error {
+	if ctxErr != nil {
+		return fmt.Errorf("%w: %w", errSegmentUnreported, ctxErr)
+	}
+	return errSegmentUnreported
 }
 
 // ValidateSegmentAvailabilityDetailed validates segments and returns detailed results
@@ -96,8 +134,21 @@ func ValidateSegmentAvailabilityDetailed(
 	defer cancel()
 
 	var validatedCount int
+	var reported int
 	for r := range usenetPool.StatMany(statCtx, ids, nntppool.StatManyOptions{Concurrency: maxConnections}) {
+		reported++
 		if r.Err != nil {
+			if !isDefinitiveMiss(r.Err) {
+				slog.DebugContext(ctx, "inconclusive segment check",
+					"segment_id", r.MessageID,
+					"error", r.Err,
+				)
+				result.ErrorCount++
+				if result.Err == nil {
+					result.Err = r.Err
+				}
+				continue
+			}
 			slog.DebugContext(ctx, "missing segment",
 				"segment_id", r.MessageID,
 				"error", r.Err,
@@ -126,6 +177,13 @@ func ValidateSegmentAvailabilityDetailed(
 			progressTracker.Update(validatedCount, result.TotalChecked)
 		}
 	}
+	if unreported := len(ids) - reported; unreported > 0 {
+		result.ErrorCount += unreported
+		if result.Err == nil {
+			result.Err = unreportedErr(statCtx.Err())
+		}
+	}
+
 	sort.Slice(result.MissingSegments, func(i, j int) bool {
 		return result.MissingSegments[i].Index < result.MissingSegments[j].Index
 	})
@@ -220,6 +278,17 @@ func ValidateSegmentAvailabilityBatch(
 		owners[r.MessageID] = owner[1:]
 
 		if r.Err != nil {
+			if !isDefinitiveMiss(r.Err) {
+				slog.DebugContext(ctx, "inconclusive segment check",
+					"segment_id", r.MessageID,
+					"error", r.Err,
+				)
+				results[fileIdx].ErrorCount++
+				if results[fileIdx].Err == nil {
+					results[fileIdx].Err = r.Err
+				}
+				continue
+			}
 			slog.DebugContext(ctx, "missing segment",
 				"segment_id", r.MessageID,
 				"error", r.Err,
@@ -235,14 +304,30 @@ func ValidateSegmentAvailabilityBatch(
 		poolManager.UpdateDownloadProgress("", 100)
 	}
 
+	// Ids still owed an answer never reached a provider (or their result was
+	// dropped when the sweep context ended). Attribute them to their files as
+	// unknown, so a truncated sweep cannot pass for a clean one.
+	sweepErr := statCtx.Err()
+	for _, remaining := range owners {
+		for _, fileIdx := range remaining {
+			results[fileIdx].ErrorCount++
+			if results[fileIdx].Err == nil {
+				results[fileIdx].Err = unreportedErr(sweepErr)
+			}
+		}
+	}
+
 	missingTotal := 0
+	errorTotal := 0
 	for _, r := range results {
 		missingTotal += r.MissingCount
+		errorTotal += r.ErrorCount
 	}
 	slog.InfoContext(ctx, "STAT sweep completed",
 		"files", nonEmptyFiles,
 		"segments", len(ids),
 		"missing", missingTotal,
+		"inconclusive", errorTotal,
 		"duration", time.Since(sweepStart),
 	)
 

--- a/internal/usenet/validation_test.go
+++ b/internal/usenet/validation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/javi11/altmount/internal/testsupport/fakepool"
 	"github.com/javi11/nntppool/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // NOTE: Tests for ValidateSegmentAvailability and ValidateSegmentAvailabilityDetailed
@@ -240,3 +241,135 @@ func (m *validationTestPoolManager) SetImportConnCapacity(_ int)                
 func (m *validationTestPoolManager) ImportConnCapacity() int                     { return 0 }
 func (m *validationTestPoolManager) SetStreamSource(_ pool.StreamActivitySource) {}
 func (m *validationTestPoolManager) NotifyStreamChange()                         {}
+
+// TestValidateSegmentAvailability_TransientErrorsAreInconclusive is the
+// regression guard for #861: a STAT that fails for an operational reason
+// (dead connection, timeout, quota, auth, 502, exhausted pool) says nothing
+// about whether the article exists. Counting it as missing let a transient
+// backup-provider failure be written into the file's permanent hole map.
+func TestValidateSegmentAvailability_TransientErrorsAreInconclusive(t *testing.T) {
+	operational := []struct {
+		name string
+		err  error
+	}{
+		{"connection died", nntppool.ErrConnectionDied},
+		{"quota exceeded", nntppool.ErrQuotaExceeded},
+		{"service unavailable", nntppool.ErrServiceUnavailable},
+		{"auth rejected", nntppool.ErrAuthRejected},
+		{"deadline exceeded", context.DeadlineExceeded},
+		{"providers exhausted", fmt.Errorf("nntp: all providers exhausted: %w", nntppool.ErrConnectionDied)},
+	}
+
+	for _, tc := range operational {
+		t.Run(tc.name, func(t *testing.T) {
+			fp := fakepool.New()
+			mgr := &validationTestPoolManager{client: fp}
+			const id = "flaky@host"
+			fp.SetBehavior(id, fakepool.SegmentBehavior{Err: tc.err})
+
+			results, err := ValidateSegmentAvailabilityBatch(
+				context.Background(), [][]string{{id}}, mgr, 1, 5*time.Second)
+			assert.NoError(t, err)
+			require.Len(t, results, 1)
+
+			assert.Zero(t, results[0].MissingCount, "operational error must not count as missing")
+			assert.Empty(t, results[0].MissingIDs, "operational error must not yield a hole id")
+			assert.Equal(t, 1, results[0].ErrorCount)
+			assert.True(t, results[0].Inconclusive())
+			assert.ErrorIs(t, results[0].Err, tc.err)
+		})
+	}
+}
+
+// TestValidateSegmentAvailability_ArticleNotFoundIsMissing keeps the genuine
+// miss path intact: only 430/423 proves the article is gone.
+func TestValidateSegmentAvailability_ArticleNotFoundIsMissing(t *testing.T) {
+	fp := fakepool.New()
+	mgr := &validationTestPoolManager{client: fp}
+	const id = "gone@host"
+	fp.SetBehavior(id, fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+	results, err := ValidateSegmentAvailabilityBatch(
+		context.Background(), [][]string{{id}}, mgr, 1, 5*time.Second)
+	assert.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Equal(t, 1, results[0].MissingCount)
+	assert.Equal(t, []string{id}, results[0].MissingIDs)
+	assert.Zero(t, results[0].ErrorCount)
+	assert.False(t, results[0].Inconclusive())
+}
+
+// TestValidateSegmentAvailabilityBatch_InconclusiveIsPerFile verifies one
+// file's transient failure does not taint its batch siblings' verdicts.
+func TestValidateSegmentAvailabilityBatch_InconclusiveIsPerFile(t *testing.T) {
+	fp := fakepool.New()
+	mgr := &validationTestPoolManager{client: fp}
+	fp.SetBehavior("flaky@host", fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
+	fp.SetBehavior("gone@host", fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+	results, err := ValidateSegmentAvailabilityBatch(context.Background(), [][]string{
+		{"ok@host"},
+		{"flaky@host"},
+		{"gone@host"},
+	}, mgr, 3, 5*time.Second)
+	assert.NoError(t, err)
+	require.Len(t, results, 3)
+
+	assert.False(t, results[0].Inconclusive())
+	assert.Zero(t, results[0].MissingCount)
+
+	assert.True(t, results[1].Inconclusive())
+	assert.Zero(t, results[1].MissingCount)
+
+	assert.False(t, results[2].Inconclusive())
+	assert.Equal(t, 1, results[2].MissingCount)
+}
+
+// TestValidateSegmentAvailabilityBatch_UnreportedSegmentsAreInconclusive
+// covers the other half of #861: StatMany emits nothing for ids it never
+// dispatched (cancelled context / elapsed sweep deadline). Treating that
+// silence as "checked and present" made a truncated sweep declare a file
+// healthy on no evidence at all.
+func TestValidateSegmentAvailabilityBatch_UnreportedSegmentsAreInconclusive(t *testing.T) {
+	fp := fakepool.New()
+	mgr := &validationTestPoolManager{client: fp}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	results, err := ValidateSegmentAvailabilityBatch(
+		ctx, [][]string{{"a@host", "b@host"}}, mgr, 1, 5*time.Second)
+	assert.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Zero(t, results[0].MissingCount)
+	assert.Empty(t, results[0].MissingIDs)
+	assert.Equal(t, 2, results[0].ErrorCount)
+	assert.True(t, results[0].Inconclusive())
+	assert.ErrorIs(t, results[0].Err, context.Canceled)
+}
+
+// TestValidateSegmentAvailabilityDetailed_TransientErrorIsInconclusive
+// mirrors the batch guard on the detailed path.
+func TestValidateSegmentAvailabilityDetailed_TransientErrorIsInconclusive(t *testing.T) {
+	fp := fakepool.New()
+	mgr := &validationTestPoolManager{client: fp}
+
+	segs := []*metapb.SegmentData{
+		{Id: "ok@host", StartOffset: 0, EndOffset: 999},
+		{Id: "flaky@host", StartOffset: 0, EndOffset: 999},
+	}
+	fp.SetBehavior("flaky@host", fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
+
+	result, err := ValidateSegmentAvailabilityDetailed(
+		context.Background(), segs, mgr, 2, 100, nil, 5*time.Second)
+	assert.NoError(t, err)
+
+	assert.Zero(t, result.MissingCount)
+	assert.Empty(t, result.MissingIDs)
+	assert.Empty(t, result.MissingSegments)
+	assert.Equal(t, 1, result.ErrorCount)
+	assert.True(t, result.Inconclusive())
+	assert.ErrorIs(t, result.Err, nntppool.ErrConnectionDied)
+}

--- a/internal/usenet/validation_test.go
+++ b/internal/usenet/validation_test.go
@@ -5,19 +5,15 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/pool"
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
 	"github.com/javi11/nntppool/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// NOTE: Tests for ValidateSegmentAvailability and ValidateSegmentAvailabilityDetailed
-// were removed during v2→v4 migration because nntppool v4 uses a concrete *Client type
-// (not an interface), making it impossible to mock directly. Integration tests with
-// a real NNTP server should be used to test validation behavior.
-//
 
 func TestSelectSegmentsForValidation(t *testing.T) {
 	// Use a deterministic RNG for predictability in middle segments.
@@ -152,13 +148,13 @@ func TestValidateSegmentAvailability_TransientErrorsAreInconclusive(t *testing.T
 			fp.SetBehavior(id, fakepool.SegmentBehavior{Err: tc.err})
 
 			results, err := ValidateSegmentAvailabilityBatch(
-				context.Background(), [][]string{{id}}, mgr, 1, 5*time.Second)
+				context.Background(), [][]string{{id}}, mgr, BatchOptions{MaxConnections: 1, Timeout: 5 * time.Second})
 			assert.NoError(t, err)
 			require.Len(t, results, 1)
 
 			assert.Zero(t, results[0].MissingCount, "operational error must not count as missing")
 			assert.Empty(t, results[0].MissingIDs, "operational error must not yield a hole id")
-			assert.Equal(t, 1, results[0].ErrorCount)
+			assert.Equal(t, 1, results[0].UnresolvedCount)
 			assert.True(t, results[0].Inconclusive())
 			assert.ErrorIs(t, results[0].Err, tc.err)
 		})
@@ -174,13 +170,13 @@ func TestValidateSegmentAvailability_ArticleNotFoundIsMissing(t *testing.T) {
 	fp.SetBehavior(id, fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
 
 	results, err := ValidateSegmentAvailabilityBatch(
-		context.Background(), [][]string{{id}}, mgr, 1, 5*time.Second)
+		context.Background(), [][]string{{id}}, mgr, BatchOptions{MaxConnections: 1, Timeout: 5 * time.Second})
 	assert.NoError(t, err)
 	require.Len(t, results, 1)
 
 	assert.Equal(t, 1, results[0].MissingCount)
 	assert.Equal(t, []string{id}, results[0].MissingIDs)
-	assert.Zero(t, results[0].ErrorCount)
+	assert.Zero(t, results[0].UnresolvedCount)
 	assert.False(t, results[0].Inconclusive())
 }
 
@@ -196,7 +192,7 @@ func TestValidateSegmentAvailabilityBatch_InconclusiveIsPerFile(t *testing.T) {
 		{"ok@host"},
 		{"flaky@host"},
 		{"gone@host"},
-	}, mgr, 3, 5*time.Second)
+	}, mgr, BatchOptions{MaxConnections: 3, Timeout: 5 * time.Second})
 	assert.NoError(t, err)
 	require.Len(t, results, 3)
 
@@ -211,49 +207,27 @@ func TestValidateSegmentAvailabilityBatch_InconclusiveIsPerFile(t *testing.T) {
 }
 
 // TestValidateSegmentAvailabilityBatch_UnreportedSegmentsAreInconclusive
-// covers the other half of #861: StatMany emits nothing for ids it never
-// dispatched (cancelled context / elapsed sweep deadline). Treating that
+// covers the other half of #861: StatMany emits nothing for ids whose
+// per-chunk deadline elapsed before they were dispatched. Treating that
 // silence as "checked and present" made a truncated sweep declare a file
-// healthy on no evidence at all.
+// healthy on no evidence at all — it must instead mark the result
+// inconclusive.
 func TestValidateSegmentAvailabilityBatch_UnreportedSegmentsAreInconclusive(t *testing.T) {
 	fp := fakepool.New()
+	// Every stat blocks past the chunk deadline, so the ids are abandoned
+	// without ever reporting a result.
+	fp.SetDefaultBehavior(fakepool.SegmentBehavior{Latency: 200 * time.Millisecond})
 	mgr := &validationTestPoolManager{client: fp}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
 	results, err := ValidateSegmentAvailabilityBatch(
-		ctx, [][]string{{"a@host", "b@host"}}, mgr, 1, 5*time.Second)
+		context.Background(), [][]string{{"a@host", "b@host"}}, mgr,
+		BatchOptions{MaxConnections: 2, Timeout: 10 * time.Millisecond})
 	assert.NoError(t, err)
 	require.Len(t, results, 1)
 
 	assert.Zero(t, results[0].MissingCount)
 	assert.Empty(t, results[0].MissingIDs)
-	assert.Equal(t, 2, results[0].ErrorCount)
+	assert.Equal(t, 2, results[0].UnresolvedCount)
 	assert.True(t, results[0].Inconclusive())
-	assert.ErrorIs(t, results[0].Err, context.Canceled)
-}
-
-// TestValidateSegmentAvailabilityDetailed_TransientErrorIsInconclusive
-// mirrors the batch guard on the detailed path.
-func TestValidateSegmentAvailabilityDetailed_TransientErrorIsInconclusive(t *testing.T) {
-	fp := fakepool.New()
-	mgr := &validationTestPoolManager{client: fp}
-
-	segs := []*metapb.SegmentData{
-		{Id: "ok@host", StartOffset: 0, EndOffset: 999},
-		{Id: "flaky@host", StartOffset: 0, EndOffset: 999},
-	}
-	fp.SetBehavior("flaky@host", fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
-
-	result, err := ValidateSegmentAvailabilityDetailed(
-		context.Background(), segs, mgr, 2, 100, nil, 5*time.Second)
-	assert.NoError(t, err)
-
-	assert.Zero(t, result.MissingCount)
-	assert.Empty(t, result.MissingIDs)
-	assert.Empty(t, result.MissingSegments)
-	assert.Equal(t, 1, result.ErrorCount)
-	assert.True(t, result.Inconclusive())
-	assert.ErrorIs(t, result.Err, nntppool.ErrConnectionDied)
+	assert.ErrorIs(t, results[0].Err, context.DeadlineExceeded)
 }


### PR DESCRIPTION
Fixes #861

## Problem

`ValidateSegmentAvailabilityBatch` counted **every** non-nil `StatManyResult.Err` as a missing article. A dead connection, timeout, cancellation, auth failure, quota, 502 or an exhausted pool inflated `MissingCount` and pushed the segment's message-id into `MissingIDs` — which `classifyHoles` then persisted into the file's known-hole map on a `degraded` verdict. Since a clean STAT sweep deliberately preserves known holes, one transient provider blip left a **permanent** false hole that no later successful check could clear.

Two related holes in the same sweep:

- `StatMany` emits nothing for ids it never dispatched, and drops in-flight results, when its context ends. Nothing checked `statCtx.Err()` or the unanswered ids afterwards, so a truncated sweep passed for a clean one — a file could be declared healthy on zero evidence.
- Pool-unavailable (`valErr`) produced `EventTypeCheckFailed`, which walks the corrupted/retry path: an outage burned the retry budget and eventually triggered an ARR re-download of a perfectly good file.

## Fix

**`internal/usenet/validation.go`** — only `errors.Is(err, nntppool.ErrArticleNotFound)` counts as a miss, matching the guard `usenet_reader.go:622` already applies before padding a hole on the streaming path. Everything else increments a new per-file `ErrorCount` and sets `Err`, which `ValidationResult.Inconclusive()` reports. After the drain, ids still owed an answer are attributed to their files as inconclusive too (wrapping `statCtx.Err()` when there is one). Both the batch and the detailed path are covered.

**`internal/health/checker.go`** — a new `EventTypeCheckInconclusive`. `judgeValidation` returns it for `valErr != nil || result.Inconclusive()`, **before** the missing-count verdict, so a sweep that hit both real misses and operational errors persists nothing.

**`internal/health/worker.go` + `internal/database/health_repository.go`** — a new `UpdateTypeInconclusive` that only moves `scheduled_check_at` (+30 min) and the error text. The record is restored to the status it held before the cycle set it to `checking`, and neither `retry_count` nor `repair_retry_count` advances. No hole classification, no hole persistence, no repair trigger.

## Known gap (upstream)

The issue's last suspicion is real and **not** fixable here. In `nntppool` (`nntp.go`, unchanged through v4.17.0) the exhaustion path is:

```go
if hasResp {
    respCh <- lastResp          // a main provider's saved 430 wins…
} else if lastErr != nil {
    respCh <- Response{Err: fmt.Errorf("nntp: all providers exhausted: %w", lastErr)}
}
```

STAT is not raceable (`messageIDOf` returns nil for STAT), so when a main returns 430 and every backup then fails operationally, `lastErr` is discarded and the saved 430 is delivered. AltMount receives `ErrArticleNotFound` with no signal that backup verification never happened, so that one case still reads as a definitive miss. The precedence needs to change in `javi11/nntppool` — a 430 should not outrank an operational error from a provider that never gave a definitive answer.

## Tests

New coverage in `internal/usenet/validation_test.go` and `internal/health/`:

- each operational error class (connection died, quota, 502, auth, deadline, exhausted pool) → inconclusive, zero missing, zero hole ids
- 430/423 → still a genuine miss
- inconclusive is per-file: a flaky file does not taint healthy or genuinely-broken siblings in the same batch
- cancelled sweep → unreported ids are inconclusive, not silently clean
- `CheckFilesBatch`: transient error → `EventTypeCheckInconclusive`, `Classification` nil, **no `KnownHoles` written to metadata**
- worker: no retry consumed, prior status restored (`degraded`/`repair_triggered` survive; a stale `checking` falls back to `pending`), no ARR rescan even at exhausted retries
- full cycle end-to-end against a transiently-failing fake pool asserts the persisted row is untouched apart from the pushed-out schedule

`newRepairTestEnv` now defaults to a fakepool answering 430 rather than a dead pool manager, so the existing repair E2E flows still exercise genuine corruption (a dead pool is no longer corruption). The pool-down batch test builds the failing manager explicitly.

`go build ./... && go test ./...` green.