### PR TITLE
feat(config): replace scoped user-agent settings with global user_agent

### DIFF
--- a/frontend/src/components/config/NetworkConfigSection.tsx
+++ b/frontend/src/components/config/NetworkConfigSection.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
-import type { ConfigResponse, NetworkConfig, NzblnkConfig } from "../../types/config";
+import type { ConfigResponse, NetworkConfig } from "../../types/config";
 
 interface NetworkConfigSectionProps {
 	config: ConfigResponse;
-	onUpdate?: (section: string, data: NetworkConfig | NzblnkConfig) => Promise<void>;
+	onUpdate?: (section: string, data: NetworkConfig | string) => Promise<void>;
 	isReadOnly?: boolean;
 	isUpdating?: boolean;
 }
@@ -21,32 +21,31 @@ export function NetworkConfigSection({
 	isUpdating,
 }: NetworkConfigSectionProps) {
 	const [data, setData] = useState<NetworkConfig>(config.network ?? emptyNetwork);
-	const [nzblnk, setNzblnk] = useState<NzblnkConfig>(config.nzblnk ?? {});
+	const [userAgent, setUserAgent] = useState<string>(config.user_agent ?? "");
 	const [hasChanges, setHasChanges] = useState(false);
 
 	useEffect(() => {
 		setData(config.network ?? emptyNetwork);
-		setNzblnk(config.nzblnk ?? {});
+		setUserAgent(config.user_agent ?? "");
 		setHasChanges(false);
-	}, [config.network, config.nzblnk]);
+	}, [config.network, config.user_agent]);
 
-	const recomputeChanges = (nextNetwork: NetworkConfig, nextNzblnk: NzblnkConfig) => {
+	const recomputeChanges = (nextNetwork: NetworkConfig, nextUserAgent: string) => {
 		const networkChanged =
 			JSON.stringify(nextNetwork) !== JSON.stringify(config.network ?? emptyNetwork);
-		const nzblnkChanged = JSON.stringify(nextNzblnk) !== JSON.stringify(config.nzblnk ?? {});
-		setHasChanges(networkChanged || nzblnkChanged);
+		const userAgentChanged = nextUserAgent !== (config.user_agent ?? "");
+		setHasChanges(networkChanged || userAgentChanged);
 	};
 
 	const handleChange = (field: keyof NetworkConfig, value: string) => {
 		const next: NetworkConfig = { ...data, [field]: value };
 		setData(next);
-		recomputeChanges(next, nzblnk);
+		recomputeChanges(next, userAgent);
 	};
 
-	const handleNzblnkChange = (field: keyof NzblnkConfig, value: string) => {
-		const next: NzblnkConfig = { ...nzblnk, [field]: value };
-		setNzblnk(next);
-		recomputeChanges(data, next);
+	const handleUserAgentChange = (value: string) => {
+		setUserAgent(value);
+		recomputeChanges(data, value);
 	};
 
 	const handleSave = async () => {
@@ -54,12 +53,12 @@ export function NetworkConfigSection({
 		// Capture locally so a refetch-triggered state reset between the two
 		// per-section PATCH calls can't drop the pending edits.
 		const networkToSave = data;
-		const nzblnkToSave = nzblnk;
+		const userAgentToSave = userAgent;
 		if (JSON.stringify(networkToSave) !== JSON.stringify(config.network ?? emptyNetwork)) {
 			await onUpdate("network", networkToSave);
 		}
-		if (JSON.stringify(nzblnkToSave) !== JSON.stringify(config.nzblnk ?? {})) {
-			await onUpdate("nzblnk", nzblnkToSave);
+		if (userAgentToSave !== (config.user_agent ?? "")) {
+			await onUpdate("user_agent", userAgentToSave);
 		}
 		setHasChanges(false);
 	};
@@ -117,39 +116,30 @@ export function NetworkConfigSection({
 				<p className="label">Comma-separated hosts, IPs, or CIDRs that bypass the proxy.</p>
 			</fieldset>
 
-			{/* NZBLNK Resolver (merged from the former NZBLNK section) */}
 			<div className="min-w-0 space-y-4 border-base-200 border-t pt-6">
 				<div className="min-w-0">
-					<h3 className="font-bold text-base-content text-lg tracking-tight">NZBLNK Resolver</h3>
+					<h3 className="font-bold text-base-content text-lg tracking-tight">HTTP User-Agent</h3>
 					<p className="break-words text-base-content/50 text-sm">
-						Configure how nzblnk:// links are resolved via public NZB indexers.
+						Global User-Agent sent on outbound HTTP requests (NZB downloads from indexers, NZBLNK
+						resolution, metadata lookups).
 					</p>
 				</div>
 
-				<div className="min-w-0 space-y-6 overflow-hidden rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
-					<div className="flex items-center gap-2">
-						<h4 className="font-bold text-base-content/40 text-xs uppercase tracking-widest">
-							HTTP Headers
-						</h4>
-						<div className="h-px flex-1 bg-base-300/50" />
-					</div>
-
-					<fieldset className="fieldset min-w-0">
-						<legend className="fieldset-legend font-semibold">Indexer User-Agent</legend>
-						<input
-							type="text"
-							className="input input-bordered w-full min-w-0 max-w-full bg-base-100 font-mono text-sm"
-							value={nzblnk.user_agent ?? ""}
-							disabled={isReadOnly}
-							placeholder="Mozilla/5.0 ... (leave empty for default)"
-							onChange={(e) => handleNzblnkChange("user_agent", e.target.value)}
-						/>
-						<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/70 text-xs">
-							HTTP User-Agent sent when searching and downloading from public NZB indexers (e.g.
-							nzbking.com, nzbindex.com). Leave empty to use the built-in default.
-						</p>
-					</fieldset>
-				</div>
+				<fieldset className="fieldset min-w-0">
+					<legend className="fieldset-legend font-semibold">User-Agent</legend>
+					<input
+						type="text"
+						className="input input-bordered w-full min-w-0 max-w-full bg-base-100 font-mono text-sm"
+						value={userAgent}
+						disabled={isReadOnly}
+						placeholder="Mozilla/5.0 ... (leave empty for default)"
+						onChange={(e) => handleUserAgentChange(e.target.value)}
+					/>
+					<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/70 text-xs">
+						Some public indexers (e.g. nzbking.com, nzbindex.com) reject non-browser agents. Leave
+						empty to use the built-in browser-like default.
+					</p>
+				</fieldset>
 			</div>
 
 			<button

--- a/frontend/src/pages/ConfigurationPage.tsx
+++ b/frontend/src/pages/ConfigurationPage.tsx
@@ -54,7 +54,6 @@ import type {
 	LogFormData,
 	MetadataConfig,
 	NetworkConfig,
-	NzblnkConfig,
 	ProviderConfig,
 	SABnzbdConfig,
 	SegmentCacheConfig,
@@ -272,10 +271,10 @@ export function ConfigurationPage() {
 					section: "providers",
 					config: { providers: data as unknown as ProviderConfig[] },
 				});
-			} else if (section === "nzblnk") {
+			} else if (section === "user_agent") {
 				await updateConfigSection.mutateAsync({
-					section: "nzblnk",
-					config: { nzblnk: data as unknown as NzblnkConfig },
+					section: "network",
+					config: { user_agent: data as unknown as string },
 				});
 			} else if (section === "network") {
 				await updateConfigSection.mutateAsync({

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -21,7 +21,7 @@ export interface ConfigResponse {
 	arrs: ArrsConfig;
 	stremio: StremioConfig;
 	providers: ProviderConfig[];
-	nzblnk: NzblnkConfig;
+	user_agent?: string;
 	network: NetworkConfig;
 	mount_path: string;
 	mount_type: MountType;
@@ -305,11 +305,6 @@ export interface PipelineTuneResponse {
 	warning?: string;
 }
 
-// NZBLNK resolver configuration
-export interface NzblnkConfig {
-	user_agent?: string;
-}
-
 // SABnzbd configuration
 export interface SABnzbdConfig {
 	enabled: boolean;
@@ -348,7 +343,7 @@ export interface ConfigUpdateRequest {
 	arrs?: ArrsConfig;
 	stremio?: Partial<StremioConfig>;
 	providers?: ProviderUpdateRequest[];
-	nzblnk?: NzblnkConfig;
+	user_agent?: string;
 	network?: NetworkConfig;
 	mount_path?: string;
 	mount_type?: MountType;
@@ -546,7 +541,6 @@ export type ConfigSection =
 	| "sabnzbd"
 	| "arrs"
 	| "stremio"
-	| "nzblnk"
 	| "network"
 	| "system";
 
@@ -965,12 +959,6 @@ export const CONFIG_SECTIONS: Record<ConfigSection | "system", ConfigSectionInfo
 		description:
 			"Upload an NZB for instant stream URLs, or enable the addon to automatically search Prowlarr by IMDB ID and stream results directly from Stremio.",
 		icon: "Tv",
-		canEdit: true,
-	},
-	nzblnk: {
-		title: "NZBLNK",
-		description: "Settings for resolving nzblnk:// links via public NZB indexers",
-		icon: "Link",
 		canEdit: true,
 	},
 	network: {

--- a/internal/api/config_handlers.go
+++ b/internal/api/config_handlers.go
@@ -237,7 +237,7 @@ func (s *Server) handlePatchConfigSection(c *fiber.Ctx) error {
 				newConfig.Providers[i].Password = oldPwdByID[newConfig.Providers[i].ID]
 			}
 		}
-	case "webdav", "api", "auth", "database", "metadata", "streaming", "health", "rclone", "import", "log", "sabnzbd", "arrs", "fuse", "segment_cache", "system", "mount_path", "mount", "stremio", "nzblnk", "network":
+	case "webdav", "api", "auth", "database", "metadata", "streaming", "health", "rclone", "import", "log", "sabnzbd", "arrs", "fuse", "segment_cache", "system", "mount_path", "mount", "stremio", "network":
 		err = c.BodyParser(newConfig)
 		// BodyParser will map fields like "profiler_enabled" from JSON to the root of newConfig
 		// because Config struct has it with `json:"profiler_enabled"`.

--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -713,7 +713,7 @@ func (s *Server) handleUploadNZBLnk(c *fiber.Ctx) error {
 
 	// Create resolver
 	cfg := s.configManager.GetConfig()
-	resolver := nzblnk.NewResolver(cfg.Nzblnk.UserAgent, httpclient.NewForExternal(cfg.Network, 30*time.Second))
+	resolver := nzblnk.NewResolver(cfg.GetUserAgent(), httpclient.NewForExternal(cfg.Network, 30*time.Second))
 
 	// Process each link
 	type linkResult struct {
@@ -908,7 +908,7 @@ func (s *Server) handleSearchNZBByName(c *fiber.Ctx) error {
 	}
 
 	cfg := s.configManager.GetConfig()
-	resolver := nzblnk.NewResolver(cfg.Nzblnk.UserAgent, httpclient.NewForExternal(cfg.Network, 30*time.Second))
+	resolver := nzblnk.NewResolver(cfg.GetUserAgent(), httpclient.NewForExternal(cfg.Network, 30*time.Second))
 	resolved, err := resolver.Resolve(c.Context(), syntheticLink)
 	if err != nil {
 		return RespondNotFound(c, "NZB", "Could not find NZB for name '"+req.Name+"': "+err.Error())

--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -458,7 +458,7 @@ func (s *Server) handleSABnzbdAddUrl(c *fiber.Ctx) error {
 	if err != nil {
 		return s.writeSABnzbdErrorFiber(c, "Failed to build NZB download request")
 	}
-	req.Header.Set("User-Agent", "altmount")
+	req.Header.Set("User-Agent", s.configManager.GetConfig().GetUserAgent())
 	resp, err := httpclient.NewLong().Do(req)
 	if err != nil {
 		return s.writeSABnzbdErrorFiber(c, "Failed to download NZB from URL")

--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -275,7 +275,7 @@ func (s *Server) findHealthyLibraryStreams(ctx context.Context, cfg *config.Conf
 	selector := &stremioEpisodeSelector{Season: season, Episode: episode}
 	var libraryStreams []fiber.Map
 	if streamType == "movie" {
-		tmdbID, movieTitle, movieYear, _ := resolveMovieMetadataFromIMDb(ctx, imdbID)
+		tmdbID, movieTitle, movieYear, _ := resolveMovieMetadataFromIMDb(ctx, imdbID, cfg.GetUserAgent())
 		yearNum, _ := strconv.Atoi(movieYear)
 		if healthyFiles, err := s.healthRepo.FindHealthyFilesForMovie(ctx, movieTitle, movieYear, tmdbID); err == nil {
 			for _, h := range healthyFiles {
@@ -299,7 +299,7 @@ func (s *Server) findHealthyLibraryStreams(ctx context.Context, cfg *config.Conf
 			}
 		}
 	} else if streamType == "series" {
-		tvdbIDStr, seriesTitle, _ := resolveSeriesMetadataFromIMDb(ctx, imdbID)
+		tvdbIDStr, seriesTitle, _ := resolveSeriesMetadataFromIMDb(ctx, imdbID, cfg.GetUserAgent())
 		tvdbID, _ := strconv.Atoi(tvdbIDStr)
 		if healthyFiles, err := s.healthRepo.FindHealthyFilesForSeries(ctx, seriesTitle, tvdbID); err == nil {
 			for _, h := range healthyFiles {
@@ -886,7 +886,7 @@ func (s *Server) searchStremioReleases(
 	seriesMatchCtx := releaseMatchContext{}
 	if streamType == "series" {
 		var err error
-		tvdbID, title, err = resolveSeriesMetadataFromIMDb(ctx, imdbID)
+		tvdbID, title, err = resolveSeriesMetadataFromIMDb(ctx, imdbID, cfg.GetUserAgent())
 		if err != nil {
 			slog.WarnContext(ctx, "Failed to resolve series metadata from IMDb ID", "error", err, "imdb_id", imdbID)
 		}
@@ -895,14 +895,14 @@ func (s *Server) searchStremioReleases(
 		// titles; resolve both once per request so the relevance gate can
 		// accept e.g. "[SubsPlease] Detective Conan - 1210" for catalog
 		// SxxEyy entries.
-		meta := resolveSeriesEpisodeMeta(ctx, imdbID)
+		meta := resolveSeriesEpisodeMeta(ctx, imdbID, cfg.GetUserAgent())
 		seriesMatchCtx = releaseMatchContext{
-			aliases:     resolveSeriesTitleAliases(ctx, imdbID),
+			aliases:     resolveSeriesTitleAliases(ctx, imdbID, cfg.GetUserAgent()),
 			episodeMeta: meta,
 			isAnime:     meta.isAnimation,
 		}
 	} else if imdbID != "" {
-		_, movieTitle, movieYear, mErr := resolveMovieMetadataFromIMDb(ctx, imdbID)
+		_, movieTitle, movieYear, mErr := resolveMovieMetadataFromIMDb(ctx, imdbID, cfg.GetUserAgent())
 		if mErr != nil {
 			slog.WarnContext(ctx, "Failed to resolve movie metadata from IMDb ID", "error", mErr, "imdb_id", imdbID)
 		}
@@ -1619,11 +1619,11 @@ func (s *Server) enqueueStremioRelease(
 			tvdbID := 0
 			if streamType == "series" {
 				category = "TV"
-				if tvdbIDStr, _, _ := resolveSeriesMetadataFromIMDb(workCtx, imdbID); tvdbIDStr != "" {
+				if tvdbIDStr, _, _ := resolveSeriesMetadataFromIMDb(workCtx, imdbID, cfg.GetUserAgent()); tvdbIDStr != "" {
 					tvdbID, _ = strconv.Atoi(tvdbIDStr)
 				}
 			} else if streamType == "movie" {
-				tmdbID, _, _, _ = resolveMovieMetadataFromIMDb(workCtx, imdbID)
+				tmdbID, _, _, _ = resolveMovieMetadataFromIMDb(workCtx, imdbID, cfg.GetUserAgent())
 			}
 			stremioDownloadID := stremioDownloadIDPrefix + uuid.NewString()
 			metaJSONPtr, metadataErr := encodeStremioQueueMetadata(stremioQueueMetadata{
@@ -1949,7 +1949,7 @@ func (s *Server) handleTestNewsnabIndexer(c *fiber.Ctx) error {
 		Enabled:        true,
 	}, httpclient.NewForExternal(cfg.Network, 10*time.Second))
 
-	ua := stremio.GetUserAgentManager().GetUserAgent("movie", "")
+	ua := stremio.GetUserAgentManager().GetUserAgent("movie", cfg.Stremio.Indexers.CustomUserAgent)
 	caps, err := client.CheckCaps(c.Context(), ua)
 	if err != nil {
 		return RespondBadRequest(c, "Failed to connect to Newsnab indexer", err.Error())
@@ -1982,12 +1982,12 @@ func (s *Server) handleRefreshStremioUserAgents(c *fiber.Ctx) error {
 
 	cfg := s.configManager.GetConfig()
 	if cfg != nil {
-		_ = mgr.FetchLatestFromGitHub(ctx)
+		_ = mgr.FetchLatestFromGitHub(ctx, cfg.GetUserAgent())
 		sonarrURL, sonarrKey := firstEnabledARR(cfg.Arrs.SonarrInstances)
 		radarrURL, radarrKey := firstEnabledARR(cfg.Arrs.RadarrInstances)
 		_ = mgr.CheckLocalARRs(ctx, sonarrURL, sonarrKey, radarrURL, radarrKey)
 	} else {
-		_ = mgr.FetchLatestFromGitHub(ctx)
+		_ = mgr.FetchLatestFromGitHub(ctx, "")
 	}
 
 	return RespondSuccess(c, mgr.GetInfo())

--- a/internal/api/stremio_inspect_handlers.go
+++ b/internal/api/stremio_inspect_handlers.go
@@ -85,7 +85,7 @@ func (s *Server) resolveInspectMetadata(ctx context.Context, req *InspectSearchR
 	}
 
 	if req.Type == "series" {
-		tvdbID, title, err := resolveSeriesMetadataFromIMDb(ctx, req.IMDbID)
+		tvdbID, title, err := resolveSeriesMetadataFromIMDb(ctx, req.IMDbID, s.configManager.GetConfig().GetUserAgent())
 		if err != nil {
 			slog.WarnContext(ctx, "Failed to resolve series metadata from IMDb ID", "error", err, "imdb_id", req.IMDbID)
 			return meta
@@ -101,7 +101,7 @@ func (s *Server) resolveInspectMetadata(ctx context.Context, req *InspectSearchR
 		return meta
 	}
 
-	tmdbID, movieTitle, movieYear, err := resolveMovieMetadataFromIMDb(ctx, req.IMDbID)
+	tmdbID, movieTitle, movieYear, err := resolveMovieMetadataFromIMDb(ctx, req.IMDbID, s.configManager.GetConfig().GetUserAgent())
 	if err != nil {
 		slog.WarnContext(ctx, "Failed to resolve movie metadata from IMDb ID", "error", err, "imdb_id", req.IMDbID)
 		return meta

--- a/internal/api/stremio_release_gate_test.go
+++ b/internal/api/stremio_release_gate_test.go
@@ -194,7 +194,7 @@ func TestReleaseMatchesContentAnimeAliasesAndAbsolute(t *testing.T) {
 }
 
 func TestResolveSeriesTitleAliasesCacheNilSafe(t *testing.T) {
-	if resolveSeriesTitleAliases(context.Background(), "") != nil {
+	if resolveSeriesTitleAliases(context.Background(), "", "test-agent") != nil {
 		t.Fatal("empty imdb must yield nil aliases")
 	}
 }

--- a/internal/api/tvdb_lookup.go
+++ b/internal/api/tvdb_lookup.go
@@ -35,14 +35,14 @@ type tvmazeLookupResponse struct {
 // failure — callers must treat nil as "no aliases known".
 var seriesTitleAliasesCache seriesMetadataCache[[]string]
 
-func resolveSeriesTitleAliases(ctx context.Context, imdbID string) []string {
+func resolveSeriesTitleAliases(ctx context.Context, imdbID, userAgent string) []string {
 	if imdbID == "" {
 		return nil
 	}
 	if cached, ok := seriesTitleAliasesCache.get(imdbID); ok {
 		return cached
 	}
-	showID, err := tvmazeShowIDForIMDb(ctx, imdbID)
+	showID, err := tvmazeShowIDForIMDb(ctx, imdbID, userAgent)
 	if err != nil || showID <= 0 {
 		return cacheAliasMiss(imdbID)
 	}
@@ -52,7 +52,7 @@ func resolveSeriesTitleAliases(ctx context.Context, imdbID string) []string {
 		return cacheAliasMiss(imdbID)
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", "altmount-stremio-tvdb-lookup")
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := tvMetadataLookupClient.Do(req)
 	if err != nil {
 		return cacheAliasMiss(imdbID)
@@ -108,14 +108,14 @@ func (m seriesEpisodeMeta) absoluteFor(season, episode int) int {
 
 var seriesEpisodeMetaCache seriesMetadataCache[seriesEpisodeMeta]
 
-func resolveSeriesEpisodeMeta(ctx context.Context, imdbID string) seriesEpisodeMeta {
+func resolveSeriesEpisodeMeta(ctx context.Context, imdbID, userAgent string) seriesEpisodeMeta {
 	if imdbID == "" {
 		return seriesEpisodeMeta{}
 	}
 	if cached, ok := seriesEpisodeMetaCache.get(imdbID); ok {
 		return cached
 	}
-	showID, metaType, err := tvmazeShowForIMDb(ctx, imdbID)
+	showID, metaType, err := tvmazeShowForIMDb(ctx, imdbID, userAgent)
 	if err != nil || showID <= 0 {
 		return cacheEpisodeMetaMiss(imdbID)
 	}
@@ -126,7 +126,7 @@ func resolveSeriesEpisodeMeta(ctx context.Context, imdbID string) seriesEpisodeM
 		return cacheEpisodeMetaMiss(imdbID)
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", "altmount-stremio-tvdb-lookup")
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := tvMetadataLookupClient.Do(req)
 	if err != nil {
 		return cacheEpisodeMetaMiss(imdbID)
@@ -163,14 +163,14 @@ func resolveSeriesEpisodeMeta(ctx context.Context, imdbID string) seriesEpisodeM
 	return meta
 }
 
-func tvmazeShowForIMDb(ctx context.Context, imdbID string) (showID int, showType string, err error) {
+func tvmazeShowForIMDb(ctx context.Context, imdbID, userAgent string) (showID int, showType string, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
 		tvmazeBaseURL+"/lookup/shows?imdb="+url.QueryEscape(imdbID), nil)
 	if err != nil {
 		return 0, "", err
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", "altmount-stremio-tvdb-lookup")
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := tvMetadataLookupClient.Do(req)
 	if err != nil {
 		return 0, "", err
@@ -186,8 +186,8 @@ func tvmazeShowForIMDb(ctx context.Context, imdbID string) (showID int, showType
 	return data.ID, data.Type, nil
 }
 
-func tvmazeShowIDForIMDb(ctx context.Context, imdbID string) (int, error) {
-	id, _, err := tvmazeShowForIMDb(ctx, imdbID)
+func tvmazeShowIDForIMDb(ctx context.Context, imdbID, userAgent string) (int, error) {
+	id, _, err := tvmazeShowForIMDb(ctx, imdbID, userAgent)
 	return id, err
 }
 
@@ -199,7 +199,7 @@ type cinemetaLookupResponse struct {
 }
 
 // resolveSeriesMetadataFromIMDb resolves both TVDB ID and series title from an IMDb ID.
-func resolveSeriesMetadataFromIMDb(ctx context.Context, imdbID string) (tvdbID, title string, err error) {
+func resolveSeriesMetadataFromIMDb(ctx context.Context, imdbID, userAgent string) (tvdbID, title string, err error) {
 	if imdbID == "" {
 		return "", "", nil
 	}
@@ -213,7 +213,7 @@ func resolveSeriesMetadataFromIMDb(ctx context.Context, imdbID string) (tvdbID, 
 	)
 	if err == nil {
 		req.Header.Set("Accept", "application/json")
-		req.Header.Set("User-Agent", "altmount-stremio-tvdb-lookup")
+		req.Header.Set("User-Agent", userAgent)
 
 		if resp, err := tvMetadataLookupClient.Do(req); err == nil {
 			defer resp.Body.Close()
@@ -241,7 +241,7 @@ func resolveSeriesMetadataFromIMDb(ctx context.Context, imdbID string) (tvdbID, 
 	)
 	if err == nil {
 		req.Header.Set("Accept", "application/json")
-		req.Header.Set("User-Agent", "altmount-stremio-tvdb-lookup")
+		req.Header.Set("User-Agent", userAgent)
 
 		if resp, err := tvMetadataLookupClient.Do(req); err == nil {
 			defer resp.Body.Close()
@@ -269,7 +269,7 @@ type cinemetaMovieLookupResponse struct {
 }
 
 // resolveMovieMetadataFromIMDb resolves TMDB ID, movie title, and release year from an IMDb ID.
-func resolveMovieMetadataFromIMDb(ctx context.Context, imdbID string) (tmdbID int, title string, year string, err error) {
+func resolveMovieMetadataFromIMDb(ctx context.Context, imdbID, userAgent string) (tmdbID int, title string, year string, err error) {
 	if imdbID == "" {
 		return 0, "", "", nil
 	}
@@ -284,7 +284,7 @@ func resolveMovieMetadataFromIMDb(ctx context.Context, imdbID string) (tmdbID in
 		return 0, "", "", err
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", "altmount-stremio-movie-lookup")
+	req.Header.Set("User-Agent", userAgent)
 
 	resp, err := tvMetadataLookupClient.Do(req)
 	if err != nil {

--- a/internal/api/tvdb_lookup_cache_test.go
+++ b/internal/api/tvdb_lookup_cache_test.go
@@ -27,7 +27,7 @@ func TestSeriesMetadataNegativeCaching(t *testing.T) {
 
 	const imdb = "tt0000001"
 	for i := 0; i < 5; i++ {
-		if aliases := resolveSeriesTitleAliases(context.Background(), imdb); aliases != nil {
+		if aliases := resolveSeriesTitleAliases(context.Background(), imdb, "test-agent"); aliases != nil {
 			t.Fatalf("expected nil aliases for an unknown series, got %v", aliases)
 		}
 	}
@@ -51,7 +51,7 @@ func TestSeriesMetadataCacheIsBounded(t *testing.T) {
 	resetSeriesMetadataCaches()
 
 	for i := 0; i < maxSeriesMetadataCacheEntries+50; i++ {
-		resolveSeriesTitleAliases(context.Background(), "tt"+strconv.Itoa(i))
+		resolveSeriesTitleAliases(context.Background(), "tt"+strconv.Itoa(i), "test-agent")
 	}
 
 	if n := seriesTitleAliasesCacheLen(); n > maxSeriesMetadataCacheEntries {

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -53,18 +53,36 @@ type Config struct {
 	Fuse            FuseConfig         `yaml:"fuse" mapstructure:"fuse" json:"fuse"`
 	SegmentCache    SegmentCacheConfig `yaml:"segment_cache" mapstructure:"segment_cache" json:"segment_cache"`
 	Providers       []ProviderConfig   `yaml:"providers" mapstructure:"providers" json:"providers"`
-	Nzblnk          NzblnkConfig       `yaml:"nzblnk" mapstructure:"nzblnk" json:"nzblnk"`
+	Nzblnk          NzblnkConfig       `yaml:"nzblnk,omitempty" mapstructure:"nzblnk" json:"-"`
 	Network         NetworkConfig      `yaml:"network" mapstructure:"network" json:"network"`
+	// UserAgent is the HTTP User-Agent sent on every outbound HTTP request that
+	// identifies AltMount (indexer NZB downloads, metadata lookups, nzblnk://
+	// resolution, GitHub release checks). Defaults to a browser-like string
+	// because some public indexers reject non-browser agents. Leave empty to
+	// use the default.
+	UserAgent string `yaml:"user_agent" mapstructure:"user_agent" json:"user_agent"`
 	MountPath       string             `yaml:"mount_path" mapstructure:"mount_path" json:"mount_path"`
 	MountType       MountType          `yaml:"mount_type" mapstructure:"mount_type" json:"mount_type"`
 	ProfilerEnabled bool               `yaml:"profiler_enabled" mapstructure:"profiler_enabled" json:"profiler_enabled" default:"false"`
 }
 
-// NzblnkConfig configures the NZBLNK resolver (used for nzblnk:// link resolution via public indexers).
+// NzblnkConfig is the legacy scoped user-agent config, retained only so
+// existing YAML files can be migrated into the global user_agent field.
 type NzblnkConfig struct {
-	// UserAgent is the HTTP User-Agent sent to indexers when resolving nzblnk:// links.
-	// Defaults to a browser-like string. Leave empty to use the default.
-	UserAgent string `yaml:"user_agent" mapstructure:"user_agent" json:"user_agent,omitempty"`
+	UserAgent string `yaml:"user_agent,omitempty" mapstructure:"user_agent" json:"-"`
+}
+
+// DefaultUserAgent is the fallback for Config.UserAgent. Browser-like because
+// some public indexers (e.g. nzbking.com) reject non-browser agents.
+const DefaultUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+// GetUserAgent returns the configured global User-Agent, falling back to
+// DefaultUserAgent when unset.
+func (c *Config) GetUserAgent() string {
+	if c.UserAgent != "" {
+		return c.UserAgent
+	}
+	return DefaultUserAgent
 }
 
 // NetworkConfig holds outbound HTTP routing options applied to every external
@@ -653,6 +671,19 @@ type StuckCleanupRule struct {
 	Message string `yaml:"message" mapstructure:"message" json:"message"`
 	Enabled bool   `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
 	Action  string `yaml:"action" mapstructure:"action" json:"action"`
+}
+
+// migrateGlobalUserAgent adopts the legacy nzblnk.user_agent as the global
+// user_agent when the global one was never customized, then clears the legacy
+// field so it is dropped from saved YAML. Idempotent.
+func migrateGlobalUserAgent(config *Config) {
+	if config.Nzblnk.UserAgent == "" {
+		return
+	}
+	if config.UserAgent == "" || config.UserAgent == DefaultUserAgent {
+		config.UserAgent = config.Nzblnk.UserAgent
+	}
+	config.Nzblnk = NzblnkConfig{}
 }
 
 // migrateArrsCleanup folds the legacy split cleanup config (separate stuck-rules
@@ -1578,6 +1609,7 @@ func (m *Manager) ReloadConfig() error {
 
 	// Migrate: fold legacy stuck/allowlist cleanup config into the unified rules.
 	migrateArrsCleanup(config)
+	migrateGlobalUserAgent(config)
 
 	// Validate configuration
 	if err := config.Validate(); err != nil {
@@ -1877,9 +1909,7 @@ func DefaultConfig(configDir ...string) *Config {
 			HistoryRetentionMinutes: 10080,
 		},
 		Providers: []ProviderConfig{},
-		Nzblnk: NzblnkConfig{
-			UserAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-		},
+		UserAgent: DefaultUserAgent,
 		Arrs: ArrsConfig{
 			Enabled:                        &scrapperEnabled, // Disabled by default
 			MaxWorkers:                     5,                // Default to 5 concurrent workers
@@ -2074,6 +2104,7 @@ func LoadConfig(configFile string) (*Config, error) {
 
 	// Migrate: fold legacy stuck/allowlist cleanup config into the unified rules.
 	migrateArrsCleanup(config)
+	migrateGlobalUserAgent(config)
 
 	// If log file was not explicitly set in the config file and we have a specific config file path,
 	// derive log file path from config file location

--- a/internal/config/useragent_test.go
+++ b/internal/config/useragent_test.go
@@ -1,0 +1,48 @@
+package config
+
+import "testing"
+
+func TestMigrateGlobalUserAgent(t *testing.T) {
+	t.Run("adopts legacy nzblnk user agent when global is default", func(t *testing.T) {
+		c := DefaultConfig()
+		c.Nzblnk.UserAgent = "LegacyAgent/1.0"
+		migrateGlobalUserAgent(c)
+		if c.UserAgent != "LegacyAgent/1.0" {
+			t.Fatalf("expected legacy agent adopted, got %q", c.UserAgent)
+		}
+		if c.Nzblnk.UserAgent != "" {
+			t.Fatal("expected legacy field cleared")
+		}
+	})
+
+	t.Run("keeps explicit global user agent", func(t *testing.T) {
+		c := DefaultConfig()
+		c.UserAgent = "Explicit/2.0"
+		c.Nzblnk.UserAgent = "LegacyAgent/1.0"
+		migrateGlobalUserAgent(c)
+		if c.UserAgent != "Explicit/2.0" {
+			t.Fatalf("expected explicit agent kept, got %q", c.UserAgent)
+		}
+		if c.Nzblnk.UserAgent != "" {
+			t.Fatal("expected legacy field cleared")
+		}
+	})
+
+	t.Run("noop without legacy value", func(t *testing.T) {
+		c := DefaultConfig()
+		migrateGlobalUserAgent(c)
+		if c.UserAgent != DefaultUserAgent {
+			t.Fatalf("expected default agent, got %q", c.UserAgent)
+		}
+	})
+}
+
+func TestGetUserAgentFallback(t *testing.T) {
+	if got := (&Config{}).GetUserAgent(); got != DefaultUserAgent {
+		t.Fatalf("expected DefaultUserAgent fallback, got %q", got)
+	}
+	c := &Config{UserAgent: "Custom/1.0"}
+	if got := c.GetUserAgent(); got != "Custom/1.0" {
+		t.Fatalf("expected configured agent, got %q", got)
+	}
+}

--- a/internal/stremio/useragent.go
+++ b/internal/stremio/useragent.go
@@ -153,9 +153,10 @@ func (m *UserAgentManager) CheckLocalARRs(ctx context.Context, sonarrURL, sonarr
 }
 
 // FetchLatestFromGitHub queries GitHub releases for latest Sonarr & Radarr version tags.
-func (m *UserAgentManager) FetchLatestFromGitHub(ctx context.Context) error {
-	sonarrVer, sonarrErr := m.fetchGitHubReleaseTag(ctx, "Sonarr/Sonarr")
-	radarrVer, radarrErr := m.fetchGitHubReleaseTag(ctx, "Radarr/Radarr")
+// userAgent is the configured User-Agent to send; empty falls back to a static identifier.
+func (m *UserAgentManager) FetchLatestFromGitHub(ctx context.Context, userAgent string) error {
+	sonarrVer, sonarrErr := m.fetchGitHubReleaseTag(ctx, "Sonarr/Sonarr", userAgent)
+	radarrVer, radarrErr := m.fetchGitHubReleaseTag(ctx, "Radarr/Radarr", userAgent)
 
 	if sonarrErr != nil && radarrErr != nil {
 		return fmt.Errorf("failed to fetch from github: sonarr: %v; radarr: %v", sonarrErr, radarrErr)
@@ -179,13 +180,16 @@ func (m *UserAgentManager) FetchLatestFromGitHub(ctx context.Context) error {
 	return nil
 }
 
-func (m *UserAgentManager) fetchGitHubReleaseTag(ctx context.Context, repo string) (string, error) {
+func (m *UserAgentManager) fetchGitHubReleaseTag(ctx context.Context, repo, userAgent string) (string, error) {
 	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return "", err
 	}
-	req.Header.Set("User-Agent", "AltMount/1.0")
+	if userAgent == "" {
+		userAgent = "AltMount/1.0"
+	}
+	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 
 	resp, err := m.httpClient.Do(req)


### PR DESCRIPTION
## Summary
- Add a root-level `user_agent` config option (defaults to a browser-like string, since some public indexers reject non-browser agents) with a `Config.GetUserAgent()` fallback accessor
- Use the configured User-Agent everywhere one was previously hardcoded:
  - NZBLNK resolver (`queue_handlers.go`)
  - SABnzbd add-url NZB download (was `"altmount"`)
  - TVmaze/Cinemeta metadata lookups in `tvdb_lookup.go` (was `"altmount-stremio-tvdb-lookup"` / `"-movie-lookup"`), UA threaded as a parameter
  - GitHub release checks in the Stremio UA manager (falls back to `AltMount/1.0` when unset)
  - Newsnab indexer test now honors the configured Stremio custom User-Agent instead of always impersonating Radarr
- Remove the scoped `nzblnk.user_agent` setting; legacy YAML values are migrated into the global field on load (unless the global one was customized) and dropped on save
- Frontend: Network section now edits the global User-Agent; `NzblnkConfig` removed from types and the configuration page

Left untouched: Stremio `user_agent_mode`/`custom_user_agent` (deliberate Sonarr/Radarr impersonation feature) and per-NNTP-provider `user_agent`.

## Test plan
- [x] New unit tests for migration + fallback (`internal/config/useragent_test.go`)
- [x] `go build ./...`, `go vet`, `go test ./internal/{config,api,stremio}/...` pass
- [x] `bun run check` and `bun run build` pass
- [ ] Manual: set User-Agent in Network settings, verify indexer NZB download sends it