### PR TITLE
feat(import): report segment cache hit rate per analysis pass

### DIFF
--- a/internal/importer/archive/iso/bluray_test.go
+++ b/internal/importer/archive/iso/bluray_test.go
@@ -406,10 +406,10 @@ func TestResolveMainFeature(t *testing.T) {
 		// dedupes only for scoring; the output Streams slice must retain
 		// the playlist's actual playback order, including duplicates.
 		data := buildMPLS(t, "0200", []MPLSPlayItem{
-			{ClipName: "00001", InTime: 0, OutTime: 30 * 45000},  // A
-			{ClipName: "00002", InTime: 0, OutTime: 60 * 45000},  // B
-			{ClipName: "00001", InTime: 0, OutTime: 30 * 45000},  // A again
-			{ClipName: "00003", InTime: 0, OutTime: 90 * 45000},  // C
+			{ClipName: "00001", InTime: 0, OutTime: 30 * 45000}, // A
+			{ClipName: "00002", InTime: 0, OutTime: 60 * 45000}, // B
+			{ClipName: "00001", InTime: 0, OutTime: 30 * 45000}, // A again
+			{ClipName: "00003", InTime: 0, OutTime: 90 * 45000}, // C
 		}, nil)
 		rs := makeImage(t, map[uint32][]byte{100: data})
 

--- a/internal/importer/archive/iso/fs_local_test.go
+++ b/internal/importer/archive/iso/fs_local_test.go
@@ -63,9 +63,9 @@ func TestUDFWalk_LogsWhenFileICBHasUnknownTag(t *testing.T) {
 	fid[19] = byte(1 + len(name))                   // L_FI (comp byte + ASCII chars)
 	binary.LittleEndian.PutUint32(fid[20:24], 2048) // long_ad.length
 	binary.LittleEndian.PutUint32(fid[24:28], bogusSector)
-	binary.LittleEndian.PutUint16(fid[28:30], 0)   // long_ad.partition (0 → partStart-relative)
-	binary.LittleEndian.PutUint16(fid[36:38], 0)   // L_IU (impl-use length)
-	fid[38] = 8                                    // CS0 compression code (8 = ASCII)
+	binary.LittleEndian.PutUint16(fid[28:30], 0) // long_ad.partition (0 → partStart-relative)
+	binary.LittleEndian.PutUint16(fid[36:38], 0) // L_IU (impl-use length)
+	fid[38] = 8                                  // CS0 compression code (8 = ASCII)
 	copy(fid[39:39+len(name)], name)
 	// Padded record length (38 header + 11 name = 49, padded to 52). We
 	// leave the trailing 3 bytes as zeros from the make().
@@ -176,9 +176,9 @@ func TestUDFWalk_FollowsIndirectEntryChain(t *testing.T) {
 			} else {
 				nextSector = feSector
 			}
-			binary.LittleEndian.PutUint32(ie[36:40], 2048)        // length
-			binary.LittleEndian.PutUint32(ie[40:44], nextSector)  // block
-			binary.LittleEndian.PutUint16(ie[44:46], 0)           // partition
+			binary.LittleEndian.PutUint32(ie[36:40], 2048)       // length
+			binary.LittleEndian.PutUint32(ie[40:44], nextSector) // block
+			binary.LittleEndian.PutUint16(ie[44:46], 0)          // partition
 		}
 
 		// Real File Entry at feSector: tag 261, allocType 0 (short_ad),
@@ -187,10 +187,10 @@ func TestUDFWalk_FollowsIndirectEntryChain(t *testing.T) {
 		binary.LittleEndian.PutUint16(fe[0:2], 261) // File Entry
 		fe[34] = 0                                  // allocType 0 = short_ad
 		binary.LittleEndian.PutUint64(fe[56:64], uint64(dataSize))
-		binary.LittleEndian.PutUint32(fe[168:172], 0)    // L_EA
-		binary.LittleEndian.PutUint32(fe[172:176], 8)    // L_AD = one short_ad
-		binary.LittleEndian.PutUint32(fe[176:180], dataSize)    // short_ad.length (adType 0 in high 2 bits)
-		binary.LittleEndian.PutUint32(fe[180:184], dataSector)  // short_ad.block
+		binary.LittleEndian.PutUint32(fe[168:172], 0)          // L_EA
+		binary.LittleEndian.PutUint32(fe[172:176], 8)          // L_AD = one short_ad
+		binary.LittleEndian.PutUint32(fe[176:180], dataSize)   // short_ad.length (adType 0 in high 2 bits)
+		binary.LittleEndian.PutUint32(fe[180:184], dataSector) // short_ad.block
 
 		dirICB := udfLongAD{length: iso9660SectorSize, loc: udfLBA{block: dirSector, part: 0}}
 		return image, dirICB
@@ -353,9 +353,9 @@ func TestLocalISO_CountExtentsForBigFiles(t *testing.T) {
 	// count its allocation descriptors. We can't reuse ListISOFiles output
 	// directly because isoFileEntry discards the ICB.
 	type probed struct {
-		path string
-		size uint64
-		ads  int // allocation descriptors observed (= number of on-disc extents)
+		path  string
+		size  uint64
+		ads   int // allocation descriptors observed (= number of on-disc extents)
 		alloc byte
 	}
 

--- a/internal/importer/archive/iso/mpls_test.go
+++ b/internal/importer/archive/iso/mpls_test.go
@@ -105,8 +105,8 @@ func TestParseMPLS(t *testing.T) {
 				{ClipName: "00001", InTime: 0, OutTime: 45000},
 				{ClipName: "00002", InTime: 0, OutTime: 90000},
 			}, []byte{
-				0x02,                                     // num_angles
-				0x00,                                     // is_different_audios flags
+				0x02,                                              // num_angles
+				0x00,                                              // is_different_audios flags
 				'0', '0', '0', '0', '7', 'M', '2', 'T', 'S', 0x00, // one alt angle entry (10 bytes)
 			}),
 			wantItems: []MPLSPlayItem{

--- a/internal/importer/archive/iso/reader.go
+++ b/internal/importer/archive/iso/reader.go
@@ -46,5 +46,19 @@ func NewISOReadSeeker(
 		return nil, nil, fmt.Errorf("iso: opened file does not implement io.ReadSeeker")
 	}
 
-	return rs, f, nil
+	// The cache lives as long as the reader, so its effectiveness can only be
+	// reported once the caller is done with it — not when this constructor
+	// returns, which is before a single sector has been read.
+	closer := closerFunc(func() error {
+		err := f.Close()
+		segStore.LogStats(ctx, nil, "iso-structure")
+		return err
+	})
+
+	return rs, closer, nil
 }
+
+// closerFunc adapts a function to io.Closer.
+type closerFunc func() error
+
+func (fn closerFunc) Close() error { return fn() }

--- a/internal/importer/archive/iso_expansion_test.go
+++ b/internal/importer/archive/iso_expansion_test.go
@@ -46,15 +46,15 @@ func TestParseDiscNumber(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]int{
-		"1":     1,
-		"2":     2,
-		"10":    10,
-		"A":     1,
-		"a":     1,
-		"B":     2,
-		"":      0,
-		"AB":    0,
-		"foo":   0,
+		"1":   1,
+		"2":   2,
+		"10":  10,
+		"A":   1,
+		"a":   1,
+		"B":   2,
+		"":    0,
+		"AB":  0,
+		"foo": 0,
 	}
 	for in, want := range cases {
 		if got := parseDiscNumber(in); got != want {

--- a/internal/importer/archive/rar/processor.go
+++ b/internal/importer/archive/rar/processor.go
@@ -123,6 +123,7 @@ func (rh *rarProcessor) AnalyzeRarContentFromNzb(ctx context.Context, rarFiles [
 	// header probing frequently revisit the same leading segments across volumes.
 	// Bounded and released (by dropping the reference) when this analysis pass returns.
 	segStore := filesystem.NewImportSegmentCache(0)
+	defer segStore.LogStats(ctx, rh.log, "rar-header")
 	ufs := filesystem.NewUsenetFileSystem(ctx, rh.poolManager, normalizedFiles, headerAnalysisPrefetch, progressTracker, readTimeout, segStore)
 
 	// Extract filenames for first part detection
@@ -794,6 +795,7 @@ func (rh *rarProcessor) processNestedRarContent(ctx context.Context, innerRarCon
 	headerAnalysisPrefetch := 1
 	// Import-scoped segment cache, private to this nested-RAR analysis pass.
 	segStore := filesystem.NewImportSegmentCache(0)
+	defer segStore.LogStats(ctx, rh.log, "rar-nested")
 	dfs := filesystem.NewDecryptingFileSystem(ctx, rh.poolManager, entries, headerAnalysisPrefetch, readTimeout, segStore)
 
 	// Find the first inner RAR part

--- a/internal/importer/archive/rar/utils_test.go
+++ b/internal/importer/archive/rar/utils_test.go
@@ -340,4 +340,3 @@ func TestGroupHasVolumeGap_NoR00Convention(t *testing.T) {
 		t.Errorf("groupHasVolumeGap with missing r02 = false, want true")
 	}
 }
-

--- a/internal/importer/archive/sevenzip/aggregator_test.go
+++ b/internal/importer/archive/sevenzip/aggregator_test.go
@@ -140,22 +140,22 @@ func TestProcessArchivePreservesInternalFolderStructure(t *testing.T) {
 			}
 
 			err := ProcessArchive(ctx, ProcessArchiveOptions{
-				VirtualDir:              tt.virtualDir,
-				ArchiveFiles:            []parser.ParsedFile{{Filename: "archive.7z"}},
-				Password:                "",
-				ReleaseDate:             0,
-				NzbPath:                 tt.nzbPath,
-				Processor:               proc,
-				MetadataService:         svc,
+				VirtualDir:             tt.virtualDir,
+				ArchiveFiles:           []parser.ParsedFile{{Filename: "archive.7z"}},
+				Password:               "",
+				ReleaseDate:            0,
+				NzbPath:                tt.nzbPath,
+				Processor:              proc,
+				MetadataService:        svc,
 				PoolManager:            nil,
 				ArchiveProgressTracker: nil,
 				AllowedFileExtensions:  nil,
 				ExtractedFiles:         extracted,
-				MaxPrefetch:             1,
-				ReadTimeout:             30 * time.Second,
-				ExpandBlurayIso:         false,
-				FilterSamples:           false,
-				RenameToNzbName:         tt.renameToNzbName,
+				MaxPrefetch:            1,
+				ReadTimeout:            30 * time.Second,
+				ExpandBlurayIso:        false,
+				FilterSamples:          false,
+				RenameToNzbName:        tt.renameToNzbName,
 			})
 			require.NoError(t, err)
 

--- a/internal/importer/archive/sevenzip/processor.go
+++ b/internal/importer/archive/sevenzip/processor.go
@@ -136,6 +136,7 @@ func (sz *sevenZipProcessor) AnalyzeSevenZipContentFromNzb(ctx context.Context, 
 	// or header probe that revisits an already-fetched segment re-downloads it.
 	// Bounded and released (by dropping the reference) when this pass returns.
 	segStore := filesystem.NewImportSegmentCache(0)
+	defer segStore.LogStats(ctx, sz.log, "7z-header")
 	ufs := filesystem.NewUsenetFileSystem(ctx, sz.poolManager, sortedFiles, headerAnalysisPrefetch, progressTracker, readTimeout, segStore)
 
 	// Extract filenames for first part detection
@@ -918,6 +919,7 @@ func (sz *sevenZipProcessor) processNestedRarContent(ctx context.Context, innerR
 	headerAnalysisPrefetch := 1
 	// Import-scoped segment cache, private to this nested-RAR analysis pass.
 	segStore := filesystem.NewImportSegmentCache(0)
+	defer segStore.LogStats(ctx, sz.log, "7z-nested")
 	dfs := filesystem.NewDecryptingFileSystem(ctx, sz.poolManager, entries, headerAnalysisPrefetch, readTimeout, segStore)
 
 	// Find the first inner RAR part

--- a/internal/importer/filesystem/segment_cache.go
+++ b/internal/importer/filesystem/segment_cache.go
@@ -2,6 +2,9 @@ package filesystem
 
 import (
 	"container/list"
+	"context"
+	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/javi11/altmount/internal/usenet"
@@ -47,7 +50,13 @@ type ImportSegmentCache struct {
 	items    map[string]*list.Element
 	order    *list.List // front = most recently used
 	maxBytes int64
-	curBytes int64
+
+	// Counters are guarded by mu alongside the map, so a Stats() snapshot is
+	// consistent with the entries it describes.
+	hits      int64
+	misses    int64
+	evictions int64
+	curBytes  int64
 }
 
 type importSegmentCacheEntry struct {
@@ -70,6 +79,72 @@ func NewImportSegmentCache(maxBytes int64) *ImportSegmentCache {
 	}
 }
 
+// ImportSegmentCacheStats is a snapshot of one cache's activity. It exists so
+// an operator can tell from a real import whether the cache earns the memory it
+// reserves — the hit rate was never measured before shipping, only assumed from
+// how archive analysis was believed to read.
+type ImportSegmentCacheStats struct {
+	Hits      int64
+	Misses    int64
+	Evictions int64
+	// Entries and Bytes describe the cache at the moment of the snapshot.
+	Entries int
+	Bytes   int64
+}
+
+// HitRate is hits as a fraction of all requests, or 0 when nothing was
+// requested. Computed here so every caller does not repeat the zero guard.
+func (s ImportSegmentCacheStats) HitRate() float64 {
+	total := s.Hits + s.Misses
+	if total == 0 {
+		return 0
+	}
+	return float64(s.Hits) / float64(total)
+}
+
+// Stats snapshots the cache's activity counters and current occupancy.
+func (c *ImportSegmentCache) Stats() ImportSegmentCacheStats {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return ImportSegmentCacheStats{
+		Hits:      c.hits,
+		Misses:    c.misses,
+		Evictions: c.evictions,
+		Entries:   len(c.items),
+		Bytes:     c.curBytes,
+	}
+}
+
+// LogStats writes a one-line summary of this cache's effectiveness. Call it
+// once, as the analysis pass finishes.
+//
+// Logged at info rather than debug on purpose: the counters exist so the hit
+// rate can be read off a real import, which is the one thing that was never
+// measured before the cache shipped. It is one line per analysis pass, not per
+// segment, so the volume is negligible. A pass that never touched the cache
+// logs nothing.
+func (c *ImportSegmentCache) LogStats(ctx context.Context, log *slog.Logger, pass string) {
+	if c == nil {
+		return
+	}
+	s := c.Stats()
+	if s.Hits+s.Misses == 0 {
+		return
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	log.InfoContext(ctx, "Import segment cache",
+		"pass", pass,
+		"hit_rate", fmt.Sprintf("%.2f", s.HitRate()),
+		"hits", s.Hits,
+		"misses", s.Misses,
+		"evictions", s.Evictions,
+		"entries", s.Entries,
+		"bytes", s.Bytes,
+	)
+}
+
 // Get returns the cached bytes for messageID, promoting the entry to
 // most-recently-used on hit.
 func (c *ImportSegmentCache) Get(messageID string) ([]byte, bool) {
@@ -78,8 +153,10 @@ func (c *ImportSegmentCache) Get(messageID string) ([]byte, bool) {
 
 	el, ok := c.items[messageID]
 	if !ok {
+		c.misses++
 		return nil, false
 	}
+	c.hits++
 	c.order.MoveToFront(el)
 	entry := el.Value.(*importSegmentCacheEntry)
 	return entry.data, true
@@ -108,6 +185,7 @@ func (c *ImportSegmentCache) Put(messageID string, data []byte) error {
 		if back == nil {
 			break
 		}
+		c.evictions++
 		entry := back.Value.(*importSegmentCacheEntry)
 		c.order.Remove(back)
 		delete(c.items, entry.id)

--- a/internal/importer/filesystem/segment_cache_stats_test.go
+++ b/internal/importer/filesystem/segment_cache_stats_test.go
@@ -1,0 +1,98 @@
+package filesystem
+
+import (
+	"fmt"
+	"testing"
+)
+
+// The cache was shipped without any way to tell whether it earns its memory.
+// These counters exist so a real import can answer that from its logs rather
+// than from a model of how archive analysis is assumed to read.
+func TestImportSegmentCache_StatsCountHitsMissesEvictions(t *testing.T) {
+	const seg = 1 << 20
+	c := NewImportSegmentCache(2 * seg)
+
+	if got := c.Stats(); got.Hits != 0 || got.Misses != 0 || got.Evictions != 0 {
+		t.Fatalf("fresh cache has non-zero stats: %+v", got)
+	}
+
+	// Miss, then store.
+	if _, ok := c.Get("a"); ok {
+		t.Fatal("empty cache should not hit")
+	}
+	if err := c.Put("a", make([]byte, seg)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hit.
+	if _, ok := c.Get("a"); !ok {
+		t.Fatal("a should hit")
+	}
+
+	// Force an eviction: two more entries against a 2-entry bound.
+	if err := c.Put("b", make([]byte, seg)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Put("c", make([]byte, seg)); err != nil {
+		t.Fatal(err)
+	}
+
+	got := c.Stats()
+	if got.Hits != 1 {
+		t.Errorf("Hits = %d, want 1", got.Hits)
+	}
+	if got.Misses != 1 {
+		t.Errorf("Misses = %d, want 1", got.Misses)
+	}
+	if got.Evictions == 0 {
+		t.Error("Evictions = 0, want at least 1 after exceeding the bound")
+	}
+}
+
+// A hit rate is the number an operator actually reads, so the type should
+// compute it rather than making every caller redo the division — including
+// the zero-request case, which must not divide by zero.
+func TestImportSegmentCacheStats_HitRate(t *testing.T) {
+	tests := []struct {
+		name       string
+		hits, miss int64
+		want       float64
+	}{
+		{"no requests", 0, 0, 0},
+		{"all hits", 3, 0, 1},
+		{"all misses", 0, 4, 0},
+		{"three quarters", 3, 1, 0.75},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := ImportSegmentCacheStats{Hits: tt.hits, Misses: tt.miss}
+			if got := s.HitRate(); got != tt.want {
+				t.Errorf("HitRate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestImportSegmentCache_StatsAreConcurrencySafe(t *testing.T) {
+	c := NewImportSegmentCache(1 << 20)
+	done := make(chan struct{})
+	for w := range 8 {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			for i := range 100 {
+				id := fmt.Sprintf("k%d", (w*100+i)%20)
+				if _, ok := c.Get(id); !ok {
+					_ = c.Put(id, make([]byte, 1024))
+				}
+				_ = c.Stats()
+			}
+		}()
+	}
+	for range 8 {
+		<-done
+	}
+	s := c.Stats()
+	if s.Hits+s.Misses == 0 {
+		t.Error("expected the concurrent workers to have recorded requests")
+	}
+}


### PR DESCRIPTION
## Why

The import-scoped segment cache shipped in #888 without any way to tell whether it earns the memory it reserves. Its hit rate was inferred from how archive analysis was *believed* to read — never measured. It reserves up to 32 MiB per instance, with up to four instances live concurrently (the nested-RAR pass runs inside the outer one, at `max_processor_workers` 2), so that assumption is worth up to 128 MiB.

This adds the counters to answer it from a real import instead of from a model.

## What

`ImportSegmentCache` gains hits / misses / evictions counters and a `Stats()` snapshot that also reports current entries and bytes. `HitRate()` computes the ratio callers actually want, including the zero-request case.

Each of the five analysis passes reports once when it finishes:

```
INFO Import segment cache pass=rar-header hit_rate=0.42 hits=118 misses=163 evictions=0 entries=170 bytes=33150000
```

Info rather than debug on purpose: the whole reason the counters exist is to be read off a real run. It is one line per analysis pass, not per segment, and a pass that never touched the cache logs nothing.

## The ISO site needed different handling

`NewISOReadSeeker` is a constructor that hands back an `io.Closer`, and the cache lives as long as the reader. A `defer` there fires before a single sector has been read — it would have reported all zeros and looked like evidence that the cache does nothing for ISO. The report moves into the Closer. The other four sites are ordinary function scopes where `defer` is correct.

## Test plan

- [x] `go build ./...`, `go vet ./...` — both exit 0
- [x] `go test ./internal/... -count=1` — green
- [x] `go test ./internal/importer/filesystem/ -race` — green
- [x] Tests written first and confirmed red (counters undefined) before implementing
- [x] Counters: hit/miss/eviction accounting, `HitRate()` including divide-by-zero, and concurrent access under `-race`

## What this does not do

It does not change caching behaviour — only observes it. The decision this enables (keep the cache, shrink it, or drop it) waits on real numbers.
