### PR TITLE
fix(health): make cancel work for scheduled cycle checks

### DIFF
--- a/internal/health/repair_e2e_test.go
+++ b/internal/health/repair_e2e_test.go
@@ -100,6 +100,13 @@ type repairTestEnv struct {
 
 func newRepairTestEnv(t *testing.T, tempDir string, arrsErr error, configure ...func(*config.Config)) *repairTestEnv {
 	t.Helper()
+	return newRepairTestEnvWithPool(t, tempDir, arrsErr, &mockPoolManager{}, configure...)
+}
+
+// newRepairTestEnvWithPool is newRepairTestEnv with an injectable pool.Manager, so tests
+// can block or fail the segment-availability sweep at a controlled point.
+func newRepairTestEnvWithPool(t *testing.T, tempDir string, arrsErr error, poolManager pool.Manager, configure ...func(*config.Config)) *repairTestEnv {
+	t.Helper()
 
 	db, err := sql.Open("sqlite3", "file::memory:?cache=shared&mode=memory")
 	require.NoError(t, err)
@@ -165,7 +172,7 @@ func newRepairTestEnv(t *testing.T, tempDir string, arrsErr error, configure ...
 	healthChecker := NewHealthChecker(
 		healthRepo,
 		metadataService,
-		&mockPoolManager{},
+		poolManager,
 		configManager.GetConfig,
 		&MockRcloneClient{},
 	)

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -57,6 +57,12 @@ type WorkerStats struct {
 	ErrorCount             int64        `json:"error_count"`
 }
 
+// activeCheck is one in-flight health check. Registrations are compared by pointer so a
+// releasing owner never removes an entry another owner has since registered for the same path.
+type activeCheck struct {
+	cancel context.CancelFunc
+}
+
 // HealthWorker manages continuous health monitoring and manual check requests
 type HealthWorker struct {
 	healthChecker       *HealthChecker
@@ -76,7 +82,7 @@ type HealthWorker struct {
 	mu           sync.RWMutex
 
 	// Active checks tracking for cancellation
-	activeChecks   map[string]context.CancelFunc // filePath -> cancel function
+	activeChecks   map[string]*activeCheck // filePath -> in-flight check
 	activeChecksMu sync.RWMutex
 
 	// Statistics
@@ -107,7 +113,7 @@ func NewHealthWorker(
 		progressBroadcaster: broadcaster,
 		status:              WorkerStatusStopped,
 		stopChan:            make(chan struct{}),
-		activeChecks:        make(map[string]context.CancelFunc),
+		activeChecks:        make(map[string]*activeCheck),
 		stats: WorkerStats{
 			Status: WorkerStatusStopped,
 		},
@@ -220,13 +226,13 @@ func (hw *HealthWorker) CancelHealthCheck(ctx context.Context, filePath string) 
 	hw.activeChecksMu.Lock()
 	defer hw.activeChecksMu.Unlock()
 
-	cancelFunc, exists := hw.activeChecks[filePath]
+	check, exists := hw.activeChecks[filePath]
 	if !exists {
 		return fmt.Errorf("no active health check found for file: %s", filePath)
 	}
 
 	// Cancel the context
-	cancelFunc()
+	check.cancel()
 
 	// Remove from active checks
 	delete(hw.activeChecks, filePath)
@@ -694,6 +700,43 @@ func (hw *HealthWorker) prepareRepairNotificationUpdate(ctx context.Context, fh 
 	return update, sideEffect
 }
 
+// beginBatchChecks registers a cancellable context per file of a cycle batch, so a file the
+// scheduled cycle is checking can be cancelled through CancelHealthCheck exactly like a manual
+// check-now. Each context is an independent child: cancelling one file neither aborts the shared
+// cross-file sweep nor disturbs the other files — the cancelled file's result is discarded
+// instead. Returns the per-file contexts and a release func that clears the registrations.
+func (hw *HealthWorker) beginBatchChecks(ctx context.Context, filePaths []string) (map[string]context.Context, func()) {
+	fileCtxs := make(map[string]context.Context, len(filePaths))
+	entries := make(map[string]*activeCheck, len(filePaths))
+
+	hw.activeChecksMu.Lock()
+	for _, filePath := range filePaths {
+		if _, exists := hw.activeChecks[filePath]; exists {
+			continue
+		}
+		fileCtx, cancel := context.WithCancel(ctx)
+		entry := &activeCheck{cancel: cancel}
+		fileCtxs[filePath] = fileCtx
+		entries[filePath] = entry
+		hw.activeChecks[filePath] = entry
+	}
+	hw.activeChecksMu.Unlock()
+
+	return fileCtxs, func() {
+		hw.activeChecksMu.Lock()
+		for filePath, entry := range entries {
+			if hw.activeChecks[filePath] == entry {
+				delete(hw.activeChecks, filePath)
+			}
+		}
+		hw.activeChecksMu.Unlock()
+
+		for _, entry := range entries {
+			entry.cancel()
+		}
+	}
+}
+
 // performDirectCheck performs a health check on a single file using the HealthChecker
 func (hw *HealthWorker) performDirectCheck(ctx context.Context, filePath string) error {
 	// Create cancellable context for this check
@@ -701,14 +744,17 @@ func (hw *HealthWorker) performDirectCheck(ctx context.Context, filePath string)
 	defer cancel()
 
 	// Track active check
+	entry := &activeCheck{cancel: cancel}
 	hw.activeChecksMu.Lock()
-	hw.activeChecks[filePath] = cancel
+	hw.activeChecks[filePath] = entry
 	hw.activeChecksMu.Unlock()
 
 	// Ensure cleanup on exit
 	defer func() {
 		hw.activeChecksMu.Lock()
-		delete(hw.activeChecks, filePath)
+		if hw.activeChecks[filePath] == entry {
+			delete(hw.activeChecks, filePath)
+		}
 		hw.activeChecksMu.Unlock()
 	}()
 
@@ -853,6 +899,10 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 		slog.ErrorContext(ctx, "Failed to bulk-set files to checking", "count", len(checkingPaths), "error", err)
 	}
 
+	// Make every file of this batch cancellable for as long as it is 'checking'.
+	fileCtxs, releaseChecks := hw.beginBatchChecks(ctx, checkingPaths)
+	defer releaseChecks()
+
 	// Process files in parallel with bounded concurrency
 	p := pool.New().WithMaxGoroutines(maxJobs)
 	var results []database.HealthStatusUpdate
@@ -887,7 +937,15 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 	for i, fileHealth := range unhealthyFiles {
 		fh := fileHealth // Capture for closure
 		event := events[i]
+		fileCtx := fileCtxs[fh.FilePath]
 		p.Go(func() {
+			// A cancelled check must not land its result: CancelHealthCheck already put the
+			// record back to pending, and the repair side effects below would undo that.
+			if fileCtx != nil && fileCtx.Err() != nil {
+				slog.InfoContext(ctx, "Discarding result of cancelled health check", "file_path", fh.FilePath)
+				return
+			}
+
 			updatePtr, sideEffect := hw.prepareUpdateForResult(ctx, fh, event)
 			updatePtr.ExpectedStatus = &checkingStatus
 			if sideEffect != nil {

--- a/internal/health/worker_cancel_test.go
+++ b/internal/health/worker_cancel_test.go
@@ -1,0 +1,93 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/pool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blockingPoolManager parks the segment-availability sweep so a test can observe and act
+// on a cycle while its files are still in 'checking'.
+type blockingPoolManager struct {
+	mockPoolManager
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (m *blockingPoolManager) GetPool() (pool.NntpClient, error) {
+	m.once.Do(func() { close(m.entered) })
+	<-m.release
+	return nil, errors.New("no pool available (test mock)")
+}
+
+// TestRunHealthCheckCycle_CancelDuringBatchCheck verifies that a file being checked by the
+// scheduled worker cycle — not just by a manual check-now — is cancellable: it is registered
+// as an active check, and cancelling it suppresses that file's result write and repair
+// side effects instead of letting the cycle finish it.
+func TestRunHealthCheckCycle_CancelDuringBatchCheck(t *testing.T) {
+	tempDir := t.TempDir()
+	bp := &blockingPoolManager{entered: make(chan struct{}), release: make(chan struct{})}
+	env := newRepairTestEnvWithPool(t, tempDir, nil, bp)
+
+	ctx := context.Background()
+	filePath := "series/show.s01e01.mkv"
+	libraryPath := "/media/library/show.s01e01.mkv"
+	maxRetries := 3
+
+	meta := validSegmentMeta(env.metadataService, 1024)
+	require.NoError(t, env.metadataService.WriteFileMetadata(filePath, meta))
+
+	// Last retry: without cancellation this cycle would trigger ARR repair.
+	insertFileHealth(t, env.db, filePath, libraryPath, maxRetries-1, maxRetries)
+
+	done := make(chan error, 1)
+	go func() { done <- env.hw.runHealthCheckCycle(ctx) }()
+
+	<-bp.entered // the sweep is in flight; the record is 'checking'
+
+	require.True(t, env.hw.IsCheckActive(filePath),
+		"a file being checked by the worker cycle must be reported as an active check")
+	require.NoError(t, env.hw.CancelHealthCheck(ctx, filePath))
+
+	close(bp.release)
+	require.NoError(t, <-done)
+
+	env.mockARRs.mu.Lock()
+	calls := len(env.mockARRs.calls)
+	env.mockARRs.mu.Unlock()
+	assert.Zero(t, calls, "a cancelled check must not trigger repair side effects")
+
+	fh, err := env.healthRepo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	assert.Equal(t, database.HealthStatusPending, fh.Status,
+		"a cancelled check must leave the record pending, not write its result")
+
+	assert.False(t, env.hw.IsCheckActive(filePath),
+		"the cycle must release its active-check registrations when it finishes")
+}
+
+// TestRunHealthCheckCycle_ReleasesActiveChecks verifies an uncancelled cycle leaves no
+// stale active-check registrations behind, which would block later cancel requests.
+func TestRunHealthCheckCycle_ReleasesActiveChecks(t *testing.T) {
+	tempDir := t.TempDir()
+	env := newRepairTestEnv(t, tempDir, nil)
+
+	ctx := context.Background()
+	filePath := "series/show.s01e02.mkv"
+
+	meta := validSegmentMeta(env.metadataService, 1024)
+	require.NoError(t, env.metadataService.WriteFileMetadata(filePath, meta))
+	insertFileHealth(t, env.db, filePath, "/media/library/show.s01e02.mkv", 0, 3)
+
+	require.NoError(t, env.hw.runHealthCheckCycle(ctx))
+
+	assert.False(t, env.hw.IsCheckActive(filePath))
+}


### PR DESCRIPTION
## Problem

Cancelling a health check from the UI did nothing for almost every file.

`runHealthCheckCycle` — the path that puts nearly every file into `checking` — never registered anything in `hw.activeChecks`. Only `performDirectCheck` (the manual "check now" path) did. So for a file the scheduled cycle was checking, `IsCheckActive()` returned false and `handleCancelHealthCheck` short-circuited with a 409 *"No active health check found"* before ever reaching the worker. `handleDeleteHealth` and `handleRestartHealthChecksBulk` silently skipped cancellation for the same reason.

## Fix

`internal/health/worker.go`:

- New `beginBatchChecks` registers a cancellable child context per file of the cycle batch, right after `SetFilesCheckingBulk`, released via `defer` — so a file is cancellable for as long as it is `checking`.
- Phase B discards the result of a cancelled file: no DB write, no ARR repair trigger, no VFS notify. The existing `ExpectedStatus: checking` guard already stops the bulk write from clobbering the `pending` status `CancelHealthCheck` sets; this stops the repair side effects from undoing it.
- `activeChecks` entries are now `*activeCheck` compared by pointer, so a releasing owner cannot delete a registration another owner has since made for the same path.

Cancelling one file does not abort the shared cross-file `StatMany` sweep or affect the other files in the batch — its result is simply thrown away.

## Test plan

- [x] `internal/health/worker_cancel_test.go` (new): one test blocks the sweep mid-cycle via an injectable `pool.Manager`, asserts the file is reported active, cancels it, and verifies it stays `pending` with zero ARR calls; one asserts no stale registrations leak after a normal cycle. Both fail before this change (`Should be true — a file being checked by the worker cycle must be reported as an active check`).
- [x] `newRepairTestEnv` gained a `newRepairTestEnvWithPool` variant to enable that block.
- [x] `go vet ./internal/health/` clean.
- [x] `go test ./... -race -count=1` passes.