### PR TITLE
feat(pool): TLS session resumption, warm connections and reconnect for providers

### DIFF
--- a/bench/results/phase1-conn-hygiene.json
+++ b/bench/results/phase1-conn-hygiene.json
@@ -1,0 +1,258 @@
+{
+  "git_sha": "dceff0ed",
+  "timestamp": "2026-09-04T11:42:23.505104Z",
+  "scenarios": [
+    {
+      "name": "B1-cold-open/premium-750k",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 146.044164,
+          "higher_is_better": false
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 137.619667,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 201.887834,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 60.5,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B1-cold-open/slow-4m",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 3809.481175,
+          "higher_is_better": false
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 2880.618084,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 8316.269917,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 90.35,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/premium-750k",
+      "metrics": [
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 223.10830304521917,
+          "higher_is_better": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 1.2387559604644776,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/slow-4m",
+      "metrics": [
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 34.97516242075892,
+          "higher_is_better": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 2.2141357851028443,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/premium-750k",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 143.936208,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 156.180334,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1.05,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/slow-4m",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 1597.042,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 1658.215584,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/premium-750k",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/slow-4m",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B4-four-streams/premium-750k",
+      "metrics": [
+        {
+          "name": "min_stream_mbps",
+          "unit": "MB/s",
+          "value": 72.73328753211541,
+          "higher_is_better": true
+        },
+        {
+          "name": "max_stream_mbps",
+          "unit": "MB/s",
+          "value": 91.31678574005694,
+          "higher_is_better": true
+        },
+        {
+          "name": "stall_p99",
+          "unit": "ms",
+          "value": 181.414958,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B5-two-handles/premium-750k",
+      "metrics": [
+        {
+          "name": "duplicate_bodies",
+          "unit": "count",
+          "value": 127,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B6-contention/premium-750k",
+      "metrics": [
+        {
+          "name": "stream_p50",
+          "unit": "ms",
+          "value": 0.027042,
+          "higher_is_better": false
+        },
+        {
+          "name": "stream_p99",
+          "unit": "ms",
+          "value": 88.00575,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "import_mbps",
+          "unit": "MB/s",
+          "value": 140.34912595195084,
+          "higher_is_better": true
+        }
+      ]
+    },
+    {
+      "name": "B7-failover/premium-750k",
+      "metrics": [
+        {
+          "name": "miss_ttfb_mean",
+          "unit": "ms",
+          "value": 168.34991,
+          "higher_is_better": false
+        },
+        {
+          "name": "miss_ttfb_p50",
+          "unit": "ms",
+          "value": 158.799208,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "bodies_per_miss",
+          "unit": "count",
+          "value": 1,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    }
+  ]
+}

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -288,6 +288,7 @@ providers:
     username: 'your_username' # Replace with your username
     password: 'your_password' # Replace with your password
     max_connections: 20
+    min_connections_alive: 2 # Warm connections kept open for fast first byte (default: 2, -1 = connect on demand only)
     inflight_requests: 10 # Concurrent bodies per connection (memory ceiling, default: 10); typical depth 3-4, raising does not improve throughput
     stat_inflight_requests: 100 # STAT pipeline depth per connection (determines idle health-sweep concurrency, default: 100)
     tls: true

--- a/frontend/src/components/config/ProvidersConfigSection.tsx
+++ b/frontend/src/components/config/ProvidersConfigSection.tsx
@@ -558,7 +558,7 @@ export function ProvidersConfigSection({
 						<div className="flex min-w-0 items-center gap-3">
 							<div
 								className="tooltip min-w-[88px] text-left"
-								data-tip="Connections kept dialed and open at all times. 0 = disabled (connect on demand)."
+								data-tip="Connections kept dialed and open at all times. 0 = default (2), -1 = connect on demand only."
 							>
 								<span className="font-black text-[10px] text-base-content/50 uppercase tracking-widest">
 									Min Alive
@@ -575,7 +575,7 @@ export function ProvidersConfigSection({
 										Number.parseInt(e.target.value, 10) || 0,
 									)
 								}
-								min={0}
+								min={-1}
 								max={provider.max_connections}
 							/>
 						</div>

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -29,6 +29,19 @@ const DefaultCategoryDir = "complete"
 type MountType string
 
 const (
+	// defaultMinConnectionsAlive keeps a couple of sockets warm so a stream
+	// started after an idle period does not pay TCP + TLS + AUTHINFO first.
+	// A negative min_connections_alive opts out entirely.
+	defaultMinConnectionsAlive = 2
+	// providerIdleTimeout stays under the idle cut most providers apply while
+	// keeping warm connections through short pauses.
+	providerIdleTimeout = 2 * time.Minute
+	// providerReconnectDelay lets a provider dropped after a 502 rejoin the
+	// pool instead of staying out until restart.
+	providerReconnectDelay = 30 * time.Second
+)
+
+const (
 	MountTypeNone           MountType = "none"
 	MountTypeRClone         MountType = "rclone"
 	MountTypeFuse           MountType = "fuse"
@@ -1402,7 +1415,21 @@ func (p *ProviderConfig) ToNNTPProvider() nntppool.Provider {
 		tlsCfg = &tls.Config{
 			InsecureSkipVerify: p.InsecureTLS,
 			ServerName:         p.Host,
+			// One cached session per connection the allowance permits, so every
+			// reconnect after the first is a resumption handshake.
+			ClientSessionCache: tls.NewLRUClientSessionCache(max(p.MaxConnections, 1)),
 		}
+	}
+
+	minConns := p.MinConnectionsAlive
+	switch {
+	case minConns < 0:
+		minConns = 0
+	case minConns == 0:
+		minConns = defaultMinConnectionsAlive
+	}
+	if minConns > p.MaxConnections {
+		minConns = p.MaxConnections
 	}
 
 	inflight := p.InflightRequests
@@ -1420,12 +1447,13 @@ func (p *ProviderConfig) ToNNTPProvider() nntppool.Provider {
 		TLSConfig:         tlsCfg,
 		Auth:              nntppool.Auth{Username: p.Username, Password: p.Password},
 		Connections:       p.MaxConnections,
-		MinConnections:    p.MinConnectionsAlive,
+		MinConnections:    minConns,
 		Backup:            isBackup,
 		StorageGroup:      p.StorageGroup,
 		Inflight:          inflight,
 		StatInflight:      statInflight,
-		IdleTimeout:       60 * time.Second,
+		IdleTimeout:       providerIdleTimeout,
+		ReconnectDelay:    providerReconnectDelay,
 		SkipPing:          p.SkipPing,
 		KeepaliveInterval: time.Duration(p.KeepaliveIntervalSeconds) * time.Second,
 		KeepaliveCommand:  p.KeepaliveCommand,

--- a/internal/config/provider_nntp_test.go
+++ b/internal/config/provider_nntp_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func tlsProvider() ProviderConfig {
+	return ProviderConfig{Host: "news.example", Port: 563, TLS: true, MaxConnections: 20}
+}
+
+func TestToNNTPProviderEnablesTLSSessionResumption(t *testing.T) {
+	p := tlsProvider()
+	np := p.ToNNTPProvider()
+	if np.TLSConfig == nil || np.TLSConfig.ClientSessionCache == nil {
+		t.Fatal("TLS providers must carry a session cache so reconnects resume instead of re-handshaking")
+	}
+}
+
+func TestToNNTPProviderIdleTimeoutIsTwoMinutes(t *testing.T) {
+	p := tlsProvider()
+	if got := p.ToNNTPProvider().IdleTimeout; got != 2*time.Minute {
+		t.Fatalf("IdleTimeout = %v, want 2m", got)
+	}
+}
+
+func TestToNNTPProviderDefaultsMinConnectionsToTwo(t *testing.T) {
+	p := tlsProvider()
+	if got := p.ToNNTPProvider().MinConnections; got != 2 {
+		t.Fatalf("MinConnections = %d, want 2 when unset", got)
+	}
+	p.MinConnectionsAlive = 5
+	if got := p.ToNNTPProvider().MinConnections; got != 5 {
+		t.Fatalf("explicit MinConnectionsAlive must win, got %d", got)
+	}
+	p.MinConnectionsAlive = 0
+	p.MaxConnections = 1
+	if got := p.ToNNTPProvider().MinConnections; got != 1 {
+		t.Fatalf("default must be capped at MaxConnections, got %d", got)
+	}
+}
+
+func TestToNNTPProviderSetsReconnectDelay(t *testing.T) {
+	p := tlsProvider()
+	if got := p.ToNNTPProvider().ReconnectDelay; got != 30*time.Second {
+		t.Fatalf("ReconnectDelay = %v, want 30s so a provider removed on 502 comes back", got)
+	}
+}


### PR DESCRIPTION
Stacked on #894.

## Summary
- TLS providers get a `ClientSessionCache` sized to `max_connections`, so reconnects after the idle cut resume the session instead of paying a full handshake.
- Provider idle timeout 60 s → 120 s.
- `min_connections_alive` defaults to 2 (capped at `max_connections`) when left at 0; `-1` opts out. UI tooltip and `config.sample.yaml` updated.
- `ReconnectDelay` 30 s so a provider removed after a mid-session 502 rejoins the pool instead of staying out until restart.

## Live A/B (dev server idle 3 min before each run)

| file | ttfb main | ttfb this PR | seek p50 main | seek p50 this PR | MB/s main | MB/s this PR |
|---|---|---|---|---|---|---|
| Supergirl S04E21 1080p | 586 ms | 274 ms | 67 | 67 | 52.0 | 52.0 |
| Avatar Fire and Ash 1080p | 144 ms | 105 ms | 306 | 342 | 118.8 | 125.1 |
| The Penguin S01E08 2160p remux | 66 ms | 67 ms | 122 | 103 | 151.9 | 120.7 |

First-byte after idle drops by roughly one TLS handshake plus AUTHINFO on the files that had to dial. Throughput differences are single 60 s samples against a live provider.

## Simulated benchmark
`make bench-compare BASE=baseline-main`: no regressions. The harness builds `nntppool.Provider` directly, so this change is not on its path; the run doubles as a same-code noise calibration and stays inside every tolerance.

## Test plan
- [x] `TestToNNTPProvider*` (session cache, idle timeout, min connections default/cap/opt-out, reconnect delay)
- [x] `go test -race ./internal/config/ ./internal/pool/`
- [x] `bun run check`
- [x] live A/B above