### PR TITLE
fix(metadata): normalize backslashes in virtual paths to prevent FUSE open() deadlock

### DIFF
--- a/internal/importer/postprocessor/category_injection_test.go
+++ b/internal/importer/postprocessor/category_injection_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -92,7 +93,8 @@ func TestCreateSymlinks_WithCategoryInjection(t *testing.T) {
 
 	// Setup Coordinator
 	coord := NewCoordinator(Config{
-		ConfigGetter: configGetter,
+		ConfigGetter:    configGetter,
+		MetadataService: metadata.NewMetadataService(metadataDir),
 	})
 
 	// Test Scenario 1: Injection Needed

--- a/internal/importer/postprocessor/path_stripping_test.go
+++ b/internal/importer/postprocessor/path_stripping_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -73,7 +74,8 @@ func TestCreateSymlinks_WithIsolation(t *testing.T) {
 
 	// Setup Coordinator
 	coord := NewCoordinator(Config{
-		ConfigGetter: configGetter,
+		ConfigGetter:    configGetter,
+		MetadataService: metadata.NewMetadataService(metadataDir),
 	})
 
 	// Call CreateSymlinks
@@ -153,8 +155,9 @@ func TestCreateStrmFiles_WithIsolation(t *testing.T) {
 
 	// Setup Coordinator
 	coord := NewCoordinator(Config{
-		ConfigGetter: configGetter,
-		UserRepo:     userRepo,
+		ConfigGetter:    configGetter,
+		UserRepo:        userRepo,
+		MetadataService: metadata.NewMetadataService(metadataDir),
 	})
 
 	// Call CreateStrmFiles

--- a/internal/importer/postprocessor/strm_generator.go
+++ b/internal/importer/postprocessor/strm_generator.go
@@ -47,12 +47,12 @@ func (c *Coordinator) CreateStrmFiles(ctx context.Context, item *database.Import
 	resultingPath = buildLibraryRelPath(resultingPath, cfg.SABnzbd.CompleteDir, category)
 
 	// Check the metadata directory to determine if this is a file or directory
-	metadataPath := filepath.Join(cfg.Metadata.RootPath, strings.TrimPrefix(originalResultingPath, "/"))
+	metadataPath := c.metadataService.GetMetadataDirectoryPath(originalResultingPath)
 	fileInfo, err := os.Stat(metadataPath)
 
 	// If stat fails, check if it's a .meta file (single file case)
 	if err != nil {
-		metaFile := metadataPath + ".meta"
+		metaFile := c.metadataService.GetMetadataFilePath(originalResultingPath)
 		if _, metaErr := os.Stat(metaFile); metaErr == nil {
 			return c.CreateSingleStrmFile(ctx, resultingPath, originalResultingPath, cfg.WebDAV.Port)
 		}

--- a/internal/importer/postprocessor/strm_generator_test.go
+++ b/internal/importer/postprocessor/strm_generator_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/metadata"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -127,8 +128,9 @@ func TestCreateStrmFiles_HostConfiguration(t *testing.T) {
 
 			// Setup Coordinator
 			coord := NewCoordinator(Config{
-				ConfigGetter: configGetter,
-				UserRepo:     userRepo,
+				ConfigGetter:    configGetter,
+				UserRepo:        userRepo,
+				MetadataService: metadata.NewMetadataService(metadataDir),
 			})
 
 			// Call CreateStrmFiles

--- a/internal/importer/postprocessor/symlink_creator.go
+++ b/internal/importer/postprocessor/symlink_creator.go
@@ -56,12 +56,12 @@ func (c *Coordinator) CreateSymlinks(ctx context.Context, item *database.ImportQ
 	actualPath := filepath.Join(cfg.MountPath, strings.TrimPrefix(originalResultingPath, "/"))
 
 	// Check the metadata directory to determine if this is a file or directory
-	metadataPath := filepath.Join(cfg.Metadata.RootPath, strings.TrimPrefix(originalResultingPath, "/"))
+	metadataPath := c.metadataService.GetMetadataDirectoryPath(originalResultingPath)
 	fileInfo, err := os.Stat(metadataPath)
 
 	// If stat fails, check if it's a .meta file (single file case)
 	if err != nil {
-		metaFile := metadataPath + ".meta"
+		metaFile := c.metadataService.GetMetadataFilePath(originalResultingPath)
 		if _, metaErr := os.Stat(metaFile); metaErr == nil {
 			return c.createSingleSymlink(actualPath, resultingPath)
 		}

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -133,34 +134,65 @@ func (ms *MetadataService) readStoreRef(metaFilePath string) string {
 	return fm.StoreRef
 }
 
-// truncateFilename truncates the filename if it's too long to prevent filesystem issues
-// when creating .meta files. Keeps filename under 250 characters.
+// normalizeVirtualPath canonicalizes a virtual path so every caller ends up
+// with exactly one on-disk name and one liteCache key for the same file.
+// A backslash is a legal Linux filename byte but deadlocks the FUSE
+// page-cache layer on open() (issue #660), so it's folded to forward slash;
+// path.Clean (not filepath.Clean, which would turn it back into a backslash
+// on Windows) then collapses "//" and "..", and the leading slash is
+// stripped so "/x" and "x" collapse to one key.
+func normalizeVirtualPath(virtualPath string) string {
+	v := strings.ReplaceAll(virtualPath, "\\", "/")
+	v = path.Clean(v)
+	v = strings.TrimPrefix(v, "/")
+	if v == "." {
+		v = ""
+	}
+	return v
+}
+
+// truncateFilename truncates the base so base+ext+".meta" fits within the
+// 255-byte name-component limit most filesystems enforce.
 func (ms *MetadataService) truncateFilename(filename string) string {
+	const maxNameLen = 255
+	const metaSuffixLen = len(".meta")
+
 	fileExt := filepath.Ext(filename)
-	filename = strings.TrimSuffix(filename, fileExt)
+	base := strings.TrimSuffix(filename, fileExt)
 
-	const maxLen = 250 // Leave room for .meta extension
+	maxBaseLen := max(maxNameLen-metaSuffixLen-len(fileExt), 0)
 
-	if len(filename) <= maxLen {
-		return filename + fileExt
+	if len(base) <= maxBaseLen {
+		return base + fileExt
 	}
 
-	// Simply truncate to maxLen
-	return filename[:maxLen] + fileExt
+	return base[:maxBaseLen] + fileExt
+}
+
+// metaFilePath is the single chokepoint for on-disk .meta file path
+// construction: every caller gets the same normalized, truncated path.
+func (ms *MetadataService) metaFilePath(virtualPath string) string {
+	v := normalizeVirtualPath(virtualPath)
+	dir := filepath.Join(ms.rootPath, filepath.Dir(v))
+	name := ms.truncateFilename(filepath.Base(v))
+	return filepath.Join(dir, name+".meta")
+}
+
+// metaDirPath is the single chokepoint for on-disk directory path
+// construction.
+func (ms *MetadataService) metaDirPath(virtualPath string) string {
+	return filepath.Join(ms.rootPath, normalizeVirtualPath(virtualPath))
 }
 
 // WriteFileMetadata writes file metadata to disk
 func (ms *MetadataService) WriteFileMetadata(virtualPath string, metadata *metapb.FileMetadata) error {
-	// Ensure the directory exists
-	metadataDir := filepath.Join(ms.rootPath, filepath.Dir(virtualPath))
+	virtualPath = normalizeVirtualPath(virtualPath)
+
+	metadataPath := ms.metaFilePath(virtualPath)
+	metadataDir := filepath.Dir(metadataPath)
 	if err := os.MkdirAll(metadataDir, 0755); err != nil {
 		return fmt.Errorf("failed to create metadata directory: %w", err)
 	}
-
-	// Create metadata file path (filename + .meta extension)
-	filename := filepath.Base(virtualPath)
-	truncatedFilename := ms.truncateFilename(filename)
-	metadataPath := filepath.Join(metadataDir, truncatedFilename+".meta")
 
 	// Sidecar ID handling for compatibility
 	// We don't write NzbdavId to the proto to maintain compatibility with versions that don't have field 14.
@@ -200,9 +232,10 @@ func (ms *MetadataService) WriteFileMetadata(virtualPath string, metadata *metap
 		writeData = raw
 	}
 
-	// Write atomically using a uniquely-named temporary file so concurrent
-	// writes to the same final path don't race on the same .tmp name.
-	tmpFile, err := os.CreateTemp(metadataDir, "."+truncatedFilename+".*.tmp")
+	// Write atomically via a uniquely-named temp file so concurrent writes
+	// don't race on the same name. Not built from the truncated filename:
+	// that would risk exceeding the name-length limit truncation exists for.
+	tmpFile, err := os.CreateTemp(metadataDir, ".meta-*.tmp")
 	if err != nil {
 		metadata.NzbdavId = nzbdavId
 		return fmt.Errorf("failed to create temporary metadata file: %w", err)
@@ -332,10 +365,8 @@ func (ms *MetadataService) WriteFileMetadataAuto(ctx context.Context, virtualPat
 // caller's handle. As a side effect, the lightweight projection is cached so
 // subsequent Readdir/Stat calls are fast without a disk read.
 func (ms *MetadataService) ReadFileMetadata(virtualPath string) (*metapb.FileMetadata, error) {
-	// Create metadata file path
-	filename := filepath.Base(virtualPath)
-	metadataDir := filepath.Join(ms.rootPath, filepath.Dir(virtualPath))
-	metadataPath := filepath.Join(metadataDir, filename+".meta")
+	virtualPath = normalizeVirtualPath(virtualPath)
+	metadataPath := ms.metaFilePath(virtualPath)
 
 	// Read file
 	data, err := os.ReadFile(metadataPath)
@@ -421,15 +452,15 @@ const liteScanBytes = 4096
 // NestedSources/SegmentData slices. Falls back to a full read in the rare
 // case the partial buffer doesn't cover the lite fields.
 func (ms *MetadataService) ReadFileMetadataLite(virtualPath string) (*FileMetadataLite, error) {
+	virtualPath = normalizeVirtualPath(virtualPath)
+
 	// Check lite cache first
 	if cached, ok := ms.liteCache.Get(virtualPath); ok {
 		return cached, nil
 	}
 
 	// Cache miss — read the head of the file and scan wire-format fields.
-	filename := filepath.Base(virtualPath)
-	metadataDir := filepath.Join(ms.rootPath, filepath.Dir(virtualPath))
-	metadataPath := filepath.Join(metadataDir, filename+".meta")
+	metadataPath := ms.metaFilePath(virtualPath)
 
 	f, err := os.Open(metadataPath)
 	if err != nil {
@@ -531,9 +562,8 @@ func parseLiteFields(buf []byte) (*FileMetadataLite, bool) {
 // partial-read scan in ReadFileMetadataLite fails to locate the lite
 // fields within liteScanBytes.
 func (ms *MetadataService) readFileMetadataLiteFull(virtualPath string) (*FileMetadataLite, error) {
-	filename := filepath.Base(virtualPath)
-	metadataDir := filepath.Join(ms.rootPath, filepath.Dir(virtualPath))
-	metadataPath := filepath.Join(metadataDir, filename+".meta")
+	virtualPath = normalizeVirtualPath(virtualPath)
+	metadataPath := ms.metaFilePath(virtualPath)
 
 	data, err := os.ReadFile(metadataPath)
 	if err != nil {
@@ -563,25 +593,19 @@ func (ms *MetadataService) readFileMetadataLiteFull(virtualPath string) (*FileMe
 
 // FileExists checks if a metadata file exists for the given virtual path
 func (ms *MetadataService) FileExists(virtualPath string) bool {
-	filename := filepath.Base(virtualPath)
-	truncatedFilename := ms.truncateFilename(filename)
-	metadataDir := filepath.Join(ms.rootPath, filepath.Dir(virtualPath))
-	metadataPath := filepath.Join(metadataDir, truncatedFilename+".meta")
-
-	_, err := os.Stat(metadataPath)
+	_, err := os.Stat(ms.metaFilePath(virtualPath))
 	return err == nil
 }
 
 // DirectoryExists checks if a metadata directory exists
 func (ms *MetadataService) DirectoryExists(virtualPath string) bool {
-	metadataDir := filepath.Join(ms.rootPath, virtualPath)
-	info, err := os.Stat(metadataDir)
+	info, err := os.Stat(ms.metaDirPath(virtualPath))
 	return err == nil && info.IsDir()
 }
 
 // ListDirectory lists all metadata files in a directory
 func (ms *MetadataService) ListDirectory(virtualPath string) ([]string, error) {
-	metadataDir := filepath.Join(ms.rootPath, virtualPath)
+	metadataDir := ms.metaDirPath(virtualPath)
 
 	entries, err := os.ReadDir(metadataDir)
 	if err != nil {
@@ -607,7 +631,7 @@ func (ms *MetadataService) ListDirectory(virtualPath string) ([]string, error) {
 // file names from a single os.ReadDir call. This is used by Readdir to avoid
 // two separate directory reads.
 func (ms *MetadataService) ListDirectoryAll(virtualPath string) (dirs []fs.FileInfo, fileNames []string, err error) {
-	metadataDir := filepath.Join(ms.rootPath, virtualPath)
+	metadataDir := ms.metaDirPath(virtualPath)
 
 	entries, err := os.ReadDir(metadataDir)
 	if err != nil {
@@ -641,7 +665,7 @@ func (ms *MetadataService) ListDirectoryAll(virtualPath string) (dirs []fs.FileI
 // write entirely when the status is unchanged, and advances on real imports and
 // deletions, which do mutate directory entries.
 func (ms *MetadataService) DirectoryModTime(virtualPath string) time.Time {
-	info, err := os.Stat(filepath.Join(ms.rootPath, virtualPath))
+	info, err := os.Stat(ms.metaDirPath(virtualPath))
 	if err != nil || !info.IsDir() {
 		return time.Time{}
 	}
@@ -699,6 +723,8 @@ func (ms *MetadataService) CreateFileMetadata(
 // that may be asked to apply a no-op should guard against it first — see
 // UpdateFileStatus.
 func (ms *MetadataService) UpdateFileMetadata(virtualPath string, updateFunc func(*metapb.FileMetadata)) error {
+	virtualPath = normalizeVirtualPath(virtualPath)
+
 	// Read existing metadata
 	metadata, err := ms.ReadFileMetadata(virtualPath)
 	if err != nil {
@@ -757,11 +783,11 @@ func (ms *MetadataService) UpdateFileStatus(virtualPath string, status metapb.Fi
 // on SourceNzbPath: for v3 metadata it aliases StoreRef, and removing it directly
 // destroyed the store out from under sibling files (issue #858).
 func (ms *MetadataService) DeleteFileMetadata(ctx context.Context, virtualPath string) error {
+	virtualPath = normalizeVirtualPath(virtualPath)
 	ms.liteCache.Remove(virtualPath)
 
-	filename := filepath.Base(virtualPath)
-	metadataDir := filepath.Join(ms.rootPath, filepath.Dir(virtualPath))
-	metadataPath := filepath.Join(metadataDir, filename+".meta")
+	metadataPath := ms.metaFilePath(virtualPath)
+	metadataDir := filepath.Dir(metadataPath)
 
 	// Read StoreRef straight off the proto rather than via ReadFileMetadata: a full
 	// read resolves segments against the store, so on an install whose store is
@@ -824,10 +850,11 @@ func (ms *MetadataService) DeleteCorruptedFile(ctx context.Context, virtualPath 
 // DeleteDirectory deletes a metadata directory and all its contents
 func (ms *MetadataService) DeleteDirectory(virtualPath string) error {
 	ctx := context.Background()
+	virtualPath = normalizeVirtualPath(virtualPath)
 
 	ms.purgeCachedTree(virtualPath)
 
-	metadataDir := filepath.Join(ms.rootPath, virtualPath)
+	metadataDir := ms.metaDirPath(virtualPath)
 	if err := ms.assertNotRootDir(metadataDir); err != nil {
 		return err
 	}
@@ -886,7 +913,8 @@ func (ms *MetadataService) DeleteDirectory(virtualPath string) error {
 // so a release folder shared with a concurrent import is never removed from under it.
 // Returns ErrDirectoryNotEmpty when the directory was preserved for that reason.
 func (ms *MetadataService) DeleteDirectoryIfEmpty(virtualPath string) error {
-	metadataDir := filepath.Join(ms.rootPath, virtualPath)
+	virtualPath = normalizeVirtualPath(virtualPath)
+	metadataDir := ms.metaDirPath(virtualPath)
 	if err := ms.assertNotRootDir(metadataDir); err != nil {
 		return err
 	}
@@ -930,9 +958,14 @@ func (ms *MetadataService) assertNotRootDir(metadataDir string) error {
 	return nil
 }
 
-// purgeCachedTree drops the cached entry for virtualPath and everything beneath it.
+// purgeCachedTree drops the cached entry for virtualPath and everything
+// beneath it. Expects virtualPath already normalized (no leading slash,
+// "/"-separated) — a "\" prefix would miss every key on Windows.
 func (ms *MetadataService) purgeCachedTree(virtualPath string) {
-	prefix := virtualPath + string(filepath.Separator)
+	prefix := virtualPath + "/"
+	if virtualPath == "" {
+		prefix = ""
+	}
 	for _, key := range ms.liteCache.Keys() {
 		if key == virtualPath || strings.HasPrefix(key, prefix) {
 			ms.liteCache.Remove(key)
@@ -943,16 +976,14 @@ func (ms *MetadataService) purgeCachedTree(virtualPath string) {
 // RenameFileMetadata atomically renames a metadata file (and its .id sidecar) from oldVirtualPath to newVirtualPath.
 // Uses os.Rename for atomicity on the same filesystem, falling back to read-write-delete for cross-device moves.
 func (ms *MetadataService) RenameFileMetadata(oldVirtualPath, newVirtualPath string) error {
+	oldVirtualPath = normalizeVirtualPath(oldVirtualPath)
+	newVirtualPath = normalizeVirtualPath(newVirtualPath)
 	ms.liteCache.Remove(oldVirtualPath)
 	ms.liteCache.Remove(newVirtualPath)
 
-	oldFilename := filepath.Base(oldVirtualPath)
-	oldDir := filepath.Join(ms.rootPath, filepath.Dir(oldVirtualPath))
-	oldMetaPath := filepath.Join(oldDir, oldFilename+".meta")
-
-	newFilename := filepath.Base(newVirtualPath)
-	newDir := filepath.Join(ms.rootPath, filepath.Dir(newVirtualPath))
-	newMetaPath := filepath.Join(newDir, newFilename+".meta")
+	oldMetaPath := ms.metaFilePath(oldVirtualPath)
+	newMetaPath := ms.metaFilePath(newVirtualPath)
+	newDir := filepath.Dir(newMetaPath)
 
 	// Ensure destination directory exists
 	if err := os.MkdirAll(newDir, 0755); err != nil {
@@ -978,24 +1009,22 @@ func (ms *MetadataService) RenameFileMetadata(oldVirtualPath, newVirtualPath str
 
 // GetMetadataFilePath returns the filesystem path for a metadata file
 func (ms *MetadataService) GetMetadataFilePath(virtualPath string) string {
-	filename := filepath.Base(virtualPath)
-	metadataDir := filepath.Join(ms.rootPath, filepath.Dir(virtualPath))
-	return filepath.Join(metadataDir, filename+".meta")
+	return ms.metaFilePath(virtualPath)
 }
 
 // GetMetadataDirectoryPath returns the filesystem path for a metadata directory
 func (ms *MetadataService) GetMetadataDirectoryPath(virtualPath string) string {
-	return filepath.Join(ms.rootPath, virtualPath)
+	return ms.metaDirPath(virtualPath)
 }
 
 func (ms *MetadataService) CreateDirectory(name string) error {
-	return os.MkdirAll(filepath.Join(ms.rootPath, name), 0755)
+	return os.MkdirAll(ms.metaDirPath(name), 0755)
 }
 
 // CleanupEmptyDirectories recursively removes empty directories under the given virtual path.
 // Uses a bottom-up approach to ensure parent directories are also removed if they become empty.
 func (ms *MetadataService) CleanupEmptyDirectories(virtualPath string, protected []string) error {
-	fullPath := filepath.Join(ms.rootPath, virtualPath)
+	fullPath := ms.metaDirPath(virtualPath)
 
 	// Check if path exists
 	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
@@ -1054,15 +1083,12 @@ func (ms *MetadataService) cleanupEmptyDirsRecursive(path string, protected []st
 
 // MoveToCorrupted moves a metadata file to a special corrupted directory for safety
 func (ms *MetadataService) MoveToCorrupted(ctx context.Context, virtualPath string) error {
+	virtualPath = normalizeVirtualPath(virtualPath)
 	ms.liteCache.Remove(virtualPath)
 
-	// Normalize path and remove leading slashes to ensure it joins correctly
-	cleanPath := filepath.FromSlash(strings.TrimPrefix(virtualPath, "/"))
-	dir := filepath.Dir(cleanPath)
-	filename := filepath.Base(cleanPath)
-
-	truncatedFilename := ms.truncateFilename(filename)
-	metadataPath := filepath.Join(ms.rootPath, dir, truncatedFilename+".meta")
+	metadataPath := ms.metaFilePath(virtualPath)
+	metaName := filepath.Base(metadataPath)
+	dir := filepath.Dir(strings.TrimPrefix(virtualPath, "/"))
 
 	// Check if source exists
 	if _, err := os.Stat(metadataPath); os.IsNotExist(err) {
@@ -1078,7 +1104,7 @@ func (ms *MetadataService) MoveToCorrupted(ctx context.Context, virtualPath stri
 		return fmt.Errorf("failed to create corrupted metadata directory: %w", err)
 	}
 
-	targetPath := filepath.Join(targetDir, truncatedFilename+".meta")
+	targetPath := filepath.Join(targetDir, metaName)
 
 	// Move the .meta file
 	if err := os.Rename(metadataPath, targetPath); err != nil {

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -2,9 +2,11 @@ package metadata
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +15,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// assertNoBackslashPersisted walks the metadata root and fails on any
+// persisted name containing a backslash (issue #660).
+func assertNoBackslashPersisted(t *testing.T, root string) {
+	t.Helper()
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		require.NoError(t, err)
+		assert.NotContains(t, d.Name(), `\`, "on-disk name must never contain a backslash: %s", path)
+		return nil
+	})
+	require.NoError(t, err)
+}
 
 func TestDeleteFileMetadata_RemovesMetadata(t *testing.T) {
 	root := t.TempDir()
@@ -538,4 +552,111 @@ func TestDeleteDirectoryIfEmpty(t *testing.T) {
 		}
 		assert.DirExists(t, root)
 	})
+}
+
+func TestGetMetadataFilePath_NormalizesBackslashAndLeadingSlash(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	base := ms.GetMetadataFilePath("movies/Release/file.mkv")
+
+	variants := []string{
+		`movies\Release\file.mkv`,
+		"/movies/Release/file.mkv",
+		"movies//Release/file.mkv",
+	}
+	for _, v := range variants {
+		assert.Equal(t, base, ms.GetMetadataFilePath(v), "variant %q must resolve to the same on-disk path", v)
+	}
+}
+
+func TestWriteFileMetadata_BackslashPathNeverPersistsBackslash(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	// A single subject can contain a backslash used as a Windows-style
+	// separator by the release, e.g. "Release\A.mkv\A.mkv".
+	virtualPath := `Release\A.mkv\A.mkv`
+	meta := ms.CreateFileMetadata(
+		1024, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	require.NoError(t, ms.WriteFileMetadata(virtualPath, meta))
+
+	assertNoBackslashPersisted(t, root)
+	assert.FileExists(t, filepath.Join(root, "Release", "A.mkv", "A.mkv.meta"))
+
+	// Reads must resolve the same normalized path the writer used.
+	got, err := ms.ReadFileMetadata(virtualPath)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, int64(1024), got.FileSize)
+}
+
+func TestRenameFileMetadata_NormalizesBackslashPath(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	oldPath := filepath.Join("movies", "old.mkv")
+	meta := ms.CreateFileMetadata(
+		1024, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	require.NoError(t, ms.WriteFileMetadata(oldPath, meta))
+
+	newPath := `movies\Sub\new.mkv`
+	require.NoError(t, ms.RenameFileMetadata(oldPath, newPath))
+
+	assertNoBackslashPersisted(t, root)
+	assert.FileExists(t, filepath.Join(root, "movies", "Sub", "new.mkv.meta"))
+}
+
+func TestTruncateFilename_KeepsCombinedNameWithinFilesystemLimit(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	// 400+ bytes crosses the 255-byte name-component limit once ext+".meta"
+	// is added; the old truncation budget didn't account for that.
+	longBase := strings.Repeat("a", 400)
+	virtualPath := longBase + ".mkv"
+
+	meta := ms.CreateFileMetadata(
+		1024, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	require.NoError(t, ms.WriteFileMetadata(virtualPath, meta), "a name this long must still be writable")
+
+	metaPath := ms.GetMetadataFilePath(virtualPath)
+	assert.LessOrEqual(t, len(filepath.Base(metaPath)), 255)
+	require.FileExists(t, metaPath)
+
+	// Reads apply the same truncation the writer used, so the file just
+	// written round-trips rather than missing.
+	got, err := ms.ReadFileMetadata(virtualPath)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, int64(1024), got.FileSize)
+}
+
+func TestDeleteDirectory_CachePurgeHandlesTrailingSlash(t *testing.T) {
+	ms := NewMetadataService(t.TempDir())
+
+	dir := filepath.Join("movies", "Release")
+	virtualPath := filepath.Join(dir, "file.mkv")
+	meta := ms.CreateFileMetadata(
+		1024, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	require.NoError(t, ms.WriteFileMetadata(virtualPath, meta))
+	_, err := ms.ReadFileMetadataLite(virtualPath)
+	require.NoError(t, err)
+
+	// A trailing slash on the directory argument used to double the purge
+	// prefix ("movies/Release/" + "/" = "movies/Release//"), which matched no
+	// cached key and left the entry behind after the directory was deleted
+	// from disk.
+	require.NoError(t, ms.DeleteDirectory(dir+"/"))
+
+	_, cached := ms.liteCache.Get(virtualPath)
+	assert.False(t, cached, "cache entry must be purged even with a trailing-slash directory argument")
 }


### PR DESCRIPTION
Fixes #660. Supersedes #685, which could not be reopened (GitHub returns "the pull
request cannot be reopened"), so this is the same branch with the conflict resolved.

### The bug

A backslash is a legal byte in a Linux filename. `internal/metadata` builds on-disk
`.meta` names straight from the virtual path, so such a name is persisted as-is, and
opening that file through the FUSE layer deadlocks: the kernel hangs in
`invalidate_inode_pages2` (`folio_wait_bit_common`) and the calling process goes into
uninterruptible D-state. A host reboot is the only recovery.

The two layers disagree. `nzbfilesystem.normalizePath` already folds backslashes to
forward slashes, but the metadata service does not, so writes land under one key and
lookups arrive under another. Still reproducible on `b6a4a977`: `WriteFileMetadata`
calls `filepath.Base(virtualPath)` on the raw path.

#849 does not cover this. It fixes separators at the RPC boundary and says outright that
a backslash is a legal POSIX filename character left alone by design. This is about a
byte that must never reach an on-disk name in the first place.

### What is here

@javi11's `fa243c60` from #685 is unchanged in the history: the normalization lives at a
single chokepoint, `metaFilePath` / `metaDirPath`, rather than being repeated at each
method top, so a future caller cannot forget it. Method-top normalization is kept only
where the local variable is also a `liteCache` key or a prefix-scan argument.

Since #685 stalled, #875 replaced `DeleteFileMetadataWithSourceNzb` with
`DeleteFileMetadata(ctx, virtualPath)`. The chokepoint is ported onto that, and the
regression test that called the old signature is rewritten.

One extra fix, from an external review of this branch. The `DeleteDirectory` cache purge
built its prefix as `virtualPath + filepath.Separator`, which misses in two ways once
paths are normalized. Cache keys always use forward slashes, so on Windows the prefix
reads `movies\` against keys like `movies/file.mkv` and matches nothing at all. And a
trailing separator doubles up, turning `movies/` into `movies//`, which also matches
nothing. Either way the directory goes from disk while its entries stay cached, and the
next read is served metadata for a file that is gone.

### Tests

`assertNoBackslashPersisted` walks the metadata root and fails on any persisted name
containing a backslash. Regression tests cover the write, rename and delete paths plus
the directory cache purge, and each was checked against the unpatched code to confirm it
actually fails there.

`go build ./...` and `go test ./...` pass on Linux with Go 1.26. The one failure I saw,
`TestIsWritable` in `internal/updater`, reproduces on unmodified `main` in the same
container and is an artifact of running the suite as root, where mode `0o400` is still
writable.


### Behaviour changes beyond backslash normalization

Two, both surfaced in review and worth being explicit about.

**Reads truncate now.** `ReadFileMetadata`, `ReadFileMetadataLite`,
`readFileMetadataLiteFull`, `DeleteFileMetadata`, `RenameFileMetadata` and
`GetMetadataFilePath` previously built their path from the raw `filepath.Base`; only
`WriteFileMetadata` and `FileExists` truncated. Routing everything through `metaFilePath`
means they all truncate. Mostly that is a fix: the stat-then-delete-then-write pattern in
`multifile/processor.go`, `rar/aggregator.go` and `sevenzip/aggregator.go` used to stat an
un-truncated path that could not exist, so a re-import of a long name skipped its
pre-delete and leaked the store refcount. The hazard it introduces is that two names
sharing their first bytes and extension now read as the same file where the read previously
missed; `TestLongFilename_SharedPrefixCollides` documents that, and closing it needs an
on-disk layout change.

**Long names can be written at all now.** `truncateFilename` budgeted 250 bytes for the
base "to leave room for .meta" without subtracting the file's own extension, and the
atomic-write temp file was built from the already-maximal truncated name. Anything over
roughly 235 bytes failed with "file name too long". Both are fixed here because the test
asked for above could not otherwise be written. Only names that could not be written are
affected, so nothing on disk needs migrating.

### Migration

`MigrateBackslashPaths` relocates metadata already written under an un-normalized name,
which the normalization would otherwise strand: invisible to `Readdir`, dropped by library
sync without being flagged corrupted, undeletable, skipped by the v2→v3 scan, and leaking
its store refcount. It runs once from `initializeMetadata`, is idempotent, and never
overwrites a live file.
