### PR TITLE
feat(usenet): pool-wide speculative read-ahead budget

### DIFF
--- a/bench/results/phase3-shared-readahead-budget.json
+++ b/bench/results/phase3-shared-readahead-budget.json
@@ -1,0 +1,270 @@
+{
+  "git_sha": "c35c1fe0",
+  "timestamp": "2026-09-04T12:52:37.173097Z",
+  "scenarios": [
+    {
+      "name": "B1-cold-open/premium-750k",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 46.000375,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 42.970375,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 53.442083,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 60.1,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B1-cold-open/slow-4m",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 3627.18916,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 3808.288167,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 7518.002666,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 60,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/premium-750k",
+      "metrics": [
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 211.47568400562284,
+          "higher_is_better": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 1.235035972595215,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/slow-4m",
+      "metrics": [
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 35.48337580238343,
+          "higher_is_better": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 2.2750753021240233,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/premium-750k",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 154.647291,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 166.73625,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1.05,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/slow-4m",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 1648.819916,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 1671.380125,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/premium-750k",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/slow-4m",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B4-four-streams/premium-750k",
+      "metrics": [
+        {
+          "name": "min_stream_mbps",
+          "unit": "MB/s",
+          "value": 72.50120957936761,
+          "higher_is_better": true,
+          "tolerance": 0.12
+        },
+        {
+          "name": "max_stream_mbps",
+          "unit": "MB/s",
+          "value": 91.07804067454218,
+          "higher_is_better": true
+        },
+        {
+          "name": "stall_p99",
+          "unit": "ms",
+          "value": 131.452792,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B5-two-handles/premium-750k",
+      "metrics": [
+        {
+          "name": "duplicate_bodies",
+          "unit": "count",
+          "value": 127,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B6-contention/premium-750k",
+      "metrics": [
+        {
+          "name": "stream_mbps",
+          "unit": "MB/s",
+          "value": 161.06739361750317,
+          "higher_is_better": true,
+          "tolerance": 0.1
+        },
+        {
+          "name": "stream_p50",
+          "unit": "ms",
+          "value": 0.036625,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "stream_p99",
+          "unit": "ms",
+          "value": 59.16925,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "import_mbps",
+          "unit": "MB/s",
+          "value": 139.00337252024266,
+          "higher_is_better": true
+        }
+      ]
+    },
+    {
+      "name": "B7-failover/premium-750k",
+      "metrics": [
+        {
+          "name": "miss_ttfb_mean",
+          "unit": "ms",
+          "value": 165.583593,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "miss_ttfb_p50",
+          "unit": "ms",
+          "value": 159.296666,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "bodies_per_miss",
+          "unit": "count",
+          "value": 1,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-09-04-streaming-seek-ramp.md
+++ b/docs/superpowers/plans/2026-09-04-streaming-seek-ramp.md
@@ -1,0 +1,66 @@
+# Seek Ramp and Buffered Forward-Skip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop a fresh reader from firing its whole prefetch window before the caller has shown streaming intent, and stop a forward jump from draining articles through the pipeline when a new reader would be cheaper (spec phase 4, defect D5, plus the B7 finding from phase 0).
+
+**Architecture:** `UsenetReader` grows its window as `rampBase << (2 × consumed)` up to `maxPrefetch`, where `consumed` is segments fully read since the reader was created (every seek creates a reader, so the anchor is creation). A range hint of at least 128 MiB (WebDAV open-ended or large ranges) skips the ramp. `MetadataVirtualFile` only drains a forward gap through the shared reader when the gap fits inside what that reader has already scheduled (`BufferedAhead`); otherwise it reopens at the target.
+
+**Spec:** `docs/superpowers/specs/2026-09-04-streaming-demand-shaping-design.md` (Phase 4)
+
+## Global Constraints
+
+- No competitor names in code, comments, commits, PRs.
+- Conventional Commits; branch `feat/streaming-seek-ramp` from `feat/streaming-shared-readahead-budget`.
+- `make bench-compare BASE=baseline-main`: no regressions; B2 throughput must hold (the ramp completes within the first three articles).
+
+---
+
+### Task 1: B9 forward-skip scenario (pre-sample before the change)
+
+**Files:** `internal/nzbfilesystem/stream_bench_test.go`
+
+Add `BenchmarkStreamForwardSkip` (premium profile): open, read 2 MB from 0, then read 2 MB at +100 MB, then 2 MB at +2 MB from there. Metrics: `jump_read_ms` (latency of the +100 MB read, gated, tolerance 0.10), `articles` (bodies fetched by the whole scenario, gated), `open_articles` (bodies fetched before the jump, info). Run it once on this branch before Tasks 2-4 and keep the numbers for the PR.
+
+- [ ] Add, `gofmt`, commit `test(bench): forward-skip scenario`, sample: `go test ./internal/nzbfilesystem/ -run '^$' -bench BenchmarkStreamForwardSkip -benchtime 1x`.
+
+### Task 2: Ramp in `UsenetReader`
+
+**Files:** `internal/usenet/usenet_reader.go`, `internal/usenet/usenet_reader_ramp_test.go`
+
+**Interfaces:**
+```go
+const (
+	rampBaseSegments     = 2
+	streamingIntentBytes = 128 << 20
+)
+// WithRangeHint tells the reader how many bytes the caller asked for. At or
+// above streamingIntentBytes the read-ahead window opens fully at once;
+// below it (or unknown, 0) the window ramps from rampBaseSegments,
+// quadrupling per consumed segment, so a probe that reads a couple of MB
+// and leaves does not drag a whole window behind it.
+func WithRangeHint(bytes int64) ReaderOption
+// BufferedAhead reports bytes scheduled for fetch beyond what the caller has
+// read: the distance a forward skip can cover without a new reader.
+func (b *UsenetReader) BufferedAhead() int64
+```
+Window: `func (b *UsenetReader) windowFor(consumed int) int` returns `maxPrefetch` when `!b.ramp`, else `min(maxPrefetch, rampBaseSegments << (2*consumed))` guarding overflow (`consumed >= 16` → `maxPrefetch`). In `downloadManager` replace `if ahead >= b.maxPrefetch` with `if ahead >= b.windowFor(currentRead)`. Ramp applies to streaming readers only (`priority == true`). `BufferedAhead` = `scheduledBytes - totalBytesRead`, where `scheduledBytes` accumulates `seg.End-seg.Start+1` under `b.mu` when a segment is scheduled.
+
+- [ ] Tests: (a) fresh reader, 40 segments, segment 0 gated: after a settle, `BodyPriorityCalls <= rampBaseSegments`; release and read all: `MaxInFlight > rampBaseSegments` eventually and every byte correct. (b) `WithRangeHint(200 << 20)`: with 30 ms latency per segment, `MaxInFlight == maxPrefetch` within the read. (c) import reader (`WithImportProfile`) is unaffected: max in flight equals maxPrefetch on the first segments. (d) `BufferedAhead` after `Start()` with segment 0 gated equals the scheduled segments' bytes and drops as bytes are read.
+- [ ] Implement; `go test -race ./internal/usenet/`; commit `feat(usenet): ramp read-ahead after open or seek; report buffered bytes`.
+
+### Task 3: Range hint and buffered forward-skip in `MetadataVirtualFile`
+
+**Files:** `internal/nzbfilesystem/metadata_remote_file.go` (`createUsenetReader`, the forward-skip block around line 1265, `bufOffReader` sibling assertion), `internal/nzbfilesystem/forward_skip_test.go`
+
+- Hint: in `createUsenetReader(ctx, start, end)`, `hint := int64(0)`; if the context carries `utils.RangeKey` (WebDAV) then `hint = end - start + 1` with `end == -1` meaning `FileSize - start`. FUSE passes no range and ramps (its read-ahead buffer promotes after three sequential reads anyway).
+- Forward skip: keep `forwardSkipLimit` as the outer bound, but when the reader exposes `BufferedAhead()` and `gap > buffered`, do not drain: `closeCurrentReader()`, `mvf.position = off`, `mvf.readAtSharedNext = off`, then continue into the shared path (`ensureReader` opens at the cursor). Add `bufAheadReader interface{ BufferedAhead() int64 }` next to `bufOffReader`.
+
+- [ ] Tests: (a) 200 segments × 64 KiB, `maxPrefetch` 4, WebDAV-less ctx: `ReadAt(64 KiB @0)`, then `ReadAt(64 KiB @ 40 segments)`: `BodyPriorityCalls <= 12` (not ≥ 44) and both reads return exact bytes. (b) small skip inside the buffered window (`maxPrefetch` 10, jump 2 segments): the shared reader pointer is unchanged and bytes are exact. (c) ctx with `utils.RangeKey = "bytes=0-"` on a 300 MB synthetic file: first read schedules more than `rampBaseSegments` fetches (hint skips the ramp).
+- [ ] Implement; `go test -race ./internal/nzbfilesystem/`; commit `feat(nzbfilesystem): range-aware ramp and buffered forward-skip`.
+
+### Task 4: Benchmark, live A/B, PR
+
+- [ ] `make bench-stream && make bench-compare BASE=baseline-main`. Expect B9 `articles` and `jump_read_ms` well below the Task 1 sample, B1 `articles` (info) down to a handful on both profiles, B2 unchanged.
+- [ ] `bench-live.sh seek-ramp`.
+- [ ] Push; `gh pr create --base feat/streaming-shared-readahead-budget`.

--- a/internal/api/provider_speedtest_storm_test.go
+++ b/internal/api/provider_speedtest_storm_test.go
@@ -141,4 +141,5 @@ func TestStorm_SpeedTestBypassesPoolManager(t *testing.T) {
 	}
 }
 
-func (m *countingPoolManager) SetStreamHeadroom(int) {}
+func (m *countingPoolManager) SetStreamHeadroom(int)                      {}
+func (m *countingPoolManager) SpeculativeBudget() *pool.SpeculativeBudget { return nil }

--- a/internal/health/repair_e2e_test.go
+++ b/internal/health/repair_e2e_test.go
@@ -76,7 +76,8 @@ type mockARRsService struct {
 	returnErr error
 }
 
-func (m *mockPoolManager) SetStreamHeadroom(int) {}
+func (m *mockPoolManager) SetStreamHeadroom(int)                      {}
+func (m *mockPoolManager) SpeculativeBudget() *pool.SpeculativeBudget { return nil }
 
 type triggerCall struct {
 	pathForRescan string

--- a/internal/importer/filesystem/warm_cache_test.go
+++ b/internal/importer/filesystem/warm_cache_test.go
@@ -106,7 +106,8 @@ func TestWarmCacheServesPrefixWithoutNetwork(t *testing.T) {
 	}
 }
 
-func (m *fsFakePoolManager) SetStreamHeadroom(int) {}
+func (m *fsFakePoolManager) SetStreamHeadroom(int)                      {}
+func (m *fsFakePoolManager) SpeculativeBudget() *pool.SpeculativeBudget { return nil }
 
 // stubReadCloser is an in-memory ReadCloser for warmPrefixReader unit tests.
 type stubReadCloser struct {

--- a/internal/importer/parser/parser_storm_test.go
+++ b/internal/importer/parser/parser_storm_test.go
@@ -68,7 +68,8 @@ func (m *fakeFullPoolManager) SetImportConnCapacity(total int) {
 	}
 }
 
-func (m *fakeFullPoolManager) SetStreamHeadroom(int) {}
+func (m *fakeFullPoolManager) SetStreamHeadroom(int)                      {}
+func (m *fakeFullPoolManager) SpeculativeBudget() *pool.SpeculativeBudget { return nil }
 func (m *fakeFullPoolManager) ImportConnCapacity() int {
 	if m.budget != nil {
 		return m.budget.Capacity()

--- a/internal/importer/processor_test.go
+++ b/internal/importer/processor_test.go
@@ -91,7 +91,8 @@ func TestPreParseFastFailSkipsOnlyMissingEpisode(t *testing.T) {
 	}
 }
 
-func (m processorTestPoolManager) SetStreamHeadroom(int) {}
+func (m processorTestPoolManager) SetStreamHeadroom(int)                      {}
+func (m processorTestPoolManager) SpeculativeBudget() *pool.SpeculativeBudget { return nil }
 
 // TestPreParseFastFailDoesNotStatPar2 verifies PAR2 segments are skipped entirely
 // from the fast-fail Stat sweep: an unreachable PAR2 segment must neither be

--- a/internal/importer/validation/fast_fail_test.go
+++ b/internal/importer/validation/fast_fail_test.go
@@ -59,7 +59,8 @@ type scriptedStatClient struct {
 	calls    map[string]int
 }
 
-func (m fastFailPoolManager) SetStreamHeadroom(int) {}
+func (m fastFailPoolManager) SetStreamHeadroom(int)                      {}
+func (m fastFailPoolManager) SpeculativeBudget() *pool.SpeculativeBudget { return nil }
 
 type uncancelableStatClient struct {
 	pool.NntpClient

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -2045,7 +2045,8 @@ func (mvf *MetadataVirtualFile) createUsenetReader(ctx context.Context, start, e
 	// for eligible video files (nil for everything else — reads fail as
 	// always). See holes.go.
 	ur, err := usenet.NewUsenetReader(ctx, mvf.poolManager.GetPool, rg, mvf.maxPrefetch, mvf.streamTracker, mvf.streamID, mvf.segmentStore,
-		usenet.WithHoleHooks(mvf.holeHooks()))
+		usenet.WithHoleHooks(mvf.holeHooks()),
+		usenet.WithSpeculativeBudget(mvf.poolManager.SpeculativeBudget()))
 	if err != nil {
 		return nil, err
 	}
@@ -2173,7 +2174,8 @@ func (mvf *MetadataVirtualFile) createUsenetReaderFromSegments(ctx context.Conte
 		return nil, fmt.Errorf("no segments cover range [%d, %d]", start, end)
 	}
 
-	ur, err := usenet.NewUsenetReader(ctx, mvf.poolManager.GetPool, rg, mvf.maxPrefetch, mvf.streamTracker, mvf.streamID, mvf.segmentStore)
+	ur, err := usenet.NewUsenetReader(ctx, mvf.poolManager.GetPool, rg, mvf.maxPrefetch, mvf.streamTracker, mvf.streamID, mvf.segmentStore,
+		usenet.WithSpeculativeBudget(mvf.poolManager.SpeculativeBudget()))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/nzbfilesystem/metadata_remote_file_test.go
+++ b/internal/nzbfilesystem/metadata_remote_file_test.go
@@ -493,7 +493,8 @@ func TestSeekResetsOriginalRangeEnd(t *testing.T) {
 	}
 }
 
-func (m *mockPoolManager) SetStreamHeadroom(int) {}
+func (m *mockPoolManager) SetStreamHeadroom(int)                      {}
+func (m *mockPoolManager) SpeculativeBudget() *pool.SpeculativeBudget { return nil }
 
 // TestSeekSamePositionDoesNotResetRange tests that seeking to the same position
 // does not reset originalRangeEnd (optimization)

--- a/internal/nzbfilesystem/stream_bench_test.go
+++ b/internal/nzbfilesystem/stream_bench_test.go
@@ -354,7 +354,10 @@ func BenchmarkStreamUnderContention(b *testing.B) {
 		_ = mvf.Close()
 		h.awaitQuietWire(500*time.Millisecond, 30*time.Second)
 		return []streambench.Metric{
-			info(streambench.Metric{Name: "stream_p50", Unit: "ms", Value: ms(lat.P(0.5))}),
+			// Single-stream throughput while an import saturates the normal lane.
+		// Read-ahead must keep its edge over import; 10 % covers run spread.
+		{Name: "stream_mbps", Unit: "MB/s", Value: mbps(off, elapsed), HigherIsBetter: true, Tolerance: 0.10},
+		info(streambench.Metric{Name: "stream_p50", Unit: "ms", Value: ms(lat.P(0.5))}),
 			info(streambench.Metric{Name: "stream_p99", Unit: "ms", Value: ms(lat.P(0.99))}),
 			{Name: "import_mbps", Unit: "MB/s", Value: mbps(importBytes.Load(), elapsed), HigherIsBetter: true},
 		}

--- a/internal/nzbfilesystem/streamtest_helpers_test.go
+++ b/internal/nzbfilesystem/streamtest_helpers_test.go
@@ -98,7 +98,8 @@ func buildSegmentData(t testing.TB, n, segSize int) []*metapb.SegmentData {
 	return out
 }
 
-func (m *fakePoolManager) SetStreamHeadroom(int) {}
+func (m *fakePoolManager) SetStreamHeadroom(int)                      {}
+func (m *fakePoolManager) SpeculativeBudget() *pool.SpeculativeBudget { return nil }
 
 // configurePoolForFile teaches the fakepool how to satisfy every segment
 // of a synthetic file built via buildSegmentData(n, segSize). Each

--- a/internal/pool/config.go
+++ b/internal/pool/config.go
@@ -14,6 +14,7 @@ func RegisterConfigHandlers(ctx context.Context, configManager *config.Manager, 
 	// Initial import connection budget: the pool's total connection capacity.
 	poolManager.SetImportConnCapacity(configManager.GetConfig().TotalProviderConnections())
 	poolManager.SetStreamHeadroom(configManager.GetConfig().GetStreamHeadroomConnections())
+	poolManager.SpeculativeBudget().SetCapacity(configManager.GetConfig().TotalProviderConnections())
 
 	configManager.OnConfigChange(func(oldConfig, newConfig *config.Config) {
 		slog.InfoContext(ctx, "Configuration updated")
@@ -25,6 +26,7 @@ func RegisterConfigHandlers(ctx context.Context, configManager *config.Manager, 
 		if capacity := newConfig.TotalProviderConnections(); capacity != oldConfig.TotalProviderConnections() {
 			slog.InfoContext(ctx, "Import connection budget updated", "capacity", capacity)
 			poolManager.SetImportConnCapacity(capacity)
+			poolManager.SpeculativeBudget().SetCapacity(capacity)
 		}
 
 		if h := newConfig.GetStreamHeadroomConnections(); h != oldConfig.GetStreamHeadroomConnections() {

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -85,6 +85,9 @@ type Manager interface {
 	// SetStreamHeadroom sets how many connections the import budget holds back
 	// per active stream. See config.Config.StreamHeadroomConnections.
 	SetStreamHeadroom(perStream int)
+	// SpeculativeBudget bounds read-ahead fetches across every stream; nil
+	// (as returned by test fakes) means unlimited.
+	SpeculativeBudget() *SpeculativeBudget
 
 	// ImportConnCapacity returns the current budget capacity snapshot,
 	// useful for sizing import worker pools.
@@ -135,16 +138,18 @@ type manager struct {
 	quotaWatchCancel context.CancelFunc
 	admission        *ImportAdmission
 	budget           *ImportBudget
+	specBudget       *SpeculativeBudget
 }
 
 // NewManager creates a new pool manager
 func NewManager(ctx context.Context, repo StatsRepository) Manager {
 	return &manager{
-		ctx:       ctx,
-		repo:      repo,
-		logger:    slog.Default().With("component", "pool"),
-		admission: NewImportAdmission(),
-		budget:    NewImportBudget(),
+		ctx:        ctx,
+		repo:       repo,
+		logger:     slog.Default().With("component", "pool"),
+		admission:  NewImportAdmission(),
+		budget:     NewImportBudget(),
+		specBudget: NewSpeculativeBudget(),
 	}
 }
 
@@ -534,6 +539,11 @@ func (m *manager) SetImportConnCapacity(total int) {
 // SetStreamHeadroom sets the per-stream import connection reservation.
 func (m *manager) SetStreamHeadroom(perStream int) {
 	m.budget.SetHeadroom(perStream)
+}
+
+// SpeculativeBudget returns the pool-wide read-ahead budget.
+func (m *manager) SpeculativeBudget() *SpeculativeBudget {
+	return m.specBudget
 }
 
 // ImportConnCapacity returns the current budget capacity snapshot.

--- a/internal/pool/specbudget.go
+++ b/internal/pool/specbudget.go
@@ -1,0 +1,83 @@
+package pool
+
+import "sync"
+
+// SpeculativeBudget bounds read-ahead fetches across every stream on the
+// pool. Without it each open handle schedules its own full prefetch window,
+// so several players on one title flood the priority lane with speculative
+// bodies and starve each other's demand reads. Demand fetches never take a
+// slot; only fetches ahead of the read position do, and only when one is
+// free right now.
+type SpeculativeBudget struct {
+	mu       sync.Mutex
+	inFlight int
+	capacity int
+}
+
+// speculativeBodiesPerConn is how many speculative bodies a connection is
+// worth: the depth at which pipelining stops paying off.
+const speculativeBodiesPerConn = 3
+
+func NewSpeculativeBudget() *SpeculativeBudget { return &SpeculativeBudget{} }
+
+// SetCapacity derives the slot count from total provider connections: three
+// bodies per connection, minus one so a demand read never finds every slot
+// taken by read-ahead. Zero or negative disables the budget (unlimited).
+func (b *SpeculativeBudget) SetCapacity(totalConns int) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if totalConns <= 0 {
+		b.capacity = 0
+		return
+	}
+	b.capacity = max(totalConns*speculativeBodiesPerConn-1, 1)
+}
+
+// Capacity returns the current slot count; 0 means unlimited.
+func (b *SpeculativeBudget) Capacity() int {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.capacity
+}
+
+// InFlight returns how many speculative fetches currently hold a slot.
+func (b *SpeculativeBudget) InFlight() int {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.inFlight
+}
+
+// TryAcquire never blocks. ok=false means the caller should skip this fetch
+// for now and try again when its reader advances. release must be called
+// exactly once when ok is true; extra calls are ignored.
+func (b *SpeculativeBudget) TryAcquire() (release func(), ok bool) {
+	if b == nil {
+		return func() {}, true
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.capacity == 0 {
+		return func() {}, true
+	}
+	if b.inFlight >= b.capacity {
+		return nil, false
+	}
+	b.inFlight++
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			b.mu.Lock()
+			b.inFlight--
+			b.mu.Unlock()
+		})
+	}, true
+}

--- a/internal/pool/specbudget_test.go
+++ b/internal/pool/specbudget_test.go
@@ -1,0 +1,55 @@
+package pool
+
+import "testing"
+
+func TestSpeculativeBudgetCapacityFormula(t *testing.T) {
+	b := NewSpeculativeBudget()
+	b.SetCapacity(50)
+	if got := b.Capacity(); got != 149 {
+		t.Fatalf("Capacity(50 conns) = %d, want 149", got)
+	}
+	b.SetCapacity(0)
+	if got := b.Capacity(); got != 0 {
+		t.Fatalf("Capacity(0) = %d, want 0 (unlimited)", got)
+	}
+	for i := 0; i < 1000; i++ {
+		if _, ok := b.TryAcquire(); !ok {
+			t.Fatal("unlimited budget must always grant")
+		}
+	}
+	if b.InFlight() != 0 {
+		t.Fatal("unlimited budget must not account")
+	}
+}
+
+func TestSpeculativeBudgetBoundsAndReleases(t *testing.T) {
+	b := NewSpeculativeBudget()
+	b.SetCapacity(1) // 1*3-1 = 2 slots
+	r1, ok1 := b.TryAcquire()
+	r2, ok2 := b.TryAcquire()
+	if !ok1 || !ok2 {
+		t.Fatal("two slots expected")
+	}
+	if _, ok := b.TryAcquire(); ok {
+		t.Fatal("third acquire must be refused")
+	}
+	r1()
+	r1() // idempotent
+	if b.InFlight() != 1 {
+		t.Fatalf("InFlight after one release = %d, want 1", b.InFlight())
+	}
+	if _, ok := b.TryAcquire(); !ok {
+		t.Fatal("slot must be reusable after release")
+	}
+	r2()
+}
+
+func TestSpeculativeBudgetNilIsUnlimited(t *testing.T) {
+	var b *SpeculativeBudget
+	release, ok := b.TryAcquire()
+	if !ok {
+		t.Fatal("nil budget must grant")
+	}
+	release()
+	b.SetCapacity(10)
+}

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -103,6 +103,26 @@ func WithHoleHooks(h *HoleHooks) ReaderOption {
 	}
 }
 
+// SpecBudget grants non-blocking read-ahead slots shared across every stream
+// on the pool. nil means unlimited. Implemented by *pool.SpeculativeBudget.
+type SpecBudget interface {
+	TryAcquire() (release func(), ok bool)
+}
+
+// demandDepth is how many segments at and just past the read position are
+// fetched unconditionally. Everything further ahead is speculative and must
+// find a free slot in the shared budget.
+const demandDepth = 2
+
+// WithSpeculativeBudget bounds this reader's read-ahead by a budget shared
+// with every other stream, so several handles cannot each open a full
+// window. Demand fetches never take a slot.
+func WithSpeculativeBudget(b SpecBudget) ReaderOption {
+	return func(r *UsenetReader) {
+		r.specBudget = b
+	}
+}
+
 // ConnBudget grants connection tokens for import segment fetches.
 // Implemented by pool.Manager (AcquireImportConnection).
 type ConnBudget interface {
@@ -178,6 +198,7 @@ type UsenetReader struct {
 	holeHooks      *HoleHooks   // optional, nil = missing segments fail the read
 	priority       bool         // true (streaming) = priority lane; false (import) = normal lane
 	budget         ConnBudget   // optional; gates import fetches on the global connection budget
+	specBudget     SpecBudget   // optional; bounds speculative fetches pool-wide (streaming only)
 	cond           *sync.Cond   // Signals downloadManager when reader advances
 
 	// Prefetch-based download tracking
@@ -672,6 +693,25 @@ func (b *UsenetReader) downloadManager(ctx context.Context) {
 			continue
 		}
 
+		// Segments beyond the demand depth are speculative: they run only
+		// when the pool-wide budget has a free slot right now. A refused slot
+		// parks the manager until the reader advances or a fetch completes,
+		// both of which signal cond, and the segment is reconsidered then —
+		// by which time it may have moved into the demand window.
+		releaseSlot := func() {}
+		if ahead >= demandDepth && b.priority && b.specBudget != nil {
+			release, ok := b.specBudget.TryAcquire()
+			if !ok {
+				b.cond.Wait()
+				b.mu.Unlock()
+				if ctx.Err() != nil {
+					return
+				}
+				continue
+			}
+			releaseSlot = release
+		}
+
 		// Schedule next segment for download
 		idx := b.nextToDownload
 		b.nextToDownload++
@@ -679,6 +719,7 @@ func (b *UsenetReader) downloadManager(ctx context.Context) {
 
 		seg, err := b.rg.GetSegment(idx)
 		if err != nil || seg == nil {
+			releaseSlot()
 			continue
 		}
 
@@ -686,6 +727,7 @@ func (b *UsenetReader) downloadManager(ctx context.Context) {
 		go func(segIdx int, s *segment) {
 			defer b.inFlight.Add(-1)
 			defer b.cond.Signal()
+			defer releaseSlot()
 			defer func() {
 				if p := recover(); p != nil {
 					b.log.ErrorContext(ctx, "Panic in download task:", "panic", p)

--- a/internal/usenet/usenet_reader_budget_test.go
+++ b/internal/usenet/usenet_reader_budget_test.go
@@ -1,0 +1,152 @@
+package usenet
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/pool"
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/altmount/internal/testsupport/segments"
+)
+
+// countingSpecBudget is a SpecBudget with a fixed capacity that records the
+// high-water mark of concurrently held slots.
+type countingSpecBudget struct {
+	mu       sync.Mutex
+	cap      int
+	held     int
+	maxHeld  int
+	refused  atomic.Int64
+	acquired atomic.Int64
+}
+
+func (b *countingSpecBudget) TryAcquire() (func(), bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.held >= b.cap {
+		b.refused.Add(1)
+		return nil, false
+	}
+	b.held++
+	b.acquired.Add(1)
+	if b.held > b.maxHeld {
+		b.maxHeld = b.held
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			b.mu.Lock()
+			b.held--
+			b.mu.Unlock()
+		})
+	}, true
+}
+
+func (b *countingSpecBudget) max() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.maxHeld
+}
+
+func newBudgetReader(t *testing.T, ctx context.Context, fp *fakepool.Client, rg *segmentRange, maxPrefetch int, budget SpecBudget) *UsenetReader {
+	t.Helper()
+	getter := func() (pool.NntpClient, error) { return fp, nil }
+	ur, err := NewUsenetReader(ctx, getter, rg, maxPrefetch, noopMetrics{}, "budget-test", nil, WithSpeculativeBudget(budget))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ur.Close() })
+	return ur
+}
+
+// Speculative fetches never exceed the budget, while the demand segments at
+// the read position start regardless.
+func TestSpeculativeFetchesRespectBudget(t *testing.T) {
+	ctx := context.Background()
+	const nSegs, segSize, maxPrefetch = 20, 256, 12
+	fp := fakepool.New()
+	for i := 0; i < nSegs; i++ {
+		fp.SetBehavior(segments.MessageID(i), fakepool.SegmentBehavior{Bytes: segments.Payload(i, segSize), Latency: 20 * time.Millisecond})
+	}
+	budget := &countingSpecBudget{cap: 3}
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+	ur := newBudgetReader(t, ctx, fp, rg, maxPrefetch, budget)
+	ur.Start()
+
+	got, err := io.ReadAll(ur)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != nSegs*segSize {
+		t.Fatalf("read %d bytes, want %d", len(got), nSegs*segSize)
+	}
+	if budget.max() > 3 {
+		t.Fatalf("speculative in flight reached %d, budget is 3", budget.max())
+	}
+	if budget.acquired.Load() == 0 {
+		t.Fatal("speculative fetches must take budget slots")
+	}
+	// Demand fetches (demandDepth per position) are outside the budget, so at
+	// most demandDepth + cap fetches overlap.
+	fakepool.AssertMaxInFlightLE(t, fp, int32(demandDepth+3))
+}
+
+// With the budget fully held elsewhere, a sequential read still completes
+// through demand fetches alone.
+func TestExhaustedBudgetNeverBlocksDemandReads(t *testing.T) {
+	ctx := context.Background()
+	const nSegs, segSize = 8, 128
+	fp := fakepool.New()
+	for i := 0; i < nSegs; i++ {
+		fp.SetBehavior(segments.MessageID(i), fakepool.SegmentBehavior{Bytes: segments.Payload(i, segSize)})
+	}
+	budget := &countingSpecBudget{cap: 0}
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+	ur := newBudgetReader(t, ctx, fp, rg, 6, budget)
+	ur.Start()
+
+	done := make(chan error, 1)
+	go func() {
+		got, err := io.ReadAll(ur)
+		if err == nil && len(got) != nSegs*segSize {
+			err = io.ErrUnexpectedEOF
+		}
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("read stalled with the speculative budget exhausted")
+	}
+	if budget.acquired.Load() != 0 {
+		t.Fatal("no slot was available, nothing may have been acquired")
+	}
+}
+
+// No budget means the previous behaviour: every segment fetched on the
+// priority lane up to maxPrefetch ahead.
+func TestNilBudgetKeepsFullWindow(t *testing.T) {
+	ctx := context.Background()
+	const nSegs, segSize, maxPrefetch = 10, 64, 4
+	fp := fakepool.New()
+	for i := 0; i < nSegs; i++ {
+		fp.SetBehavior(segments.MessageID(i), fakepool.SegmentBehavior{Bytes: segments.Payload(i, segSize), Latency: 10 * time.Millisecond})
+	}
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+	ur := newBudgetReader(t, ctx, fp, rg, maxPrefetch, nil)
+	ur.Start()
+	if _, err := io.ReadAll(ur); err != nil {
+		t.Fatal(err)
+	}
+	if fp.BodyPriorityCalls() != nSegs {
+		t.Fatalf("priority calls = %d, want %d", fp.BodyPriorityCalls(), nSegs)
+	}
+	fakepool.AssertMaxInFlightLE(t, fp, int32(maxPrefetch))
+}

--- a/internal/usenet/validation_test.go
+++ b/internal/usenet/validation_test.go
@@ -162,7 +162,8 @@ func TestValidateSegmentAvailability_TransientErrorsAreInconclusive(t *testing.T
 	}
 }
 
-func (m *validationTestPoolManager) SetStreamHeadroom(int) {}
+func (m *validationTestPoolManager) SetStreamHeadroom(int)                      {}
+func (m *validationTestPoolManager) SpeculativeBudget() *pool.SpeculativeBudget { return nil }
 
 // TestValidateSegmentAvailability_ArticleNotFoundIsMissing keeps the genuine
 // miss path intact: only 430/423 proves the article is gone.


### PR DESCRIPTION
Stacked on #896 → #895 → #894.

## Summary
- `pool.SpeculativeBudget`: a non-blocking, pool-wide slot count for read-ahead fetches, sized as three bodies per provider connection minus one (149 slots for 50 connections; unlimited when capacity is unset). Owned by `pool.Manager`, kept in sync with provider capacity next to the import budget.
- `UsenetReader` classifies each scheduled segment: the segment at the read position and the next one are **demand** and always fetch; everything further ahead is **speculative** and fetches only when a budget slot is free right now. A refused slot parks the download manager until the reader advances or a fetch completes, and the segment is reconsidered (by then it may be demand).
- Streaming fetches all stay on the priority lane. The spec suggested moving speculative fetches to the normal lane; I did not, because a saturating import would then take bandwidth from a stream's read-ahead that today it cannot touch. B6 gains a gated single-stream-throughput-under-import metric to keep that property measured (161 MB/s before and after this change).
- `WithSpeculativeBudget(nil)` and the nil budget returned by test fakes behave exactly as before.

## Simulated benchmark vs baseline (`make bench-compare BASE=baseline-main`, medians of 3)

| Scenario | Metric | base | this PR |
|---|---|---|---|
| B1 cold open, premium-750k | ttfb mean (ms) | 146 | 46 |
| B1 cold open, slow-4m | ttfb mean (ms) | 3907 | 3627 |
| B2 sequential, premium-750k | MB/s | 219 | 211 (same-code spread is 209-223) |
| B2 sequential, slow-4m | MB/s | 35.2 | 35.5 |
| B4 four streams | min stream MB/s | 77.7 | 72.5 (inside tolerance; bimodal 72/78 across same-code runs) |
| B4 four streams | stall p99 (ms) | 181 | 131 |
| B6 contention | stream MB/s | 162.5 (sampled pre-change on this branch) | 161.1 |
| B6 contention | import MB/s | 136 | 139 |
| B6 contention | stream p99 (ms) | 94 | 59 |

No REGRESSION rows. B5 duplicate bodies is unchanged by design (that is the flight-dedup PR).

## Live A/B (dev server, real providers)

| file | ttfb #896 | ttfb this PR | seek p50 #896 | seek p50 this PR | MB/s #896 | MB/s this PR |
|---|---|---|---|---|---|---|
| Supergirl S04E21 1080p | 134 | 111 | 63 | 73 | 52.0 | 52.0 |
| Avatar Fire and Ash 1080p | 70 | 67 | 121 | 82 | 115.4 | 119.4 |
| The Penguin S01E08 2160p remux | 87 | 83 | 137 | 104 | 113.2 | 124.7 |

## Test plan
- [x] `SpeculativeBudget` unit tests (capacity formula, bound and release, idempotent release, nil = unlimited)
- [x] reader tests: speculative in-flight never exceeds the budget while demand starts; an exhausted budget never blocks a sequential read; nil budget keeps the previous full window
- [x] `go test -race` on `internal/usenet`, `internal/nzbfilesystem`, `internal/pool`, plus every package with a fake manager
- [x] `make bench-compare` no regressions; live A/B above