### PR TITLE
fix(rclone): obscure the webdav password when creating the internal mount config

### DIFF
--- a/pkg/rclonecli/client.go
+++ b/pkg/rclonecli/client.go
@@ -496,6 +496,13 @@ func (m *Manager) createConfig(ctx context.Context, configName, webdavURL string
 				"user":            user,
 				"pass":            pass,
 			},
+			// Obscure the plaintext webdav password before rclone stores it.
+			// Without this rclone keeps it as-is, then fails to reveal it and
+			// sends a garbled password to the local webdav → 401 when
+			// auth.login_required is true (the whole native-mount blocker).
+			"opt": map[string]any{
+				"obscure": true,
+			},
 		},
 	}
 

--- a/pkg/rclonecli/client.go
+++ b/pkg/rclonecli/client.go
@@ -496,17 +496,9 @@ func (m *Manager) createConfig(ctx context.Context, configName, webdavURL string
 				"user":            user,
 				"pass":            pass,
 			},
-			// Tell rclone the password above is plaintext.
-			//
-			// Without this, config/create guesses: it tries to reveal the value
-			// and, if that succeeds, assumes it was already obscured and stores
-			// it verbatim. The guess is wrong for any plaintext password that
-			// happens to be revealable — base64-shaped strings, which is what a
-			// randomly generated password usually looks like. Such a password is
-			// then stored un-obscured, reveals to a different string on every
-			// later read, and the mount authenticates against altmount's own
-			// WebDAV with the wrong credential: 401 when auth.login_required is
-			// on. Passing obscure explicitly removes the guess.
+			// obscure tells rclone the password is plaintext. Without it,
+			// config/create guesses, and guesses wrong for any password that is
+			// itself revealable, storing it verbatim (#691).
 			"opt": map[string]any{
 				"obscure": true,
 			},

--- a/pkg/rclonecli/client.go
+++ b/pkg/rclonecli/client.go
@@ -496,10 +496,17 @@ func (m *Manager) createConfig(ctx context.Context, configName, webdavURL string
 				"user":            user,
 				"pass":            pass,
 			},
-			// Obscure the plaintext webdav password before rclone stores it.
-			// Without this rclone keeps it as-is, then fails to reveal it and
-			// sends a garbled password to the local webdav → 401 when
-			// auth.login_required is true (the whole native-mount blocker).
+			// Tell rclone the password above is plaintext.
+			//
+			// Without this, config/create guesses: it tries to reveal the value
+			// and, if that succeeds, assumes it was already obscured and stores
+			// it verbatim. The guess is wrong for any plaintext password that
+			// happens to be revealable — base64-shaped strings, which is what a
+			// randomly generated password usually looks like. Such a password is
+			// then stored un-obscured, reveals to a different string on every
+			// later read, and the mount authenticates against altmount's own
+			// WebDAV with the wrong credential: 401 when auth.login_required is
+			// on. Passing obscure explicitly removes the guess.
 			"opt": map[string]any{
 				"obscure": true,
 			},

--- a/pkg/rclonecli/config_test.go
+++ b/pkg/rclonecli/config_test.go
@@ -1,0 +1,71 @@
+package rclonecli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// TestCreateConfig_SendsObscureOpt pins the obscure flag on the config/create
+// RC call.
+//
+// rclone decides for itself whether an incoming password is already obscured:
+// it tries to reveal the value, and if that succeeds it assumes the caller
+// handed it an obscured secret and stores it verbatim. That guess is wrong for
+// any plaintext password that happens to be revealable, which includes ordinary
+// base64-shaped generated passwords. The password is then stored un-obscured,
+// reveals to a different string on every later read, and the internal mount
+// authenticates against AltMount's own WebDAV with the wrong credential.
+func TestCreateConfig_SendsObscureOpt(t *testing.T) {
+	var body map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding config/create body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parsing test server URL: %v", err)
+	}
+
+	m := &Manager{
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ctx:        context.Background(),
+		rcPort:     u.Port(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	const plaintext = "s3cret-password"
+	if err := m.createConfig(context.Background(), "altmount", "http://localhost:8080/webdav", "altmount", plaintext); err != nil {
+		t.Fatalf("createConfig: %v", err)
+	}
+
+	opt, ok := body["opt"].(map[string]any)
+	if !ok {
+		t.Fatalf("config/create carried no opt block; rclone will guess at the password format. body=%v", body)
+	}
+	if obscure, _ := opt["obscure"].(bool); !obscure {
+		t.Errorf("opt.obscure = %v, want true", opt["obscure"])
+	}
+
+	// The password must still go over as plaintext: obscure tells rclone to do
+	// the obscuring itself, so pre-obscuring here would double-encode it.
+	params, ok := body["parameters"].(map[string]any)
+	if !ok {
+		t.Fatalf("config/create carried no parameters block. body=%v", body)
+	}
+	if got := params["pass"]; got != plaintext {
+		t.Errorf("parameters.pass = %v, want the plaintext %q", got, plaintext)
+	}
+}

--- a/pkg/rclonecli/config_test.go
+++ b/pkg/rclonecli/config_test.go
@@ -12,16 +12,9 @@ import (
 	"time"
 )
 
-// TestCreateConfig_SendsObscureOpt pins the obscure flag on the config/create
-// RC call.
-//
-// rclone decides for itself whether an incoming password is already obscured:
-// it tries to reveal the value, and if that succeeds it assumes the caller
-// handed it an obscured secret and stores it verbatim. That guess is wrong for
-// any plaintext password that happens to be revealable, which includes ordinary
-// base64-shaped generated passwords. The password is then stored un-obscured,
-// reveals to a different string on every later read, and the internal mount
-// authenticates against AltMount's own WebDAV with the wrong credential.
+// TestCreateConfig_SendsObscureOpt pins the obscure flag on config/create.
+// Without it rclone guesses whether the password is already obscured, and a
+// plaintext password that happens to be revealable is stored verbatim (#691).
 func TestCreateConfig_SendsObscureOpt(t *testing.T) {
 	var body map[string]any
 


### PR DESCRIPTION
Fixes #691.

`createConfig` calls `config/create` without the `obscure` opt, so rclone decides for
itself whether the password it was handed is already obscured: it tries to reveal the
value, and stores it verbatim when that succeeds. For a plaintext password that happens
to be revealable, the stored value then reveals to something else, and the internal
mount authenticates against AltMount's own WebDAV with the wrong credential. That is a
401 when `auth.login_required` is on.

@javi11, this is why it worked when you checked on #691. A password with no particular
shape round-trips fine either way. A base64-shaped one, which is what most generated
passwords look like, does not.

Reproduced on rclone v1.75.0. For each row: `config/create` with the given password, then
`rclone reveal` on what ended up in `rclone.conf`.

| password handed to `config/create` | `opt.obscure` | reveals back to the original |
| --- | --- | --- |
| ordinary string | absent | yes |
| ordinary string | `true` | yes |
| itself a valid obscured string | absent | **no** |
| itself a valid obscured string | `true` | yes |

Row three is the bug. The password is stored un-obscured, so every later read de-obscures
it into a different string.

The password still goes over as plaintext; `obscure` only tells rclone to do the obscuring
rather than guess. Recreating the remote therefore supplies plaintext again and repairs a
previously mis-stored value instead of double-encoding it.

@WhispersOfJ independently reproduced this on #691 and had a fix in #792, which was closed
when it got folded into #799. This is that change on its own, plus a test asserting the RC
body carries `opt.obscure` and still sends the password in plaintext. The test fails
against the current `createConfig`.
