### PR TITLE
fix(rclonecli): wire dir_cache_time and vfs_cache_min_free_space into the mount

### DIFF
--- a/pkg/rclonecli/client.go
+++ b/pkg/rclonecli/client.go
@@ -198,6 +198,16 @@ func (m *Manager) performMount(ctx context.Context, provider, mountPath, webdavU
 	}
 	vfsOpt["PollInterval"] = 0 // Poll interval not supported for webdav, set to 0
 
+	// DirCacheTime is applied regardless of vfs_cache_mode: it governs how long
+	// directory listings are cached, not file content, so it still matters when
+	// content caching is off. Cuts PROPFIND load against the WebDAV backend
+	// during library scans.
+	if cfg.RClone.DirCacheTime != "" {
+		if dirCacheTime, e := time.ParseDuration(cfg.RClone.DirCacheTime); e == nil {
+			vfsOpt["DirCacheTime"] = dirCacheTime.Nanoseconds()
+		}
+	}
+
 	// Add VFS options if caching is enabled
 	if cfg.RClone.VFSCacheMode != "off" {
 		if cfg.RClone.VFSCacheMaxAge != "" {
@@ -210,6 +220,9 @@ func (m *Manager) performMount(ctx context.Context, provider, mountPath, webdavU
 			// Ensure the reported total disk space matches the configured cache size
 			// so media servers see accurate available space
 			vfsOpt["DiskSpaceTotalSize"] = cfg.RClone.VFSCacheMaxSize
+		}
+		if cfg.RClone.VFSCacheMinFreeSpace != "" {
+			vfsOpt["CacheMinFreeSpace"] = cfg.RClone.VFSCacheMinFreeSpace
 		}
 		if cfg.RClone.VFSCachePollInterval != "" {
 			vfsOpt["CachePollInterval"] = cfg.RClone.VFSCachePollInterval

--- a/pkg/rclonecli/vfsopt_test.go
+++ b/pkg/rclonecli/vfsopt_test.go
@@ -1,0 +1,74 @@
+package rclonecli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+)
+
+// TestPerformMount_SendsDirCacheTimeAndCacheMinFreeSpace covers two settings
+// that config.sample.yaml documents, that GetDefaultConfig fills in, and that
+// never reached rclone: they were absent from the vfsOpt map performMount
+// builds, so setting them had no effect and produced no error either.
+func TestPerformMount_SendsDirCacheTimeAndCacheMinFreeSpace(t *testing.T) {
+	var body map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding mount/mount body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parsing test server URL: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.RClone.VFSCacheMode = "full"
+	cfg.RClone.DirCacheTime = "10m"
+	cfg.RClone.VFSCacheMinFreeSpace = "1G"
+
+	ready := make(chan struct{})
+	close(ready)
+
+	m := &Manager{
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ctx:           context.Background(),
+		cfg:           config.NewManager(cfg, ""),
+		rcPort:        u.Port(),
+		mounts:        make(map[string]*MountInfo),
+		serverReady:   ready,
+		serverStarted: true,
+		httpClient:    &http.Client{Timeout: 5 * time.Second},
+	}
+
+	if err := m.performMount(context.Background(), "altmount", t.TempDir(), "http://localhost:8080/webdav"); err != nil {
+		t.Fatalf("performMount: %v", err)
+	}
+
+	vfsOpt, ok := body["vfsOpt"].(map[string]any)
+	if !ok {
+		t.Fatalf("mount/mount carried no vfsOpt block. body=%v", body)
+	}
+
+	// 10m expressed the way rclone's Duration type reports it.
+	if got, want := vfsOpt["DirCacheTime"], float64(10*time.Minute); got != want {
+		t.Errorf("vfsOpt.DirCacheTime = %v, want %v (10m in nanoseconds)", got, want)
+	}
+
+	if got, want := vfsOpt["CacheMinFreeSpace"], "1G"; got != want {
+		t.Errorf("vfsOpt.CacheMinFreeSpace = %v, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #880.

`DirCacheTime` and `VFSCacheMinFreeSpace` are declared in `RCloneConfig`, documented in
`config.sample.yaml` with their rclone flags, and given defaults by `GetDefaultConfig`,
but neither was ever added to the `vfsOpt` map `performMount` sends to `mount/mount`.
Setting either did nothing and reported no error.

`DirCacheTime` is applied regardless of `vfs_cache_mode`. It governs how long directory
listings are cached rather than file content, so it still matters with content caching
off, where it cuts PROPFIND load during library scans. `CacheMinFreeSpace` is
cache-specific and stays inside the existing guard.

Value types checked against the rclone AltMount ships (v1.75.0), which reports
`DirCacheTime` as a `Duration` and `CacheMinFreeSpace` as a `SizeSuffix`. The duration
goes over as nanoseconds, matching how `CacheMaxAge` is already passed; the size goes over
as the configured string, matching `CacheMaxSize`, `ChunkSize` and `ReadAhead`.

rclone's own `DirCacheTime` default is 5m and AltMount documents 10m, so this doubles the
directory cache lifetime for anyone who never set the field. That is what the documented
default asks for, but it changes behaviour on upgrade and probably wants a release note.

The test asserts both land in `vfsOpt` and fails against current `main`, where each reads
back `nil`.

