### PR TITLE
fix(usenet): panic in segmentRange.GetSegment during concurrent read/cleanup

### DIFF
--- a/internal/usenet/segment.go
+++ b/internal/usenet/segment.go
@@ -82,6 +82,12 @@ func (r *segmentRange) GetSegment(index int) (*segment, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Re-check bounds: a concurrent Clear() may have nil-ed the slice
+	// between releasing the read lock and acquiring the write lock.
+	if index >= len(r.segments) {
+		return nil, ErrSegmentLimit
+	}
+
 	// Double-check after acquiring write lock.
 	if r.segments[index] != nil {
 		return r.segments[index], nil

--- a/internal/usenet/segment_test.go
+++ b/internal/usenet/segment_test.go
@@ -1,6 +1,7 @@
 package usenet
 
 import (
+	"context"
 	"errors"
 	"io"
 	"sync"
@@ -448,6 +449,44 @@ func TestSegmentRangeClear_ConcurrentSafety(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+// TestSegmentRange_GetSegment_ConcurrentClear reproduces issue #870: GetSegment
+// validated the index under RLock, then re-acquired the write lock for lazy
+// creation and indexed r.segments without re-checking bounds. A concurrent
+// Clear() nil-ing the slice in that window panicked with index out of range.
+func TestSegmentRange_GetSegment_ConcurrentClear(t *testing.T) {
+	t.Parallel()
+
+	loader := &mockLoader{
+		segments: []Segment{{Id: "seg", Start: 0, End: 99, Size: 100}},
+		groups:   [][]string{nil},
+	}
+
+	for range 20000 {
+		sr := &segmentRange{
+			start:    0,
+			end:      99,
+			segments: make([]*segment, 1),
+			ctx:      context.Background(),
+			loader:   loader,
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			seg, err := sr.GetSegment(0)
+			if err == nil && seg == nil {
+				t.Error("GetSegment returned nil segment without error")
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			_ = sr.Clear()
+		}()
+		wg.Wait()
+	}
 }
 
 // BenchmarkClear benchmarks the Clear operation


### PR DESCRIPTION
## Summary

Fixes #870.

`segmentRange.GetSegment` validated `index` under a read lock, released it, then re-acquired the write lock for lazy segment creation and dereferenced `r.segments[index]` without re-checking bounds. A concurrent `Clear()` (called from `UsenetReader` buffer cleanup) sets `r.segments = nil` in that window, producing the observed `index out of range [0] with length 0` panic that crashed the FUSE mount (`Transport endpoint is not connected`).

## Fix

Re-validate bounds after acquiring the write lock; return `ErrSegmentLimit` (same as the pre-lock path) when the slice was cleared concurrently.

## Test plan

- [x] New regression test `TestSegmentRange_GetSegment_ConcurrentClear` — 20k iterations of concurrent `GetSegment`/`Clear`; reproduced the exact production panic at `segment.go:86` before the fix, passes after
- [x] `go test -race ./internal/usenet/` passes
- [x] `go vet ./internal/usenet/` clean