### PR TITLE
fix(metadata): govern .nzbz store lifetime by reference count only

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -198,7 +198,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 	})
 
-	healthWorker, librarySyncWorker, err := startHealthWorker(ctx, cfg, repos.HealthRepo, poolManager, configManager, rcloneRCClient, arrsService, importerService, progressBroadcaster, fs)
+	healthWorker, librarySyncWorker, err := startHealthWorker(ctx, cfg, metadataService, repos.HealthRepo, poolManager, configManager, rcloneRCClient, arrsService, importerService, progressBroadcaster, fs)
 	if err != nil {
 		logger.Warn("Health worker initialization failed", "err", err)
 	}

--- a/cmd/altmount/cmd/setup.go
+++ b/cmd/altmount/cmd/setup.go
@@ -382,6 +382,7 @@ func setupWebDAV(
 func startHealthWorker(
 	ctx context.Context,
 	cfg *config.Config,
+	metadataService *metadata.MetadataService,
 	healthRepo *database.HealthRepository,
 	poolManager pool.Manager,
 	configManager *config.Manager,
@@ -391,8 +392,10 @@ func startHealthWorker(
 	broadcaster *progress.ProgressBroadcaster,
 	contentVerifyFS contentverify.Opener,
 ) (*health.HealthWorker, *health.LibrarySyncWorker, error) {
-	// Create metadata service for health worker
-	metadataService := metadata.NewMetadataService(cfg.Metadata.RootPath)
+	// The health and library-sync workers share the process-wide metadata service so
+	// their deletions go through the same store reference counter the importer wires
+	// up. A second instance here silently skipped every DecStoreRef, leaking .nzbz
+	// stores and letting the two lite caches serve each other stale entries.
 
 	// Create health checker
 	healthChecker := health.NewHealthChecker(

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -24,7 +24,6 @@ database:
 # Metadata filesystem configuration
 metadata:
   root_path: '/config/metadata' # Directory to store metadata files (required)
-  delete_source_nzb_on_removal: false # Delete source NZB file when metadata is removed (default: false)
   delete_completed_nzb: false # Delete NZB source file after successful import (default: false, DANGEROUS: prevents re-import)
   backup:
     enabled: false # Enable automatic metadata backups

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,7 +10,6 @@ database:
     path: /config/altmount.db
 metadata:
     root_path: /config/metadata
-    delete_source_nzb_on_removal: false
 streaming:
     max_prefetch: 30
 health:

--- a/docs/docs/3. Configuration/health-monitoring.md
+++ b/docs/docs/3. Configuration/health-monitoring.md
@@ -261,7 +261,7 @@ When Sonarr/Radarr deletes a file or series/movie, AltMount automatically cleans
 1. **Receives the webhook** with the absolute file/folder path from ARR
 2. **Looks up the health record** — first by `library_path` (the absolute ARR path), falling back to the normalized `file_path`
 3. **Deletes the health record** from the database
-4. **Deletes the metadata** (`.meta` and `.id` sidecar files) and optionally the source NZB
+4. **Deletes the metadata** (`.meta` and `.id` sidecar files), plus the shared `.nzbz` store once no other metadata still references it
 
 For directory deletions (MovieDelete, SeriesDelete), AltMount deletes all health records and metadata within that directory prefix.
 

--- a/docs/static/openapi.yaml
+++ b/docs/static/openapi.yaml
@@ -4463,8 +4463,6 @@ components:
           $ref: "#/components/schemas/config.MetadataBackupConfig"
         delete_completed_nzb:
           type: boolean
-        delete_source_nzb_on_removal:
-          type: boolean
         root_path:
           type: string
       type: object

--- a/docs/static/swagger.yaml
+++ b/docs/static/swagger.yaml
@@ -1217,8 +1217,6 @@ definitions:
         $ref: '#/definitions/config.MetadataBackupConfig'
       delete_completed_nzb:
         type: boolean
-      delete_source_nzb_on_removal:
-        type: boolean
       root_path:
         type: string
     type: object

--- a/frontend/src/components/config/MetadataConfigSection.tsx
+++ b/frontend/src/components/config/MetadataConfigSection.tsx
@@ -1,5 +1,5 @@
 import cronstrue from "cronstrue";
-import { Download, HardDrive, History, Save, ShieldAlert, Trash2 } from "lucide-react";
+import { Download, HardDrive, History, Save, ShieldAlert } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useBatchExportNZB } from "../../hooks/useConfig";
 import type { ConfigResponse, MetadataBackupConfig, MetadataConfig } from "../../types/config";
@@ -40,12 +40,6 @@ export function MetadataConfigSection({
 	}, [config.metadata]);
 
 	const handleInputChange = (field: keyof MetadataConfig, value: string) => {
-		const newData = { ...formData, [field]: value };
-		setFormData(newData);
-		setHasChanges(JSON.stringify(newData) !== JSON.stringify(config.metadata));
-	};
-
-	const handleCheckboxChange = (field: keyof MetadataConfig, value: boolean) => {
 		const newData = { ...formData, [field]: value };
 		setFormData(newData);
 		setHasChanges(JSON.stringify(newData) !== JSON.stringify(config.metadata));
@@ -278,43 +272,6 @@ export function MetadataConfigSection({
 								</fieldset>
 							</div>
 						)}
-					</div>
-				</div>
-
-				{/* Retention Logic */}
-				<div className="space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
-					<div className="flex items-center gap-2">
-						<Trash2 className="h-4 w-4 text-base-content/60" />
-						<h4 className="font-bold text-base-content/40 text-xs uppercase tracking-widest">
-							Source Cleanup
-						</h4>
-						<div className="h-px flex-1 bg-base-300/50" />
-					</div>
-					<p className="text-[11px] text-base-content/40 leading-relaxed">
-						Controls NZB source file retention during import. For orphaned file cleanup, see{" "}
-						<span className="font-semibold text-base-content/60">Health → Orphan Cleanup</span>.
-					</p>
-
-					<div className="space-y-4">
-						<label className="label cursor-pointer items-start justify-start gap-4">
-							<input
-								type="checkbox"
-								className="checkbox checkbox-primary checkbox-sm mt-1 shrink-0"
-								checked={formData.delete_source_nzb_on_removal ?? false}
-								disabled={isReadOnly}
-								onChange={(e) =>
-									handleCheckboxChange("delete_source_nzb_on_removal", e.target.checked)
-								}
-							/>
-							<div className="min-w-0 flex-1">
-								<span className="block whitespace-normal break-words font-bold text-xs">
-									Purge Source NZB
-								</span>
-								<span className="mt-1 block whitespace-normal break-words text-base-content/50 text-xs leading-relaxed">
-									Delete original NZB file when metadata is manually removed from AltMount.
-								</span>
-							</div>
-						</label>
 					</div>
 				</div>
 

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -69,7 +69,6 @@ export interface DatabaseConfig {
 // Metadata configuration
 export interface MetadataConfig {
 	root_path: string;
-	delete_source_nzb_on_removal?: boolean;
 	backup: MetadataBackupConfig;
 	migration?: MetadataMigrationConfig;
 }
@@ -385,7 +384,6 @@ export interface DatabaseUpdateRequest {
 // Metadata update request
 export interface MetadataUpdateRequest {
 	root_path?: string;
-	delete_source_nzb_on_removal?: boolean;
 	backup?: MetadataBackupConfig;
 }
 

--- a/internal/api/arrs_handlers.go
+++ b/internal/api/arrs_handlers.go
@@ -424,8 +424,6 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 	}
 
 	// Process File Deletions
-	deleteSourceNzb := cfg.Metadata.ShouldDeleteSourceNzb()
-
 	for _, path := range filesToDelete {
 		normalizedPath := normalize(path)
 
@@ -471,7 +469,7 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 
 		// Delete metadata (and optionally source NZB)
 		if s.metadataService != nil {
-			if err := s.metadataService.DeleteFileMetadataWithSourceNzb(c.Context(), metadataPath, deleteSourceNzb); err != nil {
+			if err := s.metadataService.DeleteFileMetadata(c.Context(), metadataPath); err != nil {
 				slog.DebugContext(c.Context(), "Failed to delete metadata from webhook (might be gone)", "path", metadataPath, "error", err)
 			}
 		}

--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -230,7 +230,7 @@ func (s *Server) handleDeleteHealth(c *fiber.Ctx) error {
 
 		// Delete metadata if requested
 		if deleteMeta && s.metadataService != nil {
-			if delErr := s.metadataService.DeleteFileMetadataWithSourceNzb(c.Context(), item.FilePath, cfg.Metadata.ShouldDeleteSourceNzb()); delErr != nil {
+			if delErr := s.metadataService.DeleteFileMetadata(c.Context(), item.FilePath); delErr != nil {
 				slog.ErrorContext(c.Context(), "Failed to delete metadata during health record deletion", "file_path", item.FilePath, "error", delErr)
 			} else {
 				metaDeleted = true
@@ -314,7 +314,7 @@ func (s *Server) handleDeleteHealthBulk(c *fiber.Ctx) error {
 
 			// Delete metadata if requested
 			if req.DeleteMeta && s.metadataService != nil {
-				if delErr := s.metadataService.DeleteFileMetadataWithSourceNzb(c.Context(), item.FilePath, cfg.Metadata.ShouldDeleteSourceNzb()); delErr != nil {
+				if delErr := s.metadataService.DeleteFileMetadata(c.Context(), item.FilePath); delErr != nil {
 					slog.ErrorContext(c.Context(), "Failed to delete metadata during bulk deletion", "file_path", item.FilePath, "error", delErr)
 				} else {
 					metaDeletedCount++

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -325,10 +325,9 @@ type DatabaseConfig struct {
 
 // MetadataConfig represents metadata filesystem configuration
 type MetadataConfig struct {
-	RootPath                 string                  `yaml:"root_path" mapstructure:"root_path" json:"root_path"`
-	DeleteSourceNzbOnRemoval *bool                   `yaml:"delete_source_nzb_on_removal" mapstructure:"delete_source_nzb_on_removal" json:"delete_source_nzb_on_removal,omitempty"`
-	Backup                   MetadataBackupConfig    `yaml:"backup" mapstructure:"backup" json:"backup"`
-	Migration                MetadataMigrationConfig `yaml:"migration" mapstructure:"migration" json:"migration"`
+	RootPath  string                  `yaml:"root_path" mapstructure:"root_path" json:"root_path"`
+	Backup    MetadataBackupConfig    `yaml:"backup" mapstructure:"backup" json:"backup"`
+	Migration MetadataMigrationConfig `yaml:"migration" mapstructure:"migration" json:"migration"`
 }
 
 // MetadataMigrationConfig configures the legacy-metadata → v3 migration.
@@ -337,11 +336,6 @@ type MetadataMigrationConfig struct {
 	// Legacy metas do not retain the original groups, and nzb.BuildNZB renders an
 	// empty <groups> element without this, which most NZB clients reject.
 	DefaultGroup string `yaml:"default_group" mapstructure:"default_group" json:"default_group"`
-}
-
-// ShouldDeleteSourceNzb returns whether source NZB files should be deleted on removal.
-func (m MetadataConfig) ShouldDeleteSourceNzb() bool {
-	return m.DeleteSourceNzbOnRemoval != nil && *m.DeleteSourceNzbOnRemoval
 }
 
 // MetadataBackupConfig represents metadata backup configuration
@@ -1653,10 +1647,9 @@ func isRunningInDocker() bool {
 // DefaultConfig returns a config with default values
 // If configDir is provided, it will be used for database and log file paths
 func DefaultConfig(configDir ...string) *Config {
-	healthEnabled := false            // Health system disabled by default
-	cleanupOrphanedMetadata := false  // Cleanup orphaned metadata disabled by default
-	resolveRepairOnImport := false    // Disable smart replacement detection by default
-	deleteSourceNzbOnRemoval := false // Delete source NZB on removal disabled by default
+	healthEnabled := false           // Health system disabled by default
+	cleanupOrphanedMetadata := false // Cleanup orphaned metadata disabled by default
+	resolveRepairOnImport := false   // Disable smart replacement detection by default
 	vfsEnabled := false
 	mountEnabled := false // Disabled by default
 	sabnzbdEnabled := false
@@ -1735,8 +1728,7 @@ func DefaultConfig(configDir ...string) *Config {
 			Path: dbPath,
 		},
 		Metadata: MetadataConfig{
-			RootPath:                 metadataPath,
-			DeleteSourceNzbOnRemoval: &deleteSourceNzbOnRemoval,
+			RootPath: metadataPath,
 			Backup: MetadataBackupConfig{
 				Enabled:     &metadataBackupEnabled,
 				Schedule:    "0 3 * * *", // daily at 3 AM UTC

--- a/internal/database/store_ref_repository.go
+++ b/internal/database/store_ref_repository.go
@@ -41,11 +41,15 @@ func (r *StoreRefRepository) IncStoreRef(ctx context.Context, storePath string) 
 
 // DecStoreRef decrements the ref_count for storePath by 1.
 // If the resulting count is ≤ 0, the row is deleted and 0 is returned.
-// Returns the new count (0 if the row was deleted or did not exist).
-func (r *StoreRefRepository) DecStoreRef(ctx context.Context, storePath string) (int64, error) {
+//
+// The second return value reports whether a row existed before the decrement.
+// Callers must not confuse an untracked store (existed=false, count=0) with the
+// last reference being dropped (existed=true, count=0): only the latter means the
+// store file is genuinely unreferenced and safe to unlink.
+func (r *StoreRefRepository) DecStoreRef(ctx context.Context, storePath string) (int64, bool, error) {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return 0, fmt.Errorf("dec store ref %q: begin tx: %w", storePath, err)
+		return 0, false, fmt.Errorf("dec store ref %q: begin tx: %w", storePath, err)
 	}
 	defer tx.Rollback()
 
@@ -55,7 +59,7 @@ func (r *StoreRefRepository) DecStoreRef(ctx context.Context, storePath string) 
 		WHERE store_path = ?
 	`)
 	if _, err := tx.ExecContext(ctx, updateQuery, storePath); err != nil {
-		return 0, fmt.Errorf("dec store ref %q: update: %w", storePath, err)
+		return 0, false, fmt.Errorf("dec store ref %q: update: %w", storePath, err)
 	}
 
 	var count int64
@@ -64,26 +68,26 @@ func (r *StoreRefRepository) DecStoreRef(ctx context.Context, storePath string) 
 	if errors.Is(err, sql.ErrNoRows) {
 		// Row didn't exist before the decrement; nothing to do.
 		if err := tx.Commit(); err != nil {
-			return 0, fmt.Errorf("dec store ref %q: commit: %w", storePath, err)
+			return 0, false, fmt.Errorf("dec store ref %q: commit: %w", storePath, err)
 		}
-		return 0, nil
+		return 0, false, nil
 	}
 	if err != nil {
-		return 0, fmt.Errorf("dec store ref %q: select: %w", storePath, err)
+		return 0, false, fmt.Errorf("dec store ref %q: select: %w", storePath, err)
 	}
 
 	if count <= 0 {
 		deleteQuery := r.dialect.q(`DELETE FROM nzb_store_refs WHERE store_path = ?`)
 		if _, err := tx.ExecContext(ctx, deleteQuery, storePath); err != nil {
-			return 0, fmt.Errorf("dec store ref %q: delete: %w", storePath, err)
+			return 0, false, fmt.Errorf("dec store ref %q: delete: %w", storePath, err)
 		}
 		count = 0
 	}
 
 	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("dec store ref %q: commit: %w", storePath, err)
+		return 0, false, fmt.Errorf("dec store ref %q: commit: %w", storePath, err)
 	}
-	return count, nil
+	return count, true, nil
 }
 
 // GetStoreRefCount returns the current ref_count for storePath.

--- a/internal/database/store_ref_repository_test.go
+++ b/internal/database/store_ref_repository_test.go
@@ -75,8 +75,9 @@ func TestStoreRefRepository_DecStoreRef_Decrement(t *testing.T) {
 	require.NoError(t, repo.IncStoreRef(ctx, storePath))
 
 	// Decrement: should return 2.
-	count, err := repo.DecStoreRef(ctx, storePath)
+	count, existed, err := repo.DecStoreRef(ctx, storePath)
 	require.NoError(t, err)
+	assert.True(t, existed, "a tracked store must report existed=true")
 	assert.Equal(t, int64(2), count)
 
 	// Verify via Get.
@@ -94,8 +95,9 @@ func TestStoreRefRepository_DecStoreRef_DeletesRowAtZero(t *testing.T) {
 	// Set up: increment once, then decrement back to zero.
 	require.NoError(t, repo.IncStoreRef(ctx, storePath))
 
-	count, err := repo.DecStoreRef(ctx, storePath)
+	count, existed, err := repo.DecStoreRef(ctx, storePath)
 	require.NoError(t, err)
+	assert.True(t, existed, "dropping the last reference must report existed=true")
 	assert.Equal(t, int64(0), count, "decrementing to zero should return 0")
 
 	// Row must be gone.
@@ -108,9 +110,11 @@ func TestStoreRefRepository_DecStoreRef_NoRow(t *testing.T) {
 	repo := setupStoreRefTestDB(t)
 	ctx := context.Background()
 
-	// Decrementing a non-existent row should not error and should return 0.
-	count, err := repo.DecStoreRef(ctx, "/store/ghost.nzbz")
+	// Decrementing a non-existent row must be distinguishable from dropping the
+	// last reference: callers unlink the store file only when existed is true.
+	count, existed, err := repo.DecStoreRef(ctx, "/store/ghost.nzbz")
 	require.NoError(t, err)
+	assert.False(t, existed, "an untracked store must report existed=false")
 	assert.Equal(t, int64(0), count)
 }
 
@@ -134,8 +138,9 @@ func TestStoreRefRepository_MultipleStores(t *testing.T) {
 	assert.Equal(t, int64(1), countB)
 
 	// Decrement A once; B should be unaffected.
-	newA, err := repo.DecStoreRef(ctx, pathA)
+	newA, existed, err := repo.DecStoreRef(ctx, pathA)
 	require.NoError(t, err)
+	assert.True(t, existed)
 	assert.Equal(t, int64(1), newA)
 
 	countB, err = repo.GetStoreRefCount(ctx, pathB)

--- a/internal/health/checker_fastfail_test.go
+++ b/internal/health/checker_fastfail_test.go
@@ -66,7 +66,7 @@ func TestCheckFilesBatch_TransportErrorIsNotCorruption(t *testing.T) {
 	writeHealthyFile(t, env, paths[1])
 	client.SetBehavior(flakyID, fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
 
-	events := env.healthChecker.CheckFilesBatch(context.Background(), paths)
+	events := env.healthChecker.CheckFilesBatch(context.Background(), paths, nil)
 	require.Len(t, events, 2)
 
 	assert.Equal(t, EventTypeCheckFailed, events[0].Type,
@@ -96,7 +96,7 @@ func TestCheckFilesBatch_TransportErrorPersistsNoHoles(t *testing.T) {
 	ids := writeMultiSegmentFile(t, env, path, 20)
 	client.SetBehavior(ids[3], fakepool.SegmentBehavior{Err: nntppool.ErrConnectionDied})
 
-	events := env.healthChecker.CheckFilesBatch(context.Background(), []string{path})
+	events := env.healthChecker.CheckFilesBatch(context.Background(), []string{path}, nil)
 	require.Len(t, events, 1)
 	assert.Equal(t, EventTypeCheckFailed, events[0].Type)
 
@@ -127,7 +127,7 @@ func TestCheckFilesBatch_FastFailStopsDoomedFileOnly(t *testing.T) {
 	writeMultiSegmentFile(t, env, paths[1], segCount)
 	client.SetBehavior(doomedIDs[0], fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
 
-	events := env.healthChecker.CheckFilesBatch(context.Background(), paths)
+	events := env.healthChecker.CheckFilesBatch(context.Background(), paths, nil)
 	require.Len(t, events, 2)
 
 	assert.Equal(t, EventTypeFileCorrupted, events[0].Type)
@@ -163,7 +163,7 @@ func TestCheckFilesBatch_NoFastFailWhenToleranceUnreached(t *testing.T) {
 	ids := writeMultiSegmentFile(t, env, path, segCount)
 	client.SetBehavior(ids[0], fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
 
-	events := env.healthChecker.CheckFilesBatch(context.Background(), []string{path})
+	events := env.healthChecker.CheckFilesBatch(context.Background(), []string{path}, nil)
 	require.Len(t, events, 1)
 
 	d := parseDetails(t, events[0])

--- a/internal/health/library_sync.go
+++ b/internal/health/library_sync.go
@@ -817,7 +817,6 @@ func (lsw *LibrarySyncWorker) SyncLibrary(ctx context.Context, dryRun bool) *Dry
 				previousPending = make(map[string]bool)
 			}
 
-			deleteSourceNzb := cfg.Metadata.ShouldDeleteSourceNzb()
 			deletedDirs := make(map[string]bool)
 
 			for relativeMountPath := range currentMetaOrphans {
@@ -830,7 +829,7 @@ func (lsw *LibrarySyncWorker) SyncLibrary(ctx context.Context, dryRun bool) *Dry
 				if previousPending[relativeMountPath] {
 					// Confirmed orphan: missing in two consecutive runs → safe to delete
 					if !dryRun {
-						if err := lsw.metadataService.DeleteFileMetadataWithSourceNzb(ctx, relativeMountPath, deleteSourceNzb); err != nil {
+						if err := lsw.metadataService.DeleteFileMetadata(ctx, relativeMountPath); err != nil {
 							if !os.IsNotExist(err) {
 								slog.ErrorContext(ctx, "Failed to delete confirmed orphaned metadata",
 									"path", relativeMountPath, "error", err)

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -634,7 +634,7 @@ func (hw *HealthWorker) deleteCorruptedFile(ctx context.Context, fh *database.Fi
 				rootPath = *cfg.Health.LibraryDir
 			}
 		}
-		if err := hw.metadataService.DeleteCorruptedFile(ctx, fh.FilePath, cfg.Metadata.ShouldDeleteSourceNzb(), physicalPath, rootPath); err != nil {
+		if err := hw.metadataService.DeleteCorruptedFile(ctx, fh.FilePath, physicalPath, rootPath); err != nil {
 			slog.ErrorContext(ctx, "Failed to delete corrupted file", "file_path", fh.FilePath, "error", err)
 			return err
 		}
@@ -1184,8 +1184,7 @@ func (hw *HealthWorker) cleanupZombieRecord(ctx context.Context, item *database.
 	relativePath := strings.TrimPrefix(item.FilePath, cfg.MountPath)
 	relativePath = strings.TrimPrefix(relativePath, "/")
 
-	deleteSourceNzb := cfg.Metadata.ShouldDeleteSourceNzb()
-	if delMetaErr := hw.metadataService.DeleteFileMetadataWithSourceNzb(ctx, relativePath, deleteSourceNzb); delMetaErr != nil {
+	if delMetaErr := hw.metadataService.DeleteFileMetadata(ctx, relativePath); delMetaErr != nil {
 		slog.ErrorContext(ctx, "Failed to delete metadata during cleanup", "file_path", item.FilePath, "error", delMetaErr)
 	} else {
 		hw.NotifyRcloneVFS(item.FilePath)

--- a/internal/importer/archive/rar/aggregator.go
+++ b/internal/importer/archive/rar/aggregator.go
@@ -396,7 +396,7 @@ func ProcessArchive(ctx context.Context, opts ProcessArchiveOptions) error {
 
 			metadataPath := metadataService.GetMetadataFilePath(item.virtualFilePath)
 			if _, err := os.Stat(metadataPath); err == nil {
-				_ = metadataService.DeleteFileMetadata(item.virtualFilePath)
+				_ = metadataService.DeleteFileMetadata(ctx, item.virtualFilePath)
 			}
 
 			if err := metadataService.WriteFileMetadataAuto(ctx, item.virtualFilePath, fileMeta, opts.SegmentIndex, opts.StoreRef); err != nil {

--- a/internal/importer/archive/sevenzip/aggregator.go
+++ b/internal/importer/archive/sevenzip/aggregator.go
@@ -331,7 +331,7 @@ func ProcessArchive(ctx context.Context, opts ProcessArchiveOptions) error {
 
 			metadataPath := metadataService.GetMetadataFilePath(item.virtualFilePath)
 			if _, err := os.Stat(metadataPath); err == nil {
-				_ = metadataService.DeleteFileMetadata(item.virtualFilePath)
+				_ = metadataService.DeleteFileMetadata(ctx, item.virtualFilePath)
 			}
 
 			if err := metadataService.WriteFileMetadataAuto(ctx, item.virtualFilePath, fileMeta, opts.SegmentIndex, opts.StoreRef); err != nil {

--- a/internal/importer/multifile/processor.go
+++ b/internal/importer/multifile/processor.go
@@ -141,7 +141,7 @@ func ProcessRegularFiles(
 
 			metadataPath := metadataService.GetMetadataFilePath(virtualPath)
 			if _, err := os.Stat(metadataPath); err == nil {
-				_ = metadataService.DeleteFileMetadata(virtualPath)
+				_ = metadataService.DeleteFileMetadata(ctx, virtualPath)
 			}
 
 			if err := metadataService.WriteFileMetadataAuto(ctx, virtualPath, fileMeta, storeIndex, storeRef); err != nil {

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -1404,7 +1404,7 @@ func (s *Service) cleanupWrittenPaths(ctx context.Context, itemID int64, paths [
 			}
 			s.cleanupHealthRecords(ctx, itemID, dirPath)
 		} else {
-			if delErr := s.metadataService.DeleteFileMetadata(p); delErr != nil {
+			if delErr := s.metadataService.DeleteFileMetadata(ctx, p); delErr != nil {
 				s.log.WarnContext(ctx, "Failed to clean up metadata file after import failure",
 					"queue_id", itemID,
 					"path", p,

--- a/internal/metadata/migration_convert_test.go
+++ b/internal/metadata/migration_convert_test.go
@@ -173,11 +173,14 @@ func (c *countingRefCounter) IncStoreRef(_ context.Context, storePath string) er
 	return nil
 }
 
-func (c *countingRefCounter) DecStoreRef(_ context.Context, storePath string) (int64, error) {
+func (c *countingRefCounter) DecStoreRef(_ context.Context, storePath string) (int64, bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.inc[storePath] == 0 {
+		return 0, false, nil
+	}
 	c.decs[storePath]++
-	return int64(c.inc[storePath] - c.decs[storePath]), nil
+	return int64(c.inc[storePath] - c.decs[storePath]), true, nil
 }
 
 func TestMigrateGroup_RefCountMatchesMigratedFiles(t *testing.T) {

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -744,28 +744,24 @@ func (ms *MetadataService) UpdateFileStatus(virtualPath string, status metapb.Fi
 	})
 }
 
-// DeleteFileMetadata deletes a metadata file
-func (ms *MetadataService) DeleteFileMetadata(virtualPath string) error {
-	return ms.DeleteFileMetadataWithSourceNzb(context.Background(), virtualPath, false)
-}
-
-// DeleteFileMetadataWithSourceNzb deletes a metadata file and optionally its source NZB
-func (ms *MetadataService) DeleteFileMetadataWithSourceNzb(ctx context.Context, virtualPath string, deleteSourceNzb bool) error {
+// DeleteFileMetadata deletes a metadata file, its .id sidecar, and — when this was
+// the last metadata file referencing it — the shared .nzbz store behind it.
+//
+// The store is a per-release artifact shared by every file of a multi-file import,
+// so its lifetime is governed exclusively by the reference count. Nothing here acts
+// on SourceNzbPath: for v3 metadata it aliases StoreRef, and removing it directly
+// destroyed the store out from under sibling files (issue #858).
+func (ms *MetadataService) DeleteFileMetadata(ctx context.Context, virtualPath string) error {
 	ms.liteCache.Remove(virtualPath)
 
 	filename := filepath.Base(virtualPath)
 	metadataDir := filepath.Join(ms.rootPath, filepath.Dir(virtualPath))
 	metadataPath := filepath.Join(metadataDir, filename+".meta")
 
-	// Always read metadata first to capture SourceNzbPath and StoreRef before deletion.
-	var sourceNzbPath string
-	var storeRef string
-	if metadata, err := ms.ReadFileMetadata(virtualPath); err == nil && metadata != nil {
-		if deleteSourceNzb {
-			sourceNzbPath = metadata.SourceNzbPath
-		}
-		storeRef = metadata.StoreRef
-	}
+	// Read StoreRef straight off the proto rather than via ReadFileMetadata: a full
+	// read resolves segments against the store, so on an install whose store is
+	// already missing it fails and we would lose the reference we need to decrement.
+	storeRef := ms.readStoreRef(metadataPath)
 
 	// Delete the metadata file
 	err := os.Remove(metadataPath)
@@ -782,28 +778,13 @@ func (ms *MetadataService) DeleteFileMetadataWithSourceNzb(ctx context.Context, 
 	// Clean up empty parent directories in metadata path
 	utils.RemoveEmptyDirs(ms.rootPath, metadataDir)
 
-	// Optionally delete the source NZB file (error-tolerant)
-	if deleteSourceNzb && sourceNzbPath != "" {
-		if err := os.Remove(sourceNzbPath); err != nil {
-			if !os.IsNotExist(err) {
-				slog.DebugContext(ctx, "Failed to delete source NZB file",
-					"nzb_path", sourceNzbPath,
-					"error", err)
-			}
-		} else {
-			slog.DebugContext(ctx, "Deleted source NZB file",
-				"nzb_path", sourceNzbPath,
-				"virtual_path", virtualPath)
-		}
-	}
-
 	// Decrement reference count for shared store file and delete it if no more refs.
 	if ms.storeRefCounter != nil && storeRef != "" {
-		newCount, err := ms.storeRefCounter.DecStoreRef(ctx, storeRef)
+		newCount, tracked, err := ms.storeRefCounter.DecStoreRef(ctx, storeRef)
 		if err != nil {
 			slog.WarnContext(ctx, "failed to decrement store ref count",
 				"store_path", storeRef, "error", err)
-		} else if newCount == 0 {
+		} else if tracked && newCount == 0 {
 			if removeErr := os.Remove(storeRef); removeErr != nil && !os.IsNotExist(removeErr) {
 				slog.WarnContext(ctx, "failed to delete orphaned store file",
 					"store_path", storeRef, "error", removeErr)
@@ -814,13 +795,13 @@ func (ms *MetadataService) DeleteFileMetadataWithSourceNzb(ctx context.Context, 
 	return nil
 }
 
-// DeleteCorruptedFile removes a file's metadata (and optionally its source NZB), then
-// removes the physical library file (if any) and cleans up now-empty parent directories
-// in the physical library tree. Metadata-tree cleanup is already handled by
-// DeleteFileMetadataWithSourceNzb; the physical-path removal is error-tolerant since
-// physicalPath is often just a view into the same mount and may already be gone.
-func (ms *MetadataService) DeleteCorruptedFile(ctx context.Context, virtualPath string, deleteSourceNzb bool, physicalPath string, physicalRoot string) error {
-	if err := ms.DeleteFileMetadataWithSourceNzb(ctx, virtualPath, deleteSourceNzb); err != nil {
+// DeleteCorruptedFile removes a file's metadata, then removes the physical library
+// file (if any) and cleans up now-empty parent directories in the physical library
+// tree. Metadata-tree cleanup is already handled by DeleteFileMetadata; the
+// physical-path removal is error-tolerant since physicalPath is often just a view
+// into the same mount and may already be gone.
+func (ms *MetadataService) DeleteCorruptedFile(ctx context.Context, virtualPath string, physicalPath string, physicalRoot string) error {
+	if err := ms.DeleteFileMetadata(ctx, virtualPath); err != nil {
 		return err
 	}
 	if physicalPath == "" {
@@ -879,17 +860,21 @@ func (ms *MetadataService) DeleteDirectory(virtualPath string) error {
 	if ms.storeRefCounter != nil {
 		for storePath, count := range storeRefCounts {
 			var lastCount int64
+			var lastTracked bool
 			for range count {
-				newCount, decErr := ms.storeRefCounter.DecStoreRef(ctx, storePath)
+				newCount, tracked, decErr := ms.storeRefCounter.DecStoreRef(ctx, storePath)
 				if decErr != nil {
 					slog.WarnContext(ctx, "failed to decrement store ref count",
 						"store_path", storePath, "error", decErr)
 					lastCount = -1 // mark as unknown; don't delete
+					lastTracked = false
 					break
 				}
-				lastCount = newCount
+				lastCount, lastTracked = newCount, tracked
 			}
-			if lastCount == 0 {
+			// An untracked store has an unknown ref count, not a zero one: leaking it
+			// is recoverable, deleting one a sibling still needs is not.
+			if lastTracked && lastCount == 0 {
 				if removeErr := os.Remove(storePath); removeErr != nil && !os.IsNotExist(removeErr) {
 					slog.WarnContext(ctx, "failed to delete orphaned store file",
 						"store_path", storePath, "error", removeErr)

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeleteFileMetadataWithSourceNzb_RemovesMetadata(t *testing.T) {
+func TestDeleteFileMetadata_RemovesMetadata(t *testing.T) {
 	root := t.TempDir()
 	ms := NewMetadataService(root)
 
@@ -30,12 +30,12 @@ func TestDeleteFileMetadataWithSourceNzb_RemovesMetadata(t *testing.T) {
 	require.FileExists(t, metaPath)
 
 	ctx := context.Background()
-	require.NoError(t, ms.DeleteFileMetadataWithSourceNzb(ctx, virtualPath, false))
+	require.NoError(t, ms.DeleteFileMetadata(ctx, virtualPath))
 
 	assert.NoFileExists(t, metaPath)
 }
 
-func TestDeleteFileMetadataWithSourceNzb_NoIDSidecar_NoError(t *testing.T) {
+func TestDeleteFileMetadata_NoIDSidecar_NoError(t *testing.T) {
 	root := t.TempDir()
 	ms := NewMetadataService(root)
 
@@ -48,7 +48,7 @@ func TestDeleteFileMetadataWithSourceNzb_NoIDSidecar_NoError(t *testing.T) {
 	require.NoError(t, ms.WriteFileMetadata(virtualPath, meta))
 
 	ctx := context.Background()
-	err := ms.DeleteFileMetadataWithSourceNzb(ctx, virtualPath, false)
+	err := ms.DeleteFileMetadata(ctx, virtualPath)
 	assert.NoError(t, err, "delete should succeed even without .id sidecar")
 
 	assert.NoFileExists(t, ms.GetMetadataFilePath(virtualPath))

--- a/internal/metadata/store_lifetime_test.go
+++ b/internal/metadata/store_lifetime_test.go
@@ -1,0 +1,224 @@
+package metadata
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeStoreRefCounter mirrors StoreRefRepository semantics in-memory: a store is
+// "tracked" once incremented, and its row disappears when the count reaches zero.
+type fakeStoreRefCounter struct {
+	counts map[string]int64
+}
+
+func newFakeStoreRefCounter() *fakeStoreRefCounter {
+	return &fakeStoreRefCounter{counts: make(map[string]int64)}
+}
+
+func (f *fakeStoreRefCounter) IncStoreRef(_ context.Context, storePath string) error {
+	f.counts[storePath]++
+	return nil
+}
+
+func (f *fakeStoreRefCounter) DecStoreRef(_ context.Context, storePath string) (int64, bool, error) {
+	count, ok := f.counts[storePath]
+	if !ok {
+		return 0, false, nil
+	}
+	count--
+	if count <= 0 {
+		delete(f.counts, storePath)
+		return 0, true, nil
+	}
+	f.counts[storePath] = count
+	return count, true, nil
+}
+
+func (f *fakeStoreRefCounter) tracked(storePath string) bool {
+	_, ok := f.counts[storePath]
+	return ok
+}
+
+// writeSharedRelease writes n v3 metadata files that all point at a single .nzbz
+// store, exactly as a season-pack import does, and returns their virtual paths.
+func writeSharedRelease(t *testing.T, ms *MetadataService, storeRef string, names ...string) []string {
+	t.Helper()
+	return writeSharedReleaseIn(t, ms, storeRef, "tv", names...)
+}
+
+// writeSharedReleaseIn is writeSharedRelease with an explicit parent directory, for
+// cases where one store is referenced from more than one directory.
+func writeSharedReleaseIn(t *testing.T, ms *MetadataService, storeRef, dir string, names ...string) []string {
+	t.Helper()
+
+	segs := make([]*metapb.NzbSeg, len(names))
+	for i, name := range names {
+		segs[i] = &metapb.NzbSeg{Id: name + "@n", Number: int32(i + 1), Bytes: 100}
+	}
+	store := &metapb.NzbStore{Files: []*metapb.NzbFileEntry{{
+		Subject:  "Season Pack",
+		Segments: segs,
+	}}}
+	require.NoError(t, ms.Store().WriteStore(storeRef, store))
+
+	paths := make([]string, len(names))
+	for i, name := range names {
+		vpath := filepath.Join(dir, name)
+		paths[i] = vpath
+		meta := &metapb.FileMetadata{
+			FileSize: 100,
+			Status:   metapb.FileStatus_FILE_STATUS_HEALTHY,
+			StoreRef: storeRef,
+			// v3 aliases source_nzb_path onto the store; the raw .nzb is long gone.
+			SourceNzbPath: storeRef,
+			SegmentRefs: []*metapb.SegmentRef{
+				{StoreIndex: int64(i), StartOffset: 0, EndOffset: 99},
+			},
+		}
+		require.NoError(t, ms.WriteFileMetadata(vpath, meta))
+		ms.IncStoreRef(context.Background(), storeRef)
+	}
+	return paths
+}
+
+func TestDeleteFileMetadata_SharedStoreSurvivesWhileSiblingsReference(t *testing.T) {
+	ms := NewMetadataService(t.TempDir())
+	refs := newFakeStoreRefCounter()
+	ms.SetStoreRefCounter(refs)
+
+	storeRef := filepath.Join(t.TempDir(), "10767-release.nzbz")
+	paths := writeSharedRelease(t, ms, storeRef, "s01e01.mkv", "s01e02.mkv", "s01e03.mkv")
+
+	ctx := context.Background()
+	require.NoError(t, ms.DeleteFileMetadata(ctx, paths[0]))
+
+	assert.FileExists(t, storeRef, "shared store must survive while siblings still reference it")
+	assert.Equal(t, int64(2), refs.counts[storeRef], "ref count must drop by exactly one")
+
+	assert.NoFileExists(t, ms.GetMetadataFilePath(paths[0]))
+	for _, survivor := range paths[1:] {
+		got, err := ms.ReadFileMetadata(survivor)
+		require.NoError(t, err, "surviving metadata must remain readable")
+		require.NotNil(t, got)
+		assert.Len(t, got.SegmentData, 1)
+	}
+}
+
+func TestDeleteFileMetadata_StoreRemovedOnLastReference(t *testing.T) {
+	ms := NewMetadataService(t.TempDir())
+	refs := newFakeStoreRefCounter()
+	ms.SetStoreRefCounter(refs)
+
+	storeRef := filepath.Join(t.TempDir(), "10767-release.nzbz")
+	paths := writeSharedRelease(t, ms, storeRef, "s01e01.mkv", "s01e02.mkv")
+
+	ctx := context.Background()
+	for _, p := range paths {
+		require.NoError(t, ms.DeleteFileMetadata(ctx, p))
+	}
+
+	assert.NoFileExists(t, storeRef, "store must be removed once the last reference is gone")
+	assert.False(t, refs.tracked(storeRef), "ref count row must be removed with the store")
+}
+
+func TestDeleteFileMetadata_UntrackedStoreIsNotRemoved(t *testing.T) {
+	ms := NewMetadataService(t.TempDir())
+	refs := newFakeStoreRefCounter()
+
+	storeRef := filepath.Join(t.TempDir(), "premigration.nzbz")
+	// Written before the refcounter exists, as v3 metadata predating migration 032 was.
+	paths := writeSharedRelease(t, ms, storeRef, "s01e01.mkv", "s01e02.mkv")
+	ms.SetStoreRefCounter(refs)
+
+	ctx := context.Background()
+	require.NoError(t, ms.DeleteFileMetadata(ctx, paths[0]))
+
+	assert.FileExists(t, storeRef,
+		"an untracked store must be left alone: a missing row means unknown refs, not zero refs")
+
+	got, err := ms.ReadFileMetadata(paths[1])
+	require.NoError(t, err)
+	require.NotNil(t, got)
+}
+
+func TestDeleteFileMetadata_DecrementsWhenStoreFileAlreadyGone(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+	refs := newFakeStoreRefCounter()
+	ms.SetStoreRefCounter(refs)
+
+	storeRef := filepath.Join(t.TempDir(), "10767-release.nzbz")
+	paths := writeSharedRelease(t, ms, storeRef, "s01e01.mkv", "s01e02.mkv")
+
+	// Reproduces an install already damaged by the old purge behaviour: the store
+	// is gone but the refcount rows remain. A second service starts with a cold
+	// store cache, so reading this metadata genuinely fails the way it does after
+	// a restart — deletion must still decrement rather than stranding the count.
+	require.NoError(t, os.Remove(storeRef))
+	restarted := NewMetadataService(root)
+	restarted.SetStoreRefCounter(refs)
+
+	ctx := context.Background()
+	_, readErr := restarted.ReadFileMetadata(paths[0])
+	require.Error(t, readErr, "test premise: the metadata must be unreadable without its store")
+
+	require.NoError(t, restarted.DeleteFileMetadata(ctx, paths[0]))
+
+	assert.Equal(t, int64(1), refs.counts[storeRef],
+		"deletion must decrement even when the store file cannot be read")
+}
+
+func TestDeleteDirectory_UntrackedStoreIsNotRemoved(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+	refs := newFakeStoreRefCounter()
+
+	storeRef := filepath.Join(t.TempDir(), "premigration.nzbz")
+	// Written before the refcounter exists, as v3 metadata predating migration 032 was.
+	writeSharedRelease(t, ms, storeRef, "s01e01.mkv", "s01e02.mkv")
+	ms.SetStoreRefCounter(refs)
+
+	require.NoError(t, ms.DeleteDirectory("tv"))
+
+	assert.FileExists(t, storeRef,
+		"an untracked store must be left alone: a missing row means unknown refs, not zero refs")
+}
+
+func TestDeleteDirectory_RemovesStoreWhenDirectoryHeldEveryReference(t *testing.T) {
+	ms := NewMetadataService(t.TempDir())
+	refs := newFakeStoreRefCounter()
+	ms.SetStoreRefCounter(refs)
+
+	storeRef := filepath.Join(t.TempDir(), "10767-release.nzbz")
+	writeSharedRelease(t, ms, storeRef, "s01e01.mkv", "s01e02.mkv", "s01e03.mkv")
+
+	require.NoError(t, ms.DeleteDirectory("tv"))
+
+	assert.NoFileExists(t, storeRef, "store must be removed once the directory held its last reference")
+	assert.False(t, refs.tracked(storeRef), "ref count row must be removed with the store")
+}
+
+func TestDeleteDirectory_KeepsStoreReferencedFromOutsideTheDirectory(t *testing.T) {
+	ms := NewMetadataService(t.TempDir())
+	refs := newFakeStoreRefCounter()
+	ms.SetStoreRefCounter(refs)
+
+	storeRef := filepath.Join(t.TempDir(), "10767-release.nzbz")
+	writeSharedReleaseIn(t, ms, storeRef, "tv", "s01e01.mkv", "s01e02.mkv")
+	outside := writeSharedReleaseIn(t, ms, storeRef, "movies", "extra.mkv")
+
+	require.NoError(t, ms.DeleteDirectory("tv"))
+
+	assert.FileExists(t, storeRef, "store must survive while metadata outside the directory references it")
+	assert.Equal(t, int64(1), refs.counts[storeRef], "only the references inside the directory may be dropped")
+
+	got, err := ms.ReadFileMetadata(outside[0])
+	require.NoError(t, err, "metadata outside the deleted directory must remain readable")
+	require.NotNil(t, got)
+}

--- a/internal/metadata/store_ref_counter.go
+++ b/internal/metadata/store_ref_counter.go
@@ -6,5 +6,8 @@ import "context"
 // Implementations are provided by the database layer; the nil value is always safe to use.
 type StoreRefCounter interface {
 	IncStoreRef(ctx context.Context, storePath string) error
-	DecStoreRef(ctx context.Context, storePath string) (int64, error)
+	// DecStoreRef decrements the count and reports whether the store was tracked
+	// at all. A count of 0 is only meaningful as "no references remain" when the
+	// second value is true; an untracked store has an unknown, not zero, ref count.
+	DecStoreRef(ctx context.Context, storePath string) (int64, bool, error)
 }

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -354,12 +354,10 @@ func (mrf *MetadataRemoteFile) RemoveFile(ctx context.Context, fileName string) 
 		}
 	}
 
-	// Check if we should delete the source NZB file
 	cfg := mrf.configGetter()
-	deleteSourceNzb := cfg.Metadata.ShouldDeleteSourceNzb()
 
-	// Use MetadataService's file delete operation with optional NZB deletion
-	err := mrf.metadataService.DeleteFileMetadataWithSourceNzb(ctx, normalizedName, deleteSourceNzb)
+	// Deletes the .meta and, once the last sibling is gone, the shared .nzbz store.
+	err := mrf.metadataService.DeleteFileMetadata(ctx, normalizedName)
 	if err != nil {
 		return true, err
 	}
@@ -2418,7 +2416,7 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 			}
 		}
 
-		if err := mvf.metadataService.DeleteCorruptedFile(ctx, mvf.name, cfg.Metadata.ShouldDeleteSourceNzb(), physicalPath, rootPath); err != nil {
+		if err := mvf.metadataService.DeleteCorruptedFile(ctx, mvf.name, physicalPath, rootPath); err != nil {
 			slog.ErrorContext(ctx, "Failed to delete corrupted file after streaming failure", "file", mvf.name, "error", err)
 		} else {
 			// The file this handle is reading no longer exists; latch it closed,

--- a/internal/stremio/cleanup.go
+++ b/internal/stremio/cleanup.go
@@ -87,9 +87,9 @@ func (s *StremioCleanupService) deleteItem(ctx context.Context, item *database.I
 					"path", item.NzbPath, "error", err)
 			}
 		} else {
-			// Single file: delete .meta + source NZB together
-			if err := s.metadataService.DeleteFileMetadataWithSourceNzb(ctx, storagePath, true); err != nil {
-				slog.ErrorContext(ctx, "StremioCleanup: failed to delete meta+nzb",
+			// Single file: delete .meta; the store follows once unreferenced
+			if err := s.metadataService.DeleteFileMetadata(ctx, storagePath); err != nil {
+				slog.ErrorContext(ctx, "StremioCleanup: failed to delete meta",
 					"path", storagePath, "error", err)
 			}
 		}


### PR DESCRIPTION
Fixes #858.

## Problem

v3 metadata assigns the shared per-release `.nzbz` store to **both** fields:

```go
m.StoreRef = storeRef
m.SourceNzbPath = storeRef
```

`DeleteFileMetadataWithSourceNzb` then unlinked `SourceNzbPath` *before* consulting the reference count. With `delete_source_nzb_on_removal: true`, deleting any one file of a multi-file import destroyed the store every sibling still needed. Automatic library orphan cleanup walks files individually, so one unlinked episode of a season pack took the whole release's store with it, leaving the episode Sonarr *had* imported unreadable:

```
failed to read store "/config/.nzbs/TV-lq/10767-release.nzbz": no such file or directory
```

Two aggravating defects turned up while fixing it:

- **The health and library-sync workers had no refcounter at all.** `SetStoreRefCounter` is called in exactly one place (`internal/importer/service.go:224`), but `startHealthWorker` built its *own* `MetadataService`. Those deletions ran the `os.Remove` branch while skipping `DecStoreRef` entirely — the reporter's "store gone, `ref_count` still 8". That instance also carried a separate lite cache the other never invalidated.
- **`DecStoreRef` returned `0` both for "last reference dropped" and "no row exists",** and the caller unlinked on `0`. Any v3 metadata predating migration `032`, or any lost best-effort `Inc`, destroyed its store on first removal.

## Approach

The raw `.nzb` is already transient — deleted on successful import (`internal/importer/service.go:1289`), otherwise kept only in `.nzbs/failed/{category}` under `import.failed_item_retention_hours`. NZBs are regenerated from the store on demand. The purge setting therefore governed a file that no longer exists, and for v3 metadata pointed at the store instead. Removing it makes the intended retention model real: **metadata + `.nzbz` are the only persistent artifacts, and the store is unlinked solely when its refcount reaches zero.**

Because the flag defaulted to `false`, this narrows behaviour rather than widening it — it is what nearly every install already did.

## Changes

- Remove `metadata.delete_source_nzb_on_removal` / `ShouldDeleteSourceNzb()`, the "Purge Source NZB" checkbox, both sample configs, and both API schemas. Retired keys only warn on load (`internal/config/manager.go:1968`), so existing configs keep working.
- Collapse `DeleteFileMetadataWithSourceNzb(ctx, path, bool)` into `DeleteFileMetadata(ctx, path)`; drop the bool from `DeleteCorruptedFile`. This also removes `internal/stremio/cleanup.go`'s hardcoded `true`.
- Read `StoreRef` via `readStoreRef` instead of `ReadFileMetadata`, so deletion still decrements on installs whose store is already missing — a full read resolves segments against the store, fails there, and strands the count.
- `DecStoreRef` returns `(count, existed, err)`; the store is unlinked only on `existed && count == 0`. Same guard applied to `DeleteDirectory`'s decrement loop. Unknown ref state now leaks a store rather than orphaning metadata — the recoverable direction.
- Share the process-wide `MetadataService` with the health and library-sync workers.

## Test plan

New `internal/metadata/store_lifetime_test.go`:

- [x] N metadata files sharing one store; delete one → store survives, count drops by exactly one, siblings still readable
- [x] Delete the last referrer → store file and refcount row both removed
- [x] Untracked store (written before the refcounter existed) → left alone, for both `DeleteFileMetadata` and `DeleteDirectory`
- [x] Store file already missing → deletion still decrements (asserts the read genuinely fails first, so the premise can't silently rot)
- [x] `DeleteDirectory` holding every reference → store removed; holding only some, with a referrer outside the directory → store survives

Three of these failed first for the right reason (store deleted while siblings referenced it). One initially passed for a bogus reason — `WriteStore` warms the store cache — so it was reworked to use a cold-cache service. The two `DeleteDirectory` positive tests passed on first run, so they were mutation-tested: collapsing the decrement loop to a single call fails both.

Verified: `go build ./...`, `go vet ./...`, `go test ./...`, `-race` green on metadata / database / health / config / importer / nzbfilesystem / stremio / api, `make build`, and frontend `bun run check` + `bun run build`.

`make` (default target) and `make lint` fail in this environment on a missing `protoc-gen-go` and a Go 1.27 export-data mismatch in `internal/encryption/rclone/pkcs7/pkcs7.go` respectively — both pre-existing and unrelated to files touched here.

## Not included

The issue also suggests reconciling `nzb_store_refs` against the `.meta` tree at startup. Deferred: with the `existed` guard in place, a stale high count only leaks a store, it can no longer orphan metadata. Worth its own issue.
