### PR TITLE
fix(segcache): prevent boot stream truncation via blocking catalog hydration with 30s timeout safety

### DIFF
--- a/internal/nzbfilesystem/segcache/cache.go
+++ b/internal/nzbfilesystem/segcache/cache.go
@@ -295,20 +295,27 @@ func (c *SegmentCache) LoadCatalog() {
 		return
 	}
 
-	var totalSize int64
 	valid := make(map[string]*cacheEntry, len(items))
 
 	for id, e := range items {
 		if _, statErr := os.Stat(e.DataPath); statErr == nil {
 			valid[id] = e
-			totalSize += e.Size
 		}
 	}
 
+	// Merge rather than replace: a Put that escaped waitReady via the hydration
+	// timeout may already have inserted entries, and those are fresher than the
+	// catalog's. Replacing the map would orphan their .seg files.
 	c.mu.Lock()
-	c.items = valid
-	c.totalSize = totalSize
+	for id, e := range valid {
+		if _, exists := c.items[id]; !exists {
+			c.items[id] = e
+			c.totalSize += e.Size
+		}
+	}
+	loaded := len(c.items)
+	total := c.totalSize
 	c.mu.Unlock()
 
-	c.logger.Info("segcache: catalog loaded", "items", len(valid), "total_bytes", totalSize)
+	c.logger.Info("segcache: catalog loaded", "items", loaded, "total_bytes", total)
 }

--- a/internal/nzbfilesystem/segcache/cache.go
+++ b/internal/nzbfilesystem/segcache/cache.go
@@ -20,9 +20,10 @@ import (
 
 // Config holds segment cache storage settings.
 type Config struct {
-	CachePath      string
-	MaxSizeBytes   int64
-	ExpiryDuration time.Duration
+	CachePath        string
+	MaxSizeBytes     int64
+	ExpiryDuration   time.Duration
+	HydrationTimeout time.Duration
 }
 
 type cacheEntry struct {
@@ -42,7 +43,8 @@ type SegmentCache struct {
 	logger    *slog.Logger
 	totalSize int64
 	dirty     atomic.Bool
-	loading   atomic.Bool
+	ready     chan struct{}
+	readyOnce sync.Once
 }
 
 // NewSegmentCache creates a new segment cache. It does NOT load any existing
@@ -57,12 +59,28 @@ func NewSegmentCache(cfg Config, logger *slog.Logger) (*SegmentCache, error) {
 		items:  make(map[string]*cacheEntry),
 		config: cfg,
 		logger: logger,
+		ready:  make(chan struct{}),
 	}
 	return c, nil
 }
 
+const defaultHydrationTimeout = 30 * time.Second
+
+func (c *SegmentCache) waitReady() {
+	timeout := c.config.HydrationTimeout
+	if timeout <= 0 {
+		timeout = defaultHydrationTimeout
+	}
+	select {
+	case <-c.ready:
+	case <-time.After(timeout):
+		c.logger.Warn("segcache: catalog hydration wait timed out, proceeding unblocked")
+	}
+}
+
 // Has reports whether the segment is present in the cache (no disk I/O).
 func (c *SegmentCache) Has(messageID string) bool {
+	c.waitReady()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	_, ok := c.items[messageID]
@@ -71,6 +89,7 @@ func (c *SegmentCache) Has(messageID string) bool {
 
 // Get returns the decoded segment bytes. Returns (nil, false) on miss.
 func (c *SegmentCache) Get(messageID string) ([]byte, bool) {
+	c.waitReady()
 	c.mu.Lock()
 	e, ok := c.items[messageID]
 	if !ok {
@@ -97,12 +116,7 @@ func (c *SegmentCache) Get(messageID string) ([]byte, bool) {
 
 // Put stores segment bytes atomically (temp-write + rename).
 func (c *SegmentCache) Put(messageID string, data []byte) error {
-	// Skip caching while the catalog hydrates. The segment is still served from
-	// Usenet, just not persisted this round; it gets cached on the next request
-	// after load. Avoids Put/load lock contention on boot.
-	if c.loading.Load() {
-		return nil
-	}
+	c.waitReady()
 
 	h := sha256.Sum256([]byte(messageID))
 	filename := hex.EncodeToString(h[:]) + ".seg"
@@ -141,6 +155,7 @@ func (c *SegmentCache) Put(messageID string, data []byte) error {
 
 // Evict removes the oldest entries (by LastAccess) until total size is within MaxSizeBytes.
 func (c *SegmentCache) Evict() {
+	c.waitReady()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -183,6 +198,7 @@ func (c *SegmentCache) Cleanup() {
 		return
 	}
 
+	c.waitReady()
 	deadline := time.Now().Add(-c.config.ExpiryDuration)
 
 	c.mu.Lock()
@@ -204,6 +220,7 @@ func (c *SegmentCache) Cleanup() {
 
 // TotalSize returns the total bytes occupied by cached segments.
 func (c *SegmentCache) TotalSize() int64 {
+	c.waitReady()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.totalSize
@@ -211,6 +228,7 @@ func (c *SegmentCache) TotalSize() int64 {
 
 // ItemCount returns the number of cached segments.
 func (c *SegmentCache) ItemCount() int {
+	c.waitReady()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return len(c.items)
@@ -219,6 +237,7 @@ func (c *SegmentCache) ItemCount() int {
 // SaveCatalog flushes the in-memory catalog to disk (catalog.json) atomically.
 // It is a no-op when the catalog has not changed since the last flush.
 func (c *SegmentCache) SaveCatalog() error {
+	c.waitReady()
 	if !c.dirty.Load() {
 		return nil
 	}
@@ -254,13 +273,12 @@ func (c *SegmentCache) SaveCatalog() error {
 }
 
 // LoadCatalog hydrates the in-memory catalog from catalog.json on disk, statting
-// each .seg file and dropping entries whose data is missing. Put is gated off
-// (see the loading flag) for the duration, so the load can assign the map
-// wholesale without racing a concurrent writer. Sets the gate on entry and
-// clears it on exit.
+// each .seg file and dropping entries whose data is missing. Operations on the cache
+// wait for ready channel to close, guaranteeing safe access after hydration completes.
 func (c *SegmentCache) LoadCatalog() {
-	c.loading.Store(true)
-	defer c.loading.Store(false)
+	defer c.readyOnce.Do(func() {
+		close(c.ready)
+	})
 
 	catalogPath := filepath.Join(c.config.CachePath, "catalog.json")
 	c.logger.Info("segcache: loading catalog", "path", catalogPath)

--- a/internal/nzbfilesystem/segcache/cache_internal_test.go
+++ b/internal/nzbfilesystem/segcache/cache_internal_test.go
@@ -2,31 +2,62 @@ package segcache
 
 import (
 	"log/slog"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestPutIgnoredWhileLoading guards the loading gate that replaced the
-// merge-under-lock path: while the catalog hydrates, Put must be a silent no-op
-// so a segment downloaded during cold load neither contends with the load nor
-// gets clobbered by the wholesale map assignment in LoadCatalog. Once the gate
-// clears, Put works normally again.
-func TestPutIgnoredWhileLoading(t *testing.T) {
+// TestOperationsBlockUntilLoaded verifies that Put/Get/Has block until LoadCatalog completes,
+// ensuring no cache misses or race conditions during boot hydration.
+func TestOperationsBlockUntilLoaded(t *testing.T) {
 	cfg := Config{CachePath: t.TempDir(), MaxSizeBytes: 10 * 1024 * 1024}
 	c, err := NewSegmentCache(cfg, slog.Default())
 	require.NoError(t, err)
 
-	c.loading.Store(true)
+	var (
+		wg      sync.WaitGroup
+		putDone = make(chan struct{})
+	)
 
-	require.NoError(t, c.Put("busy@msg", []byte("data")))
-	assert.False(t, c.Has("busy@msg"), "Put must be ignored while catalog is loading")
-	assert.EqualValues(t, 0, c.ItemCount())
-	assert.EqualValues(t, 0, c.TotalSize())
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := c.Put("busy@msg", []byte("data"))
+		assert.NoError(t, err)
+		close(putDone)
+	}()
 
-	c.loading.Store(false)
+	// Ensure the goroutine is blocked waiting for hydration
+	select {
+	case <-putDone:
+		t.Fatal("Put should have blocked until LoadCatalog")
+	case <-time.After(50 * time.Millisecond):
+	}
 
-	require.NoError(t, c.Put("busy@msg", []byte("data")))
+	// Now hydrate the catalog
+	c.LoadCatalog()
+
+	// Put should complete
+	wg.Wait()
 	assert.True(t, c.Has("busy@msg"))
+	assert.EqualValues(t, 1, c.ItemCount())
+}
+
+// TestOperationsProceedWhenHydrationTimesOut guards against deadlocks if LoadCatalog is never called.
+func TestOperationsProceedWhenHydrationTimesOut(t *testing.T) {
+	cfg := Config{
+		CachePath:        t.TempDir(),
+		MaxSizeBytes:     10 * 1024 * 1024,
+		HydrationTimeout: 20 * time.Millisecond,
+	}
+	c, err := NewSegmentCache(cfg, slog.Default())
+	require.NoError(t, err)
+
+	// Put without calling LoadCatalog: should unblock after HydrationTimeout and succeed.
+	err = c.Put("unhydrated@msg", []byte("data"))
+	assert.NoError(t, err)
+	assert.True(t, c.Has("unhydrated@msg"))
 }

--- a/internal/nzbfilesystem/segcache/cache_internal_test.go
+++ b/internal/nzbfilesystem/segcache/cache_internal_test.go
@@ -61,3 +61,33 @@ func TestOperationsProceedWhenHydrationTimesOut(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, c.Has("unhydrated@msg"))
 }
+
+// TestLoadCatalogKeepsEntriesFromEscapedPuts verifies that a Put that proceeded
+// past the hydration timeout is not clobbered when LoadCatalog later hydrates,
+// which would orphan its .seg file on disk.
+func TestLoadCatalogKeepsEntriesFromEscapedPuts(t *testing.T) {
+	dir := t.TempDir()
+
+	seed, err := NewSegmentCache(Config{CachePath: dir, MaxSizeBytes: 10 * 1024 * 1024}, slog.Default())
+	require.NoError(t, err)
+	seed.LoadCatalog()
+	require.NoError(t, seed.Put("old@msg", []byte("old-data")))
+	require.NoError(t, seed.SaveCatalog())
+
+	c, err := NewSegmentCache(Config{
+		CachePath:        dir,
+		MaxSizeBytes:     10 * 1024 * 1024,
+		HydrationTimeout: 20 * time.Millisecond,
+	}, slog.Default())
+	require.NoError(t, err)
+
+	// Escapes waitReady via the timeout, landing in the map before hydration.
+	require.NoError(t, c.Put("escaped@msg", []byte("escaped-data")))
+
+	c.LoadCatalog()
+
+	assert.True(t, c.Has("escaped@msg"))
+	assert.True(t, c.Has("old@msg"))
+	assert.EqualValues(t, 2, c.ItemCount())
+	assert.EqualValues(t, int64(len("old-data")+len("escaped-data")), c.TotalSize())
+}


### PR DESCRIPTION
## Description
Fixes cold-start stream truncation by synchronizing segment cache access during startup catalog hydration.

### Problem
Previously (#757), catalog loading was moved to a background goroutine and gated by an `atomic.Bool loading` flag. When a client requested a stream immediately after server boot:
1. The cache map `c.items` was empty, so `Get()` returned misses for all cached segments.
2. The reader was forced to cold-dial NNTP connections and fire 30–60 simultaneous requests over the wire.
3. `Put()` silently skipped caching while `loading` was true, and any `Put()` that landed before the flag was set was clobbered when `LoadCatalog()` assigned `c.items = valid`.
4. If any cold NNTP request stalled, `http.ServeContent` had already committed the `206 Partial Content` header and `Content-Length`, resulting in an unexpected connection drop mid-stream (curl 18).

### Solution
- Replaced `loading` boolean with a `ready chan struct{}` and `sync.Once`.
- Cache operations wait on `c.waitReady()` before accessing the map.
- Added a `30 * time.Second` bounded timeout (`HydrationTimeout`, configurable via `Config`) so degraded physical disk I/O or an uncalled `LoadCatalog` never indefinitely deadlocks streaming goroutines.
- Added unit tests verifying blocking behavior and timeout fallback.

### Verification
- `go test ./...` passed across all packages.
- `golangci-lint` passed with 0 issues.