### PR TITLE
feat(health): stop checking a file once its failure threshold is exceeded

### DIFF
--- a/docs/docs/3. Configuration/health-monitoring.md
+++ b/docs/docs/3. Configuration/health-monitoring.md
@@ -72,6 +72,10 @@ A file whose damage exceeds the hard-coded playback caps (a run longer than 4 co
 
 **To make AltMount stricter** — repair on any missing segment, no degraded grace period — set **Acceptable Missing** to **0%**. This also applies at import time: a freshly grabbed release with even one confirmed missing segment is rejected immediately, so your ARR can search for an alternate release, instead of importing degraded.
 
+The threshold also decides when a health check can **stop early**. Once a file's confirmed missing segments put it irreversibly above the threshold, further checking cannot change the outcome, so AltMount stops checking that file and moves its remaining connection budget to the other files in the batch. At 0% tolerance the first confirmed missing article settles the file. Results from a check that stopped early are labelled as partial in the UI: their segment counts are a subset of the file, not a complete map of the damage.
+
+Only a confirmed *article not found* response (NNTP 430/423) counts toward the threshold. Connection failures, timeouts, and provider outages never mark a segment as missing — a check that could not resolve some of its segments is recorded as a failed attempt and retried later, so a transient network problem cannot condemn a file.
+
 **Scheduling & Concurrency:**
 
 | Setting | Default | Description |

--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthItemCard.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthItemCard.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../../../lib/utils";
 import { type FileHealth, HealthPriority } from "../../../../types/api";
 import { HealthItemActionsMenu } from "./HealthItemActionsMenu";
+import { PartialCheckBadge } from "./PartialCheckBadge";
 import { PlaybackImpactBadge } from "./PlaybackImpactBadge";
 
 interface HealthItemCardProps {
@@ -59,10 +60,11 @@ export const HealthItemCard = memo(function HealthItemCard({
 }: HealthItemCardProps) {
 	const [isExpanded, setIsExpanded] = useState(false);
 
-	const playbackImpact = useMemo(
-		() => parseHealthErrorDetails(item.error_details)?.playback_impact ?? null,
+	const errorDetails = useMemo(
+		() => parseHealthErrorDetails(item.error_details),
 		[item.error_details],
 	);
+	const playbackImpact = errorDetails?.playback_impact ?? null;
 
 	// Reuse status icon logic from HealthTableRow
 	const getNextPriority = (current: HealthPriority): HealthPriority => {
@@ -136,6 +138,7 @@ export const HealthItemCard = memo(function HealthItemCard({
 						<div className="mt-2 flex flex-wrap gap-2">
 							<HealthBadge status={item.status} isMasked={item.is_masked} />
 							{playbackImpact && <PlaybackImpactBadge impact={playbackImpact} />}
+							{errorDetails && <PartialCheckBadge details={errorDetails} />}
 
 							<button
 								type="button"

--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthTableRow.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthTableRow.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../../../lib/utils";
 import { type FileHealth, HealthPriority } from "../../../../types/api";
 import { HealthItemActionsMenu } from "./HealthItemActionsMenu";
+import { PartialCheckBadge } from "./PartialCheckBadge";
 import { PlaybackImpactBadge } from "./PlaybackImpactBadge";
 
 interface HealthTableRowProps {
@@ -56,10 +57,11 @@ export const HealthTableRow = memo(function HealthTableRow({
 		}
 	}, [item.metadata]);
 
-	const playbackImpact = useMemo(
-		() => parseHealthErrorDetails(item.error_details)?.playback_impact ?? null,
+	const errorDetails = useMemo(
+		() => parseHealthErrorDetails(item.error_details),
 		[item.error_details],
 	);
+	const playbackImpact = errorDetails?.playback_impact ?? null;
 
 	const getNextPriority = (current: HealthPriority): HealthPriority => {
 		switch (current) {
@@ -180,6 +182,7 @@ export const HealthTableRow = memo(function HealthTableRow({
 				<div className="flex flex-wrap items-center gap-2">
 					<HealthBadge status={item.status} isMasked={item.is_masked} />
 					{playbackImpact && <PlaybackImpactBadge impact={playbackImpact} />}
+					{errorDetails && <PartialCheckBadge details={errorDetails} />}
 				</div>
 				{/* Show last_error for repair failures and general errors */}
 				{item.last_error && (

--- a/frontend/src/pages/HealthPage/components/HealthTable/PartialCheckBadge.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/PartialCheckBadge.tsx
@@ -1,0 +1,40 @@
+import { CircleSlash } from "lucide-react";
+import type { HealthErrorDetails } from "../../../../types/api";
+
+interface PartialCheckBadgeProps {
+	details: HealthErrorDetails;
+}
+
+// PartialCheckBadge marks a result produced by a check that stopped once the
+// file's failure threshold was irreversibly exceeded. The verdict is final,
+// but the segment counts are partial and the missing-segment map is
+// incomplete by design — so the badge exists to stop the numbers reading as a
+// full survey of the damage.
+export function PartialCheckBadge({ details }: PartialCheckBadgeProps) {
+	if (!details.terminated_early) {
+		return null;
+	}
+
+	const checked = details.sampled ?? 0;
+	const total = details.total_articles ?? 0;
+	const missing = details.missing_articles ?? 0;
+
+	const missingText =
+		missing > 0
+			? `Failed after ${missing} confirmed missing segment${missing === 1 ? "" : "s"}`
+			: "Check stopped early";
+	const scopeText =
+		total > 0
+			? ` — stopped after ${checked.toLocaleString()} of ${total.toLocaleString()} segments`
+			: "";
+
+	return (
+		<span
+			className="badge badge-ghost badge-xs gap-1"
+			title={details.termination_reason || `${missingText}${scopeText}`}
+		>
+			<CircleSlash className="h-3 w-3" aria-hidden="true" />
+			{`${missingText}${scopeText}`}
+		</span>
+	);
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -244,6 +244,13 @@ export interface HealthErrorDetails {
 	total_articles?: number;
 	sampled?: number;
 	playback_impact?: PlaybackImpact;
+	// Segments whose availability was never established (transport failures, or
+	// ids the sweep never reached). Deliberately not counted as missing.
+	unresolved_segments?: number;
+	// Set when the check stopped before examining every planned segment, which
+	// makes `sampled` a partial count and the missing-segment map incomplete.
+	terminated_early?: boolean;
+	termination_reason?: string;
 }
 
 export interface HealthCleanupRequest {

--- a/internal/database/error_details.go
+++ b/internal/database/error_details.go
@@ -17,6 +17,19 @@ type HealthErrorDetails struct {
 	TotalArticles   int           `json:"total_articles,omitempty"`
 	Sampled         int           `json:"sampled,omitempty"`
 	PlaybackImpact  *holes.Impact `json:"playback_impact,omitempty"`
+
+	// UnresolvedSegments counts segments whose availability was never
+	// established — transport failures, or ids the sweep never reached.
+	// They are deliberately not counted as missing.
+	UnresolvedSegments int `json:"unresolved_segments,omitempty"`
+
+	// TerminatedEarly marks a result produced by a check that stopped before
+	// examining every planned segment, so Sampled is a partial count and the
+	// missing-segment map is incomplete by design.
+	TerminatedEarly bool `json:"terminated_early,omitempty"`
+
+	// TerminationReason explains why the check stopped early.
+	TerminationReason string `json:"termination_reason,omitempty"`
 }
 
 // Marshal renders the envelope for storage, returning nil on the (practically

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -246,6 +246,28 @@ func (hc *HealthChecker) judgeValidation(ctx context.Context, prep preparedCheck
 		return event
 	}
 
+	// Segments whose availability was never established make the sweep
+	// inconclusive: the file can be neither cleared nor condemned on evidence
+	// that was not gathered. A settled verdict wins over that noise — once the
+	// missing-segment threshold is irreversibly exceeded, no amount of further
+	// checking could change the outcome.
+	if result.UnresolvedCount > 0 && !result.TerminatedEarly {
+		event.Type = EventTypeCheckFailed
+		event.Status = database.HealthStatusCorrupted
+		event.Error = fmt.Errorf("%d of %d segments could not be checked (provider or connection failure)",
+			result.UnresolvedCount, result.UnresolvedCount+result.TotalChecked)
+		details := database.HealthErrorDetails{
+			ErrorType:          "segments_unresolved",
+			Message:            event.Error.Error(),
+			MissingArticles:    result.MissingCount,
+			TotalArticles:      prep.totalSegments,
+			Sampled:            result.TotalChecked,
+			UnresolvedSegments: result.UnresolvedCount,
+		}
+		event.Details = details.Marshal()
+		return event
+	}
+
 	if result.MissingCount > 0 {
 		event.Type = EventTypeFileCorrupted
 		event.Status = database.HealthStatusCorrupted
@@ -253,11 +275,18 @@ func (hc *HealthChecker) judgeValidation(ctx context.Context, prep preparedCheck
 			result.MissingCount, result.TotalChecked)
 		event.Classification = hc.classifyHoles(ctx, prep.filePath, result)
 		details := database.HealthErrorDetails{
-			ErrorType:       "missing_segments",
-			MissingArticles: result.MissingCount,
-			TotalArticles:   prep.totalSegments,
-			Sampled:         result.TotalChecked,
-			PlaybackImpact:  event.Classification,
+			ErrorType:          "missing_segments",
+			MissingArticles:    result.MissingCount,
+			TotalArticles:      prep.totalSegments,
+			Sampled:            result.TotalChecked,
+			UnresolvedSegments: result.UnresolvedCount,
+			PlaybackImpact:     event.Classification,
+			TerminatedEarly:    result.TerminatedEarly,
+		}
+		if result.TerminatedEarly {
+			details.TerminationReason = fmt.Sprintf(
+				"missing-segment threshold exceeded after %d of %d segments",
+				result.TotalChecked, prep.totalSegments)
 		}
 		event.Details = details.Marshal()
 		return event
@@ -279,13 +308,11 @@ func (hc *HealthChecker) CheckFile(ctx context.Context, filePath string, opts ..
 		return *prep.earlyEvent
 	}
 
-	cfg := hc.configGetter()
 	results, err := usenet.ValidateSegmentAvailabilityBatch(
 		ctx,
 		[][]string{prep.sampledIDs},
 		hc.poolManager,
-		cfg.GetMaxConnectionsForHealthChecks(),
-		cfg.GetHealthReadTimeout(),
+		hc.batchOptions([]preparedCheck{prep}),
 	)
 
 	var result usenet.ValidationResult
@@ -293,6 +320,34 @@ func (hc *HealthChecker) CheckFile(ctx context.Context, filePath string, opts ..
 		result = results[0]
 	}
 	return hc.judgeValidation(ctx, prep, result, err)
+}
+
+// batchOptions builds the sweep configuration for a set of prepared checks,
+// including the fast-fail policy. A file stops consuming stats as soon as its
+// confirmed missing segments irreversibly exceed the configured
+// acceptable-missing threshold: that predicate is monotonic in the miss count,
+// so no amount of further checking could bring the file back under it, and the
+// segments it would have checked cannot change the repair decision.
+//
+// Only confirmed article-not-found responses feed the count (the sweep never
+// classifies a transport failure as missing), and the file's full segment
+// count is the denominator, so the policy matches the one health.classifyHoles
+// applies to the final verdict.
+func (hc *HealthChecker) batchOptions(preps []preparedCheck) usenet.BatchOptions {
+	cfg := hc.configGetter()
+	acceptable := cfg.GetAcceptableMissingSegmentsPercentage()
+
+	return usenet.BatchOptions{
+		MaxConnections: cfg.GetMaxConnectionsForHealthChecks(),
+		Timeout:        cfg.GetHealthReadTimeout(),
+		ShouldStop: func(fileIdx int, result usenet.ValidationResult) bool {
+			if fileIdx >= len(preps) {
+				return false
+			}
+			return holes.ExceedsAcceptableMissing(
+				result.MissingCount, preps[fileIdx].totalSegments, acceptable)
+		},
+	}
 }
 
 // prepareConcurrency bounds the parallel metadata-read phase of a batch check.
@@ -327,13 +382,11 @@ func (hc *HealthChecker) CheckFilesBatch(ctx context.Context, filePaths []string
 		}
 	}
 
-	cfg := hc.configGetter()
 	results, valErr := usenet.ValidateSegmentAvailabilityBatch(
 		ctx,
 		perFileIDs,
 		hc.poolManager,
-		cfg.GetMaxConnectionsForHealthChecks(),
-		cfg.GetHealthReadTimeout(),
+		hc.batchOptions(preps),
 	)
 
 	events := make([]HealthEvent, len(preps))

--- a/internal/health/checker_batch_test.go
+++ b/internal/health/checker_batch_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/javi11/altmount/internal/config"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/pool"
 	"github.com/javi11/altmount/internal/testsupport/fakepool"
@@ -26,9 +27,9 @@ func (m *fakeClientPoolManager) HasPool() bool                     { return true
 
 // newBatchTestEnv builds a repair test env whose checker and worker use a
 // fakepool-backed pool manager instead of the always-failing mock.
-func newBatchTestEnv(t *testing.T, tempDir string, client pool.NntpClient) *repairTestEnv {
+func newBatchTestEnv(t *testing.T, tempDir string, client pool.NntpClient, configure ...func(*config.Config)) *repairTestEnv {
 	t.Helper()
-	env := newRepairTestEnv(t, tempDir, nil)
+	env := newRepairTestEnv(t, tempDir, nil, configure...)
 
 	pm := &fakeClientPoolManager{client: client}
 	env.healthChecker = NewHealthChecker(

--- a/internal/health/checker_fastfail_test.go
+++ b/internal/health/checker_fastfail_test.go
@@ -1,0 +1,198 @@
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/nntppool/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeMultiSegmentFile writes metadata for a file made of segCount segments
+// and returns their IDs in order, so tests can make an arbitrary segment miss.
+func writeMultiSegmentFile(t *testing.T, env *repairTestEnv, filePath string, segCount int) []string {
+	t.Helper()
+	const segSize = int64(1024)
+
+	segs := make([]*metapb.SegmentData, segCount)
+	ids := make([]string, segCount)
+	for i := range segs {
+		ids[i] = fmt.Sprintf("seg-%s-%d@test.example.com", filePath, i)
+		segs[i] = &metapb.SegmentData{
+			Id:          ids[i],
+			SegmentSize: segSize,
+			StartOffset: 0,
+			EndOffset:   segSize - 1,
+		}
+	}
+	meta := env.metadataService.CreateFileMetadata(
+		segSize*int64(segCount), "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		segs, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	require.NoError(t, env.metadataService.WriteFileMetadata(filePath, meta))
+	return ids
+}
+
+func parseDetails(t *testing.T, ev HealthEvent) database.HealthErrorDetails {
+	t.Helper()
+	require.NotNil(t, ev.Details, "event carries no error details")
+	var d database.HealthErrorDetails
+	require.NoError(t, json.Unmarshal([]byte(*ev.Details), &d))
+	return d
+}
+
+// TestCheckFilesBatch_TransportErrorIsNotCorruption is the correctness fix the
+// issue calls for: a connection failure must neither condemn a file nor let it
+// pass as healthy. It is a failed attempt, which the existing retry ladder
+// re-runs later.
+func TestCheckFilesBatch_TransportErrorIsNotCorruption(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+
+	client := fakepool.New()
+	env := newBatchTestEnv(t, t.TempDir(), client)
+
+	paths := []string{"complete/flaky.mkv", "complete/fine.mkv"}
+	flakyID := writeHealthyFile(t, env, paths[0])
+	writeHealthyFile(t, env, paths[1])
+	client.SetBehavior(flakyID, fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
+
+	events := env.healthChecker.CheckFilesBatch(context.Background(), paths)
+	require.Len(t, events, 2)
+
+	assert.Equal(t, EventTypeCheckFailed, events[0].Type,
+		"a transport error is an inconclusive attempt, not corruption")
+	assert.NotEqual(t, EventTypeFileHealthy, events[0].Type,
+		"a segment we never resolved must not pass as available")
+	assert.Equal(t, EventTypeFileHealthy, events[1].Type, "sibling unaffected")
+}
+
+// TestCheckFilesBatch_TransportErrorPersistsNoHoles guards the latent bug the
+// old any-error-is-missing classification caused: phantom misses could reach a
+// degraded verdict and be written into the file's hole map, after which
+// playback zero-fills bytes that were never actually missing.
+func TestCheckFilesBatch_TransportErrorPersistsNoHoles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+
+	client := fakepool.New()
+	env := newBatchTestEnv(t, t.TempDir(), client, func(c *config.Config) {
+		checkAll := true
+		c.Health.CheckAllSegments = &checkAll
+		c.Health.AcceptableMissingSegmentsPercentage = 100 // never fail on misses alone
+	})
+
+	const path = "complete/blip.mkv"
+	ids := writeMultiSegmentFile(t, env, path, 20)
+	client.SetBehavior(ids[3], fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
+
+	events := env.healthChecker.CheckFilesBatch(context.Background(), []string{path})
+	require.Len(t, events, 1)
+	assert.Equal(t, EventTypeCheckFailed, events[0].Type)
+
+	meta, err := env.metadataService.ReadFileMetadata(path)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+	assert.Empty(t, meta.KnownHoles, "a transport blip must never be recorded as a hole")
+}
+
+// TestCheckFilesBatch_FastFailStopsDoomedFileOnly is the feature end to end: a
+// file that has already exceeded its threshold stops consuming stats while its
+// batch siblings are swept in full.
+func TestCheckFilesBatch_FastFailStopsDoomedFileOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+
+	const segCount = 20
+	client := fakepool.New()
+	env := newBatchTestEnv(t, t.TempDir(), client, func(c *config.Config) {
+		checkAll := true
+		c.Health.CheckAllSegments = &checkAll
+		c.Health.AcceptableMissingSegmentsPercentage = 0 // zero tolerance
+	})
+
+	paths := []string{"complete/doomed.mkv", "complete/fine.mkv"}
+	doomedIDs := writeMultiSegmentFile(t, env, paths[0], segCount)
+	writeMultiSegmentFile(t, env, paths[1], segCount)
+	client.SetBehavior(doomedIDs[0], fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+	events := env.healthChecker.CheckFilesBatch(context.Background(), paths)
+	require.Len(t, events, 2)
+
+	assert.Equal(t, EventTypeFileCorrupted, events[0].Type)
+	assert.Equal(t, EventTypeFileHealthy, events[1].Type)
+
+	doomed := parseDetails(t, events[0])
+	assert.True(t, doomed.TerminatedEarly, "doomed file records a partial check")
+	assert.Equal(t, 1, doomed.MissingArticles)
+	assert.Equal(t, segCount, doomed.TotalArticles)
+	assert.Less(t, doomed.Sampled, segCount, "stopped short of a full sweep")
+
+	assert.Less(t, client.StatCalls(), int64(2*segCount),
+		"fast-fail must save stat calls versus sweeping both files in full")
+}
+
+// TestCheckFilesBatch_NoFastFailWhenToleranceUnreached proves the threshold is
+// respected rather than any miss terminating the sweep: with tolerance above
+// the observed miss rate the file is swept in full, preserving the hole map.
+func TestCheckFilesBatch_NoFastFailWhenToleranceUnreached(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+
+	const segCount = 20
+	client := fakepool.New()
+	env := newBatchTestEnv(t, t.TempDir(), client, func(c *config.Config) {
+		checkAll := true
+		c.Health.CheckAllSegments = &checkAll
+		c.Health.AcceptableMissingSegmentsPercentage = 50 // 1/20 = 5%, well under
+	})
+
+	const path = "complete/tolerated.mkv"
+	ids := writeMultiSegmentFile(t, env, path, segCount)
+	client.SetBehavior(ids[0], fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+	events := env.healthChecker.CheckFilesBatch(context.Background(), []string{path})
+	require.Len(t, events, 1)
+
+	d := parseDetails(t, events[0])
+	assert.False(t, d.TerminatedEarly)
+	assert.Equal(t, segCount, d.Sampled, "every segment was checked")
+	assert.Equal(t, int64(segCount), client.StatCalls())
+}
+
+// TestCheckFile_FastFailParityWithBatch keeps the manual single-file check on
+// the same semantics as the batch sweep.
+func TestCheckFile_FastFailParityWithBatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+
+	const segCount = 20
+	client := fakepool.New()
+	env := newBatchTestEnv(t, t.TempDir(), client, func(c *config.Config) {
+		checkAll := true
+		c.Health.CheckAllSegments = &checkAll
+		c.Health.AcceptableMissingSegmentsPercentage = 0
+	})
+
+	const path = "complete/solo.mkv"
+	ids := writeMultiSegmentFile(t, env, path, segCount)
+	client.SetBehavior(ids[0], fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+	event := env.healthChecker.CheckFile(context.Background(), path)
+	assert.Equal(t, EventTypeFileCorrupted, event.Type)
+	assert.True(t, parseDetails(t, event).TerminatedEarly)
+	assert.Less(t, client.StatCalls(), int64(segCount))
+}

--- a/internal/usenet/validation.go
+++ b/internal/usenet/validation.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand"
-	"sort"
 	"time"
 
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/pool"
-	"github.com/javi11/altmount/internal/progress"
 	"github.com/javi11/nntppool/v4"
 )
 
@@ -23,134 +21,67 @@ func SelectSegmentsForValidation(segments []*metapb.SegmentData, samplePercentag
 	return selectSegmentsForValidation(segments, samplePercentage)
 }
 
-// MissingSegment identifies one unavailable segment together with the byte
-// range it covers in file coordinates, enabling playback-impact classification.
-type MissingSegment struct {
-	Index int    // index into the original segments slice
-	ID    string // Usenet message ID
-	Start int64  // inclusive file-coordinate byte range
-	End   int64
-}
-
-// ValidationResult holds detailed validation results
+// ValidationResult holds the outcome of a segment availability sweep for one
+// file. Segments fall into exactly three buckets: available, confirmed
+// missing (a 430/423 from the provider), and unresolved (a transport or
+// infrastructure failure, or an id the sweep never got to). TotalChecked
+// counts only the two resolved buckets, so a segment we learned nothing about
+// never dilutes the observed miss rate.
 type ValidationResult struct {
 	TotalChecked    int
 	MissingCount    int
+	UnresolvedCount int
 	MissingIDs      []string
-	MissingSegments []MissingSegment // same 50-entry cap as MissingIDs
+	// TerminatedEarly reports that the sweep stopped short of this file's
+	// planned samples because its verdict was already settled.
+	TerminatedEarly bool
 }
 
-// ValidateSegmentAvailabilityDetailed validates segments and returns detailed results
-// instead of failing fast on the first error.
-func ValidateSegmentAvailabilityDetailed(
-	ctx context.Context,
-	segments []*metapb.SegmentData,
-	poolManager pool.Manager,
-	maxConnections int,
-	samplePercentage int,
-	progressTracker progress.ProgressTracker,
-	timeout time.Duration,
-) (ValidationResult, error) {
-	result := ValidationResult{
-		MissingIDs: []string{},
-	}
+// maxTrackedMissingIDs caps the message-ids stored per file so a wholly dead
+// release cannot produce a huge metadata blob. MissingCount stays exact.
+const maxTrackedMissingIDs = 50
 
-	if len(segments) == 0 {
-		return result, nil
-	}
+// BatchOptions tunes a cross-file STAT sweep.
+type BatchOptions struct {
+	// MaxConnections bounds STATs in flight and also sets the chunk size the
+	// sweep dispatches in.
+	MaxConnections int
 
-	usenetPool, err := poolManager.GetPool()
-	if err != nil {
-		return result, fmt.Errorf("cannot validate segments: usenet connection pool unavailable: %w", err)
-	}
+	// Timeout is the per-item budget scaled into each chunk's deadline.
+	Timeout time.Duration
 
-	if usenetPool == nil {
-		return result, fmt.Errorf("cannot validate segments: usenet connection pool is nil")
-	}
-
-	segmentsToValidate := selectSegmentsForValidation(segments, samplePercentage)
-	result.TotalChecked = len(segmentsToValidate)
-
-	if maxConnections <= 0 {
-		maxConnections = 1
-	}
-
-	ids := make([]string, len(segmentsToValidate))
-	for i, seg := range segmentsToValidate {
-		ids[i] = seg.Id
-	}
-
-	// Segment identity (by message ID) → original index, so misses reported
-	// by StatMany can be mapped back to their file-coordinate byte range via
-	// the prefix-sum offset table.
-	indexByID := make(map[string]int, len(segments))
-	fileOffsets := make([]int64, len(segments))
-	var pos int64
-	for i, seg := range segments {
-		indexByID[seg.Id] = i
-		fileOffsets[i] = pos
-		pos += seg.EndOffset - seg.StartOffset + 1
-	}
-
-	statCtx, cancel := context.WithTimeout(ctx, pool.StatManyTimeout(len(ids), maxConnections, timeout))
-	defer cancel()
-
-	var validatedCount int
-	for r := range usenetPool.StatMany(statCtx, ids, nntppool.StatManyOptions{Concurrency: maxConnections}) {
-		if r.Err != nil {
-			slog.DebugContext(ctx, "missing segment",
-				"segment_id", r.MessageID,
-				"error", r.Err,
-			)
-			result.MissingCount++
-			if len(result.MissingIDs) < 50 { // cap stored entries to avoid huge metadata blobs
-				result.MissingIDs = append(result.MissingIDs, r.MessageID)
-				if idx, ok := indexByID[r.MessageID]; ok {
-					seg := segments[idx]
-					result.MissingSegments = append(result.MissingSegments, MissingSegment{
-						Index: idx,
-						ID:    r.MessageID,
-						Start: fileOffsets[idx],
-						End:   fileOffsets[idx] + (seg.EndOffset - seg.StartOffset),
-					})
-				}
-			}
-			continue
-		}
-
-		poolManager.IncArticlesDownloaded()
-		poolManager.UpdateDownloadProgress("", 100)
-
-		if progressTracker != nil {
-			validatedCount++
-			progressTracker.Update(validatedCount, result.TotalChecked)
-		}
-	}
-	sort.Slice(result.MissingSegments, func(i, j int) bool {
-		return result.MissingSegments[i].Index < result.MissingSegments[j].Index
-	})
-
-	return result, nil
+	// ShouldStop, when non-nil, is consulted after every chunk for each file
+	// still being swept. Returning true removes that file from the remaining
+	// chunks, leaving its siblings unaffected. Callers must only return true
+	// for a verdict that further checking cannot reverse, since the file's
+	// unchecked segments are then never looked at.
+	ShouldStop func(fileIdx int, result ValidationResult) bool
 }
 
 // ValidateSegmentAvailabilityBatch checks pre-sampled segment IDs for many files
-// in a single StatMany sweep. perFileIDs is index-aligned with the returned
+// in one interleaved STAT sweep. perFileIDs is index-aligned with the returned
 // results: files with an empty ID list yield a zero ValidationResult. IDs are
 // interleaved round-robin across files (every file's first sample, then every
 // file's second, …) so one file with many segments cannot serialize the sweep
-// for the others. An error is returned only for infrastructure failures (pool
-// unavailable); per-segment misses are reported in the per-file results.
+// for the others.
+//
+// The sweep dispatches in MaxConnections-sized chunks rather than one giant
+// StatMany, mirroring the import fast-fail sweep. The chunk boundary is the
+// only place a file can be dropped from the remaining work, so it is also what
+// bounds how far past a settled verdict the sweep can run.
+//
+// An error is returned for infrastructure failures (pool unavailable) and for
+// caller cancellation; per-segment outcomes are reported in the per-file
+// results.
 func ValidateSegmentAvailabilityBatch(
 	ctx context.Context,
 	perFileIDs [][]string,
 	poolManager pool.Manager,
-	maxConnections int,
-	timeout time.Duration,
+	opts BatchOptions,
 ) ([]ValidationResult, error) {
 	results := make([]ValidationResult, len(perFileIDs))
 	for i := range results {
 		results[i].MissingIDs = []string{}
-		results[i].TotalChecked = len(perFileIDs[i])
 	}
 
 	total := 0
@@ -173,28 +104,23 @@ func ValidateSegmentAvailabilityBatch(
 		return results, fmt.Errorf("cannot validate segments: usenet connection pool is nil")
 	}
 
-	if maxConnections <= 0 {
-		maxConnections = 1
+	if opts.MaxConnections <= 0 {
+		opts.MaxConnections = 1
 	}
 
-	// Round-robin interleave IDs across files. Results stream out of order from
-	// StatMany, so ownership is resolved by ID: owners maps each message-id to
-	// the file indexes that reference it (FIFO pop per result, so duplicate IDs
-	// shared across files each get their own attribution).
+	// Round-robin interleave IDs across files into one flat plan. Ownership is
+	// positional (ids[i] belongs to fileOf[i]) rather than keyed by message-id,
+	// so an id shared by two files is attributed to each of them independently.
 	ids := make([]string, 0, total)
-	owners := make(map[string][]int, total)
+	fileOf := make([]int, 0, total)
 	for round := 0; round < maxSamples; round++ {
 		for fileIdx, fileIDs := range perFileIDs {
 			if round < len(fileIDs) {
-				id := fileIDs[round]
-				ids = append(ids, id)
-				owners[id] = append(owners[id], fileIdx)
+				ids = append(ids, fileIDs[round])
+				fileOf = append(fileOf, fileIdx)
 			}
 		}
 	}
-
-	statCtx, cancel := context.WithTimeout(ctx, pool.StatManyTimeout(len(ids), maxConnections, timeout))
-	defer cancel()
 
 	nonEmptyFiles := 0
 	for _, fileIDs := range perFileIDs {
@@ -207,32 +133,85 @@ func ValidateSegmentAvailabilityBatch(
 	slog.InfoContext(ctx, "Starting STAT sweep",
 		"files", nonEmptyFiles,
 		"segments", len(ids),
-		"concurrency", maxConnections,
+		"concurrency", opts.MaxConnections,
 	)
 
-	for r := range usenetPool.StatMany(statCtx, ids, nntppool.StatManyOptions{Concurrency: maxConnections}) {
-		owner := owners[r.MessageID]
-		if len(owner) == 0 {
-			// Unknown ID — should not happen, but never panic on pool output.
-			continue
-		}
-		fileIdx := owner[0]
-		owners[r.MessageID] = owner[1:]
+	dropped := make([]bool, len(perFileIDs))
+	skipped := 0
 
-		if r.Err != nil {
-			slog.DebugContext(ctx, "missing segment",
-				"segment_id", r.MessageID,
-				"error", r.Err,
-			)
-			results[fileIdx].MissingCount++
-			if len(results[fileIdx].MissingIDs) < 50 { // cap stored IDs to avoid huge metadata blobs
-				results[fileIdx].MissingIDs = append(results[fileIdx].MissingIDs, r.MessageID)
+	for pos := 0; pos < len(ids); {
+		chunk := make([]string, 0, opts.MaxConnections)
+		chunkOwners := make([]int, 0, opts.MaxConnections)
+		for pos < len(ids) && len(chunk) < opts.MaxConnections {
+			fileIdx := fileOf[pos]
+			if dropped[fileIdx] {
+				skipped++
+			} else {
+				chunk = append(chunk, ids[pos])
+				chunkOwners = append(chunkOwners, fileIdx)
 			}
+			pos++
+		}
+		if len(chunk) == 0 {
 			continue
 		}
 
-		poolManager.IncArticlesDownloaded()
-		poolManager.UpdateDownloadProgress("", 100)
+		statCtx, cancel := context.WithTimeout(ctx, pool.StatManyTimeout(len(chunk), opts.MaxConnections, opts.Timeout))
+		errByID := make(map[string]error, len(chunk))
+		for r := range usenetPool.StatMany(statCtx, chunk, nntppool.StatManyOptions{Concurrency: opts.MaxConnections}) {
+			errByID[r.MessageID] = r.Err
+		}
+		cancel()
+
+		// Caller cancellation invalidates the whole sweep: the remaining files
+		// would otherwise be judged on evidence that was never gathered.
+		if ctx.Err() != nil {
+			return results, ctx.Err()
+		}
+
+		for i, id := range chunk {
+			res := &results[chunkOwners[i]]
+			statErr, reported := errByID[id]
+			switch {
+			case !reported:
+				// The chunk deadline expired before this id was dispatched, so
+				// StatMany abandoned it. Reachability was never proven.
+				res.UnresolvedCount++
+			case statErr == nil:
+				res.TotalChecked++
+				poolManager.IncArticlesDownloaded()
+				poolManager.UpdateDownloadProgress("", 100)
+			case IsArticleNotFound(statErr):
+				res.TotalChecked++
+				res.MissingCount++
+				if len(res.MissingIDs) < maxTrackedMissingIDs {
+					res.MissingIDs = append(res.MissingIDs, id)
+				}
+			default:
+				// Transport or infrastructure failure. Never a confirmed miss:
+				// a connection blip must not condemn a file.
+				slog.DebugContext(ctx, "segment check unresolved",
+					"segment_id", id,
+					"error", statErr,
+				)
+				res.UnresolvedCount++
+			}
+		}
+
+		if opts.ShouldStop == nil {
+			continue
+		}
+		for i := range perFileIDs {
+			if dropped[i] || len(perFileIDs[i]) == 0 || !opts.ShouldStop(i, results[i]) {
+				continue
+			}
+			dropped[i] = true
+			// Only a file with work left to skip was genuinely cut short; one
+			// that happened to settle on its final chunk ran to completion.
+			if results[i].TotalChecked+results[i].UnresolvedCount < len(perFileIDs[i]) {
+				results[i].TerminatedEarly = true
+			}
+		}
 	}
 
 	missingTotal := 0
@@ -242,6 +221,8 @@ func ValidateSegmentAvailabilityBatch(
 	slog.InfoContext(ctx, "STAT sweep completed",
 		"files", nonEmptyFiles,
 		"segments", len(ids),
+		"checked", len(ids)-skipped,
+		"skipped_after_early_termination", skipped,
 		"missing", missingTotal,
 		"duration", time.Since(sweepStart),
 	)

--- a/internal/usenet/validation_batch_test.go
+++ b/internal/usenet/validation_batch_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/javi11/altmount/internal/pool"
 	"github.com/javi11/altmount/internal/testsupport/fakepool"
@@ -49,7 +48,7 @@ func TestValidateSegmentAvailabilityBatch(t *testing.T) {
 		mgr := &validationTestPoolManager{client: client}
 		perFile := [][]string{idList("a", 3), idList("b", 2), idList("c", 4)}
 
-		results, err := ValidateSegmentAvailabilityBatch(context.Background(), perFile, mgr, 4, time.Second)
+		results, err := ValidateSegmentAvailabilityBatch(context.Background(), perFile, mgr, batchOpts(4))
 		require.NoError(t, err)
 		require.Len(t, results, 3)
 		for i, r := range results {
@@ -69,7 +68,7 @@ func TestValidateSegmentAvailabilityBatch(t *testing.T) {
 		mgr := &validationTestPoolManager{client: client}
 		perFile := [][]string{idList("good", 3), broken, idList("also-good", 2)}
 
-		results, err := ValidateSegmentAvailabilityBatch(context.Background(), perFile, mgr, 8, time.Second)
+		results, err := ValidateSegmentAvailabilityBatch(context.Background(), perFile, mgr, batchOpts(8))
 		require.NoError(t, err)
 		assert.Equal(t, 0, results[0].MissingCount)
 		assert.Equal(t, 3, results[1].MissingCount)
@@ -82,7 +81,7 @@ func TestValidateSegmentAvailabilityBatch(t *testing.T) {
 		mgr := &validationTestPoolManager{client: client}
 		perFile := [][]string{idList("a", 2), nil, idList("c", 1)}
 
-		results, err := ValidateSegmentAvailabilityBatch(context.Background(), perFile, mgr, 2, time.Second)
+		results, err := ValidateSegmentAvailabilityBatch(context.Background(), perFile, mgr, batchOpts(2))
 		require.NoError(t, err)
 		require.Len(t, results, 3)
 		assert.Equal(t, 0, results[1].MissingCount)
@@ -96,7 +95,7 @@ func TestValidateSegmentAvailabilityBatch(t *testing.T) {
 		mgr := &validationTestPoolManager{client: client}
 		perFile := [][]string{idList("m", 60)}
 
-		results, err := ValidateSegmentAvailabilityBatch(context.Background(), perFile, mgr, 8, time.Second)
+		results, err := ValidateSegmentAvailabilityBatch(context.Background(), perFile, mgr, batchOpts(8))
 		require.NoError(t, err)
 		assert.Equal(t, 60, results[0].MissingCount)
 		assert.Len(t, results[0].MissingIDs, 50)
@@ -108,7 +107,7 @@ func TestValidateSegmentAvailabilityBatch(t *testing.T) {
 		mgr := &validationTestPoolManager{client: client}
 		perFile := [][]string{{"dup@test", "a-1@test"}, {"dup@test"}}
 
-		results, err := ValidateSegmentAvailabilityBatch(context.Background(), perFile, mgr, 1, time.Second)
+		results, err := ValidateSegmentAvailabilityBatch(context.Background(), perFile, mgr, batchOpts(1))
 		require.NoError(t, err)
 		assert.Equal(t, 1, results[0].MissingCount)
 		assert.Equal(t, 1, results[1].MissingCount)
@@ -117,7 +116,7 @@ func TestValidateSegmentAvailabilityBatch(t *testing.T) {
 
 func TestValidateSegmentAvailabilityBatch_PoolUnavailable(t *testing.T) {
 	mgr := &failingPoolManager{}
-	_, err := ValidateSegmentAvailabilityBatch(context.Background(), [][]string{idList("a", 2)}, mgr, 2, time.Second)
+	_, err := ValidateSegmentAvailabilityBatch(context.Background(), [][]string{idList("a", 2)}, mgr, batchOpts(2))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pool unavailable")
 }
@@ -127,7 +126,7 @@ func TestValidateSegmentAvailabilityBatch_PoolUnavailable(t *testing.T) {
 // preparation must not fail on a down pool.
 func TestValidateSegmentAvailabilityBatch_EmptyInputSkipsPool(t *testing.T) {
 	mgr := &failingPoolManager{} // would error if the pool were acquired
-	results, err := ValidateSegmentAvailabilityBatch(context.Background(), [][]string{nil, {}}, mgr, 2, time.Second)
+	results, err := ValidateSegmentAvailabilityBatch(context.Background(), [][]string{nil, {}}, mgr, batchOpts(2))
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 }
@@ -144,7 +143,7 @@ func TestValidateSegmentAvailabilityBatch_Interleaves(t *testing.T) {
 		{"c-0@test"},
 	}
 
-	_, err := ValidateSegmentAvailabilityBatch(context.Background(), perFile, mgr, 2, time.Second)
+	_, err := ValidateSegmentAvailabilityBatch(context.Background(), perFile, mgr, batchOpts(2))
 	require.NoError(t, err)
 
 	want := []string{"a-0@test", "b-0@test", "c-0@test", "a-1@test", "b-1@test", "a-2@test"}

--- a/internal/usenet/validation_fastfail_test.go
+++ b/internal/usenet/validation_fastfail_test.go
@@ -1,0 +1,212 @@
+package usenet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/nntppool/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func batchOpts(maxConns int) BatchOptions {
+	return BatchOptions{MaxConnections: maxConns, Timeout: time.Second}
+}
+
+// TestBatch_ConfirmedMissingVsTransport is the core classification contract:
+// only a 430/423 counts as a confirmed missing segment. Every other error is
+// unresolved — the segment's reachability was never proven either way.
+func TestBatch_ConfirmedMissingVsTransport(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            error
+		wantMissing    int
+		wantUnresolved int
+	}{
+		{"article not found 430", nntppool.ErrArticleNotFound, 1, 0},
+		{"article not found 423", &nntppool.Error{Code: 423, Message: "no article with that number"}, 1, 0},
+		{"connection died", nntppool.ErrConnectionDied, 0, 1},
+		{"max connections", nntppool.ErrMaxConnections, 0, 1},
+		{"service unavailable", nntppool.ErrServiceUnavailable, 0, 1},
+		{"auth required", nntppool.ErrAuthRequired, 0, 1},
+		{"quota exceeded", nntppool.ErrQuotaExceeded, 0, 1},
+		{"deadline exceeded", context.DeadlineExceeded, 0, 1},
+		{"providers exhausted by transport", fmt.Errorf("nntp: all providers exhausted: %w", nntppool.ErrConnectionDied), 0, 1},
+		{"providers exhausted by 430", fmt.Errorf("nntp: all providers exhausted: %w", nntppool.ErrArticleNotFound), 1, 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fakepool.New()
+			client.SetBehavior("x-0@test", fakepool.SegmentBehavior{Err: tc.err})
+			mgr := &validationTestPoolManager{client: client}
+
+			results, err := ValidateSegmentAvailabilityBatch(
+				context.Background(), [][]string{{"x-0@test", "x-1@test"}}, mgr, batchOpts(2))
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantMissing, results[0].MissingCount, "MissingCount")
+			assert.Equal(t, tc.wantUnresolved, results[0].UnresolvedCount, "UnresolvedCount")
+		})
+	}
+}
+
+// TestBatch_TotalCheckedCountsResolvedOnly proves an unresolved segment is not
+// counted as checked: TotalChecked feeds the projection denominator in
+// health.classifyHoles, and a segment we learned nothing about must not dilute
+// the observed miss rate.
+func TestBatch_TotalCheckedCountsResolvedOnly(t *testing.T) {
+	client := fakepool.New()
+	client.SetBehavior("r-1@test", fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
+	client.SetBehavior("r-2@test", fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+	mgr := &validationTestPoolManager{client: client}
+
+	results, err := ValidateSegmentAvailabilityBatch(
+		context.Background(), [][]string{idList("r", 4)}, mgr, batchOpts(4))
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, results[0].TotalChecked, "2 available + 1 confirmed missing")
+	assert.Equal(t, 1, results[0].MissingCount)
+	assert.Equal(t, 1, results[0].UnresolvedCount)
+}
+
+// TestBatch_UnreportedIDCountsUnresolved covers the silent-truncation hole:
+// StatMany abandons undispatched ids when its deadline expires, so an id that
+// never produces a result must not be mistaken for an available segment.
+func TestBatch_UnreportedIDCountsUnresolved(t *testing.T) {
+	client := fakepool.New()
+	// Every stat blocks past the chunk deadline, so StatMany's own ctx fires
+	// and most ids are abandoned without ever reporting.
+	client.SetDefaultBehavior(fakepool.SegmentBehavior{Latency: 200 * time.Millisecond})
+	mgr := &validationTestPoolManager{client: client}
+
+	results, err := ValidateSegmentAvailabilityBatch(
+		context.Background(), [][]string{idList("u", 6)}, mgr,
+		BatchOptions{MaxConnections: 2, Timeout: 10 * time.Millisecond})
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, results[0].MissingCount, "a timeout is never a confirmed miss")
+	assert.Equal(t, 6, results[0].UnresolvedCount, "every unreported id is unresolved")
+	assert.Equal(t, 0, results[0].TotalChecked)
+}
+
+// TestBatch_FastFailStopsOneFileNotTheBatch is the feature's headline
+// behaviour: a file whose confirmed misses irreversibly exceed its threshold
+// stops consuming stats, while its batch siblings are swept in full.
+func TestBatch_FastFailStopsOneFileNotTheBatch(t *testing.T) {
+	client := fakepool.New()
+	doomed := idList("doomed", 40)
+	// Only the very first sample is missing; with zero tolerance that alone
+	// settles the file.
+	client.SetBehavior(doomed[0], fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+	healthy := idList("healthy", 40)
+
+	mgr := &validationTestPoolManager{client: client}
+	opts := batchOpts(4)
+	opts.ShouldStop = func(_ int, r ValidationResult) bool { return r.MissingCount > 0 }
+
+	results, err := ValidateSegmentAvailabilityBatch(
+		context.Background(), [][]string{doomed, healthy}, mgr, opts)
+
+	require.NoError(t, err)
+	assert.True(t, results[0].TerminatedEarly, "doomed file terminated early")
+	assert.Equal(t, 1, results[0].MissingCount)
+	assert.Less(t, results[0].TotalChecked, 40, "doomed file stopped short of a full sweep")
+
+	assert.False(t, results[1].TerminatedEarly, "sibling ran to completion")
+	assert.Equal(t, 40, results[1].TotalChecked, "sibling checked every segment")
+	assert.Equal(t, 0, results[1].MissingCount)
+
+	assert.Less(t, client.StatCalls(), int64(80), "fast-fail saved stat calls")
+}
+
+// TestBatch_NoShouldStopSweepsEverything guards the default: without a stop
+// policy the sweep keeps its full-hole-map behaviour.
+func TestBatch_NoShouldStopSweepsEverything(t *testing.T) {
+	client := fakepool.New()
+	client.SetDefaultBehavior(fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+	mgr := &validationTestPoolManager{client: client}
+
+	results, err := ValidateSegmentAvailabilityBatch(
+		context.Background(), [][]string{idList("all", 30)}, mgr, batchOpts(4))
+
+	require.NoError(t, err)
+	assert.False(t, results[0].TerminatedEarly)
+	assert.Equal(t, 30, results[0].MissingCount)
+	assert.Equal(t, int64(30), client.StatCalls())
+}
+
+// TestBatch_FastFailIgnoresTransportErrors is the safety property from the
+// issue: a flaky connection must never condemn a file, no matter how many
+// segments it affects.
+func TestBatch_FastFailIgnoresTransportErrors(t *testing.T) {
+	client := fakepool.New()
+	client.SetDefaultBehavior(fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
+	mgr := &validationTestPoolManager{client: client}
+
+	opts := batchOpts(4)
+	opts.ShouldStop = func(_ int, r ValidationResult) bool { return r.MissingCount > 0 }
+
+	results, err := ValidateSegmentAvailabilityBatch(
+		context.Background(), [][]string{idList("flaky", 30)}, mgr, opts)
+
+	require.NoError(t, err)
+	assert.False(t, results[0].TerminatedEarly, "transport errors never trigger fast-fail")
+	assert.Equal(t, 30, results[0].UnresolvedCount)
+	assert.Equal(t, int64(30), client.StatCalls(), "the whole file was still swept")
+}
+
+// TestBatch_ContextCancellationSurfaces proves an aborted sweep reports the
+// cancellation instead of silently returning a clean-looking partial result.
+func TestBatch_ContextCancellationSurfaces(t *testing.T) {
+	client := fakepool.New()
+	client.SetDefaultBehavior(fakepool.SegmentBehavior{Latency: 20 * time.Millisecond})
+	mgr := &validationTestPoolManager{client: client}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	_, err := ValidateSegmentAvailabilityBatch(ctx, [][]string{idList("c", 200)}, mgr, batchOpts(2))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded), "got %v", err)
+}
+
+// chunkRecorder records the size of every StatMany chunk so tests can assert
+// the sweep dispatches in bounded waves rather than one giant call.
+type chunkRecorder struct {
+	*fakepool.Client
+	mu     sync.Mutex
+	chunks []int
+}
+
+func (c *chunkRecorder) StatMany(ctx context.Context, ids []string, opts nntppool.StatManyOptions) <-chan nntppool.StatManyResult {
+	c.mu.Lock()
+	c.chunks = append(c.chunks, len(ids))
+	c.mu.Unlock()
+	return c.Client.StatMany(ctx, ids, opts)
+}
+
+func (c *chunkRecorder) sizes() []int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]int(nil), c.chunks...)
+}
+
+// TestBatch_DispatchesInBoundedChunks pins the wave size to maxConnections,
+// matching the import fast-fail sweep. The chunk boundary is what makes
+// per-file termination possible at all.
+func TestBatch_DispatchesInBoundedChunks(t *testing.T) {
+	rec := &chunkRecorder{Client: fakepool.New()}
+	mgr := &validationTestPoolManager{client: rec}
+
+	_, err := ValidateSegmentAvailabilityBatch(
+		context.Background(), [][]string{idList("k", 25)}, mgr, batchOpts(10))
+
+	require.NoError(t, err)
+	assert.Equal(t, []int{10, 10, 5}, rec.sizes())
+}

--- a/internal/usenet/validation_test.go
+++ b/internal/usenet/validation_test.go
@@ -3,15 +3,11 @@ package usenet
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"math/rand"
-	"sync"
 	"testing"
-	"time"
 
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/pool"
-	"github.com/javi11/altmount/internal/testsupport/fakepool"
 	"github.com/javi11/nntppool/v4"
 	"github.com/stretchr/testify/assert"
 )
@@ -89,118 +85,6 @@ func TestSelectSegmentsForValidation(t *testing.T) {
 			len(selectSegmentsForValidation(largeSegments, 10)),
 		)
 	})
-}
-
-// TestValidateSegmentAvailabilityDetailed_MissingSegmentEmitsDebugLog verifies
-// the same for the non-fail-fast detailed path.
-// NOT parallel: we replace the global slog default.
-func TestValidateSegmentAvailabilityDetailed_MissingSegmentEmitsDebugLog(t *testing.T) {
-	const segID = "missing-detailed@host"
-
-	var mu sync.Mutex
-	type logRecord struct{ msg, segID string }
-	var captured []logRecord
-
-	handler := &captureLogHandler{
-		onHandle: func(r slog.Record) {
-			var sid string
-			r.Attrs(func(a slog.Attr) bool {
-				if a.Key == "segment_id" {
-					sid = a.Value.String()
-				}
-				return true
-			})
-			mu.Lock()
-			captured = append(captured, logRecord{msg: r.Message, segID: sid})
-			mu.Unlock()
-		},
-	}
-	prev := slog.Default()
-	slog.SetDefault(slog.New(handler))
-	t.Cleanup(func() { slog.SetDefault(prev) })
-
-	fp := fakepool.New()
-	fp.SetBehavior(segID, fakepool.SegmentBehavior{
-		Err: nntppool.ErrArticleNotFound,
-	})
-
-	mgr := &validationTestPoolManager{client: fp}
-	segs := []*metapb.SegmentData{{Id: segID}}
-
-	result, err := ValidateSegmentAvailabilityDetailed(context.Background(), segs, mgr, 1, 100, nil, 5*time.Second)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, result.MissingCount)
-
-	mu.Lock()
-	defer mu.Unlock()
-	found := false
-	for _, r := range captured {
-		if r.msg == "missing segment" && r.segID == segID {
-			found = true
-		}
-	}
-	assert.True(t, found, "expected 'missing segment' debug log for segment_id=%q, got: %+v", segID, captured)
-}
-
-// TestValidateSegmentAvailabilityDetailed_MissingSegmentByteRanges verifies
-// that misses are reported with their original index and file-coordinate byte
-// range (prefix sum of usable segment lengths), for both full and sampled runs.
-func TestValidateSegmentAvailabilityDetailed_MissingSegmentByteRanges(t *testing.T) {
-	fp := fakepool.New()
-	mgr := &validationTestPoolManager{client: fp}
-
-	// 10 segments of 1000 usable bytes each (with a non-zero archive slice
-	// offset on segment 3 to prove usable length, not segment size, drives
-	// the prefix sum).
-	segs := make([]*metapb.SegmentData, 10)
-	for i := range segs {
-		segs[i] = &metapb.SegmentData{
-			Id:          fmt.Sprintf("seg%d@host", i),
-			SegmentSize: 1200,
-			StartOffset: 100,
-			EndOffset:   1099, // usable = 1000
-		}
-	}
-
-	fp.SetBehavior("seg0@host", fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
-	fp.SetBehavior("seg7@host", fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
-
-	result, err := ValidateSegmentAvailabilityDetailed(context.Background(), segs, mgr, 2, 100, nil, 5*time.Second)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, result.MissingCount)
-	assert.Len(t, result.MissingSegments, 2)
-
-	assert.Equal(t, 0, result.MissingSegments[0].Index)
-	assert.Equal(t, "seg0@host", result.MissingSegments[0].ID)
-	assert.Equal(t, int64(0), result.MissingSegments[0].Start)
-	assert.Equal(t, int64(999), result.MissingSegments[0].End)
-
-	assert.Equal(t, 7, result.MissingSegments[1].Index)
-	assert.Equal(t, int64(7000), result.MissingSegments[1].Start)
-	assert.Equal(t, int64(7999), result.MissingSegments[1].End)
-
-	// MissingIDs stays populated for compatibility.
-	assert.ElementsMatch(t, []string{"seg0@host", "seg7@host"}, result.MissingIDs)
-}
-
-// TestValidateSegmentAvailabilityDetailed_MissingSegmentsCap verifies the
-// 50-entry cap holds while MissingCount reports the true total.
-func TestValidateSegmentAvailabilityDetailed_MissingSegmentsCap(t *testing.T) {
-	fp := fakepool.New()
-	mgr := &validationTestPoolManager{client: fp}
-
-	segs := make([]*metapb.SegmentData, 60)
-	for i := range segs {
-		id := fmt.Sprintf("seg%d@host", i)
-		segs[i] = &metapb.SegmentData{Id: id, StartOffset: 0, EndOffset: 999}
-		fp.SetBehavior(id, fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
-	}
-
-	result, err := ValidateSegmentAvailabilityDetailed(context.Background(), segs, mgr, 4, 100, nil, 5*time.Second)
-	assert.NoError(t, err)
-	assert.Equal(t, 60, result.MissingCount)
-	assert.Len(t, result.MissingIDs, 50)
-	assert.Len(t, result.MissingSegments, 50)
 }
 
 // validationTestPoolManager is a minimal pool.Manager for validation tests.


### PR DESCRIPTION
## Summary

Health checks with `check_all_segments` enabled kept STAT-ing every remaining segment of a file that had *already* exceeded its missing-segment threshold. At 0% tolerance one confirmed miss settles the file, so a 10-file batch could spend ~7 minutes on checks that could not change any repair decision.

## What changed

**Three-way segment classification** (`internal/usenet/validation.go`)

`ValidationResult` gained `UnresolvedCount`. Previously *any* non-nil error from `StatMany` incremented `MissingCount`. Now only `errors.Is(err, nntppool.ErrArticleNotFound)` — which covers both 430 and 423 via nntppool's semantic `Is` — counts as a confirmed miss. `ErrConnectionDied`, `ErrMaxConnections`, 502, 480, quota errors, `context.DeadlineExceeded`, and transport-caused `all providers exhausted` are unresolved.

`TotalChecked` now counts resolved segments only, so an unresolved segment cannot dilute the denominator feeding `holes.ClassifyProjected`. The sweep also checks `ctx.Err()` after each chunk and treats never-reported ids as unresolved, closing an existing hole where an expired `StatMany` deadline reported its undispatched segments as *present*.

**Chunked sweep with per-file termination**

The single `StatMany` call became a loop of `max_connections`-sized chunks — the same chunking `internal/importer/validation/fast_fail.go:285` already uses for imports. Files whose verdict is settled are dropped between chunks; in-flight requests always complete, and siblings are unaffected. Policy is injected as `BatchOptions.ShouldStop`, so `internal/usenet` stays mechanism-only with no `holes` dependency.

**No new config**

Termination is driven by the existing `acceptable_missing_segments_percentage`. `holes.ExceedsAcceptableMissing` is `missing/total*100 > acceptable` — monotonic in `missing`, so once true it can never become false. That is what makes early termination sound rather than a heuristic. At `100` it never fires, preserving the never-fail-on-misses escape hatch.

This is safe for the hole map: a file that trips the threshold is escalated to `VerdictFailed` (`internal/health/holes.go:67`), and `AddKnownHoles` only runs on `VerdictDegraded` — so a fast-failed file never had holes persisted anyway.

## Latent bug fixed

Under the old rule, a transport blip on a video file inflated `MissingCount`, which could produce a `degraded` verdict, which called `AddKnownHoles` — **persisting phantom holes into metadata that playback then zero-fills over real data, permanently.** `TestCheckFilesBatch_TransportErrorPersistsNoHoles` guards this.

`prepareUpdateForResult` treats `CheckFailed` and `FileCorrupted` identically, so status transitions and retry counts are unchanged by the reclassification.

## Also

- Removed `ValidateSegmentAvailabilityDetailed` (and `MissingSegment`): no non-test callers, and keeping it meant maintaining a second divergent classification path.
- `error_details` gained `terminated_early`, `termination_reason`, `unresolved_segments`. No migration — it is a JSON blob, and `sampled`/`total_articles` already carried the checked/total counts.
- New `PartialCheckBadge` in the health table and card. Both now parse `error_details` once instead of twice.

## Acceptance criteria

| Criterion | Status |
|---|---|
| File removed from active batch once threshold irreversibly exceeded | ✅ |
| Other files in the same batch continue checking | ✅ |
| Confirmed article-not-found can trigger early termination | ✅ |
| Transport errors never count as confirmed missing | ✅ |
| Health retries and repair behavior unchanged | ✅ |
| API/UI indicates a partial, early-terminated result | ✅ |

## Test plan

13 new tests, each written before the code and watched fail first.

- `internal/usenet/validation_fastfail_test.go` — a 10-case table over every error shape (430, 423, `ErrConnectionDied`, `ErrMaxConnections`, 502, 480, quota, deadline, and `all providers exhausted` wrapping both a transport error *and* a 430); resolved-only `TotalChecked`; unreported ids as unresolved; one file terminating while its sibling completes; no `ShouldStop` sweeping everything; transport errors never terminating; cancellation surfacing; chunk sizes pinned to `[10, 10, 5]`.
- `internal/health/checker_fastfail_test.go` — transport error is neither corruption nor healthy; no phantom holes persisted; fast-fail stops only the doomed file; no termination when tolerance is unreached; `CheckFile` parity with the batch path.

Verified: `go build ./...`, `go vet ./...` clean; full `go test ./...` passes; `-race` clean on `internal/health`, `internal/usenet`, `internal/database`, `internal/importer/...`; `biome check` and the frontend production build pass.

Note: `make` and `make golangci-lint` fail in this environment for pre-existing, unrelated reasons — `protoc-gen-go` is not installed, and golangci-lint hits a Go 1.27 export-data mismatch in `internal/encryption/` (untouched here). Verified with `go build`/`vet`/`test` directly.

## Follow-up worth watching

Strict handling means a sweep with any unresolved segment is retried rather than judged on partial evidence. Against a flaky provider at 100% verification this could cause retry churn that eventually triggers repair. This is not a regression — transport errors already marked files corrupted before — but if it shows up in practice, adding a small unresolved tolerance is a change to one branch in `judgeValidation`.

Closes #863
