### PR TITLE
feat(usenet): first-byte fan-out hold and buffered forward-skip

### DIFF
--- a/bench/results/phase4-seek-ramp.json
+++ b/bench/results/phase4-seek-ramp.json
@@ -1,0 +1,330 @@
+{
+  "git_sha": "4e8888bd",
+  "timestamp": "2026-09-04T13:55:22.729672Z",
+  "scenarios": [
+    {
+      "name": "B1-cold-open/premium-750k",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 45.067158,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 44.890958,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 55.734625,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 60,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B1-cold-open/slow-4m",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 3722.1781,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 3826.356125,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 5071.207292,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 60,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/premium-750k",
+      "metrics": [
+        {
+          "name": "startup_ms",
+          "unit": "ms",
+          "value": 218.947375,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 264.0342168255446,
+          "higher_is_better": true
+        },
+        {
+          "name": "throughput_total",
+          "unit": "MB/s",
+          "value": 218.3633178013325,
+          "higher_is_better": true,
+          "informational": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 1.231315984725952,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/slow-4m",
+      "metrics": [
+        {
+          "name": "startup_ms",
+          "unit": "ms",
+          "value": 1662.072083,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 55.54469090939183,
+          "higher_is_better": true
+        },
+        {
+          "name": "throughput_total",
+          "unit": "MB/s",
+          "value": 42.17401012392385,
+          "higher_is_better": true,
+          "informational": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 1.5167168680826824,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/premium-750k",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 154.450875,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 166.459458,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1.05,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/slow-4m",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 1647.078916,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 1671.670833,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/premium-750k",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/slow-4m",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B4-four-streams/premium-750k",
+      "metrics": [
+        {
+          "name": "min_stream_mbps",
+          "unit": "MB/s",
+          "value": 84.23273424957456,
+          "higher_is_better": true,
+          "tolerance": 0.12
+        },
+        {
+          "name": "max_stream_mbps",
+          "unit": "MB/s",
+          "value": 91.00743751730575,
+          "higher_is_better": true
+        },
+        {
+          "name": "stall_p99",
+          "unit": "ms",
+          "value": 132.850959,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B5-two-handles/premium-750k",
+      "metrics": [
+        {
+          "name": "duplicate_bodies",
+          "unit": "count",
+          "value": 127,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B6-contention/premium-750k",
+      "metrics": [
+        {
+          "name": "stream_mbps",
+          "unit": "MB/s",
+          "value": 251.2553104155867,
+          "higher_is_better": true,
+          "tolerance": 0.1
+        },
+        {
+          "name": "stream_startup_ms",
+          "unit": "ms",
+          "value": 239.96525,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "stream_p50",
+          "unit": "ms",
+          "value": 0.03725,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "stream_p99",
+          "unit": "ms",
+          "value": 58.9115,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "import_mbps",
+          "unit": "MB/s",
+          "value": 145.56179210381092,
+          "higher_is_better": true
+        }
+      ]
+    },
+    {
+      "name": "B7-failover/premium-750k",
+      "metrics": [
+        {
+          "name": "miss_ttfb_mean",
+          "unit": "ms",
+          "value": 158.256167,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "miss_ttfb_p50",
+          "unit": "ms",
+          "value": 151.536791,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "bodies_per_miss",
+          "unit": "count",
+          "value": 1,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B9-forward-skip/premium-750k",
+      "metrics": [
+        {
+          "name": "jump_read_ms",
+          "unit": "ms",
+          "value": 145.525166,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 66,
+          "higher_is_better": false
+        },
+        {
+          "name": "open_articles",
+          "unit": "count",
+          "value": 62,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-09-04-streaming-flight-dedup.md
+++ b/docs/superpowers/plans/2026-09-04-streaming-flight-dedup.md
@@ -1,0 +1,73 @@
+# In-Flight Article Dedup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Two readers that want the same article at the same time download it once (spec phase 5, defect D4): two handles on one file, or a shared and an ephemeral reader on one handle.
+
+**Architecture:** The watermark buffer moves from `segment` to a shared, article-wide `articleBuf` keyed by message-ID in a process-wide sharded `flightMap` inside `internal/usenet`. The first reader to need an article becomes its leader and streams into the `articleBuf`; later readers join and read the same buffer through their own `[Start, End]` trim. If a leader's reader is closed mid-article, the next waiting follower claims leadership and continues into a fresh attempt past the published watermark. Entries leave the map when the article is complete and no segment references it. Supersede is not needed: every stream fetch already rides the priority lane.
+
+**Spec:** `docs/superpowers/specs/2026-09-04-streaming-demand-shaping-design.md` (Phase 5)
+
+## Global Constraints
+
+- No competitor names in code, comments, commits, PRs.
+- Conventional Commits; branch `feat/streaming-flight-dedup` from `feat/streaming-seek-ramp`.
+- `make bench-compare BASE=baseline-main`: no regressions; B5 `duplicate_bodies` must drop to 0.
+
+---
+
+### Task 1: `articleBuf` and `flightMap`
+
+**Files:** create `internal/usenet/flight.go`, `internal/usenet/flight_test.go`; modify `internal/usenet/segment.go`.
+
+**Interfaces (package-private):**
+```go
+// articleBuf is one article's decoded bytes as they arrive, shared by every
+// segment (reader) that wants it.
+type articleBuf struct{ /* mu, buf, ready, done, err, attempt, notify, refs, leading bool */ }
+func (a *articleBuf) attemptWriter() *articleWriter   // same watermark rules as before
+func (a *articleBuf) finish(w *articleWriter)
+func (a *articleBuf) setData(data []byte)
+func (a *articleBuf) setError(err error)
+func (a *articleBuf) published() int64
+func (a *articleBuf) waitDone(ctx context.Context) error // blocks until done/error
+// claimLead returns true for exactly one caller while no leader is active;
+// a leader whose attempt ended without finishing releases leadership so a
+// follower can take over.
+func (a *articleBuf) claimLead() bool
+func (a *articleBuf) releaseLead()
+
+type flightMap struct{ shards [16]struct{ mu sync.Mutex; m map[string]*articleBuf } }
+var flights flightMap
+// acquire returns the article's buffer, creating it on first use, and adds a
+// reference; release drops the reference and deletes the entry once it is
+// done and unreferenced (or errored and unreferenced).
+func (f *flightMap) acquire(id string, size int64) *articleBuf
+func (f *flightMap) release(id string, a *articleBuf)
+func (f *flightMap) len() int // tests
+```
+`segment` keeps `Id/Start/End/SegmentSize/groups/loaderIdx` and gains `art *articleBuf` (acquired lazily in `attach()` by the download goroutine or by `SetData`/`SetError` callers), `released`, `reader`. `segmentReader` reads from `s.art`. `SetData`/`SetError` delegate to the article (a zero-filled hole or a patch is per-reader policy, but the bytes are identical for every reader of that article, so sharing them is correct; a `SetError` from one reader's policy would leak to others, so `SetError` from the hole path must not be shared — see Task 2). `Release()` drops the reference; the article itself is not torn down while others hold it. `Release()` on a segment whose article is still downloading must unblock only this segment's reader: `segmentReader` checks `s.released` first.
+
+- [ ] Tests: two segments on one ID see the same bytes progressively; release of one does not affect the other; entry removed once done and both released; `claimLead` exclusive and re-claimable after `releaseLead`; `waitDone` unblocks on finish, error, and ctx cancel.
+- [ ] Implement; `go test -race ./internal/usenet/` (existing segment tests must still pass unchanged in behaviour).
+- [ ] Commit `feat(usenet): article buffers shared across readers through a flight map`.
+
+### Task 2: Leader/follower fetch
+
+**Files:** `internal/usenet/usenet_reader.go` (`downloadSegmentWithRetry`, goroutine tail), `internal/usenet/usenet_reader_flight_test.go`.
+
+`downloadSegmentWithRetry(ctx, seg)` for streaming readers:
+1. `art := seg.attach()`; loop:
+   - if `art.claimLead()`: run the existing retry loop with `w := art.attemptWriter()` and `BodyStreamPriority`; on success `art.finish(w)`, cache `Put`, return; on `ErrArticleNotFound` `art.setError(err)` (shared: the article really is gone) and return; on any other final error, if the reader's own ctx is done, `art.releaseLead()` and return ctx.Err() (a follower may take over); otherwise `art.setError(err)` and return.
+   - else: `err := art.waitDone(ctx)`; if `err == nil` return `(nil, nil)` (bytes already in the shared buffer); if the article ended in error return it; if `waitDone` returned because the leader gave up (buffer not done, no leader) loop to claim.
+2. The goroutine tail: streaming readers no longer call `SetData` on success (unchanged from phase 2); the hole path keeps `SetData(zeros)` per segment, which must **not** write into the shared article: give `segment` a private override (`s.override []byte`) used by `SetData` when `s.art` is already shared and not done; simpler: `SetData` on a segment always writes a private buffer (`s.local`) that `segmentReader` prefers over `s.art`. Cache hits and patches also use `SetData` and are private.
+
+- [ ] Tests: (a) two readers over the same 20-segment file with 20 ms latency: `BodyStreamPriorityCalls == 20`, both read exact bytes; (b) leader reader interrupted after the first chunk (gate + `Interrupt()`): the follower completes with exact bytes and total calls == 2; (c) a hole on one reader (OnHole → pad) does not pad the other reader (its `OnHole` returns fail and it gets `ErrArticleNotFound`); (d) import readers bypass the flight map (buffered `Body`, counts unchanged).
+- [ ] Implement; `go test -race ./internal/usenet/ ./internal/nzbfilesystem/`.
+- [ ] Commit `feat(usenet): readers join an in-flight article instead of fetching it twice`.
+
+### Task 3: Benchmark, live A/B, PR
+
+- [ ] `make bench-stream && make bench-compare BASE=baseline-main`: B5 `duplicate_bodies` → 0; B2/B4 unchanged.
+- [ ] Live: run two concurrent `curl` reads of the same file from the dev server and compare provider bytes in the dashboard metrics (or `bench-live.sh flight-dedup` for the standard table).
+- [ ] Push; `gh pr create --base feat/streaming-seek-ramp`.

--- a/internal/nzbfilesystem/forward_skip_test.go
+++ b/internal/nzbfilesystem/forward_skip_test.go
@@ -117,8 +117,8 @@ func TestNoRangeRamps(t *testing.T) {
 		t.Fatal(err)
 	}
 	time.Sleep(100 * time.Millisecond) // the manager must not schedule more even given time
-	if got := fp.BodyPriorityCalls(); got > 8 {
-		t.Fatalf("a 1 KB probe scheduled %d fetches, want at most the first ramp step of 8", got)
+	if got := fp.BodyPriorityCalls(); got > 16 {
+		t.Fatalf("a 1 KB probe scheduled %d fetches, want at most the opening window of 16", got)
 	}
 	close(gate)
 }

--- a/internal/nzbfilesystem/forward_skip_test.go
+++ b/internal/nzbfilesystem/forward_skip_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/javi11/altmount/internal/testsupport/fakepool"
 	"github.com/javi11/altmount/internal/testsupport/segments"
-	"github.com/javi11/altmount/internal/utils"
 )
 
 // A forward jump past what the shared reader has buffered reopens at the
@@ -73,52 +72,23 @@ func TestForwardSkipInsideBufferKeepsReader(t *testing.T) {
 	}
 }
 
-// An open-ended WebDAV range on a large file is playback: the window opens
-// fully rather than ramping.
-func TestOpenEndedRangeSkipsRamp(t *testing.T) {
-	ctx := context.WithValue(context.Background(), utils.RangeKey, "bytes=0-")
-	const n, segSize, maxPrefetch = 3000, 64 << 10, 16 // ~188 MB
-	fp := fakepool.New()
-	gate := make(chan struct{})
-	configurePoolForFile(fp, n, segSize, fakepool.SegmentBehavior{})
-	fp.SetBehavior(segments.MessageID(0), fakepool.SegmentBehavior{
-		Bytes: segments.Payload(0, segSize), ChunkSize: 4096, TailGate: gate,
-	})
-	mvf := newTestMVF(t, ctx, fp, n, segSize, maxPrefetch)
-	buf := make([]byte, 1024)
-	if _, err := mvf.ReadAt(buf, 0); err != nil {
-		t.Fatal(err)
-	}
-	// Segment 0's tail is still held; the manager keeps scheduling the rest of
-	// the window in the background, so give it a moment to get there.
-	deadline := time.Now().Add(2 * time.Second)
-	for fp.BodyPriorityCalls() < maxPrefetch && time.Now().Before(deadline) {
-		time.Sleep(5 * time.Millisecond)
-	}
-	if got := fp.BodyPriorityCalls(); got < maxPrefetch {
-		t.Fatalf("open-ended range must open the full window: %d fetches, want %d", got, maxPrefetch)
-	}
-	close(gate)
-}
-
-// Without a range (FUSE) the first read schedules only the base window.
-func TestNoRangeRamps(t *testing.T) {
+// Before the first byte of a head read arrives, a fresh handle has fanned
+// out no more than the opening window.
+func TestHeadReadFansOutAtMostTheOpeningWindowBeforeFirstByte(t *testing.T) {
 	ctx := context.Background()
-	const n, segSize, maxPrefetch = 3000, 64 << 10, 16
+	const n, segSize, maxPrefetch = 3000, 64 << 10, 60
 	fp := fakepool.New()
-	gate := make(chan struct{})
 	configurePoolForFile(fp, n, segSize, fakepool.SegmentBehavior{})
 	fp.SetBehavior(segments.MessageID(0), fakepool.SegmentBehavior{
-		Bytes: segments.Payload(0, segSize), ChunkSize: 4096, TailGate: gate,
+		Bytes: segments.Payload(0, segSize), Latency: 500 * time.Millisecond,
 	})
 	mvf := newTestMVF(t, ctx, fp, n, segSize, maxPrefetch)
 	buf := make([]byte, 1024)
-	if _, err := mvf.ReadAt(buf, 0); err != nil {
-		t.Fatal(err)
-	}
-	time.Sleep(100 * time.Millisecond) // the manager must not schedule more even given time
+	done := make(chan struct{})
+	go func() { _, _ = mvf.ReadAt(buf, 0); close(done) }()
+	time.Sleep(150 * time.Millisecond) // segment 0 has not delivered a byte yet
 	if got := fp.BodyPriorityCalls(); got > 16 {
-		t.Fatalf("a 1 KB probe scheduled %d fetches, want at most the opening window of 16", got)
+		t.Fatalf("fanned out %d fetches before the first byte, want at most 16", got)
 	}
-	close(gate)
+	<-done
 }

--- a/internal/nzbfilesystem/forward_skip_test.go
+++ b/internal/nzbfilesystem/forward_skip_test.go
@@ -117,8 +117,8 @@ func TestNoRangeRamps(t *testing.T) {
 		t.Fatal(err)
 	}
 	time.Sleep(100 * time.Millisecond) // the manager must not schedule more even given time
-	if got := fp.BodyPriorityCalls(); got > 2 {
-		t.Fatalf("a probe read scheduled %d fetches, want the base window of 2", got)
+	if got := fp.BodyPriorityCalls(); got > 8 {
+		t.Fatalf("a 1 KB probe scheduled %d fetches, want at most the first ramp step of 8", got)
 	}
 	close(gate)
 }

--- a/internal/nzbfilesystem/forward_skip_test.go
+++ b/internal/nzbfilesystem/forward_skip_test.go
@@ -1,0 +1,124 @@
+package nzbfilesystem
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/altmount/internal/testsupport/segments"
+	"github.com/javi11/altmount/internal/utils"
+)
+
+// A forward jump past what the shared reader has buffered reopens at the
+// target instead of downloading every article in the gap.
+func TestForwardSkipBeyondBufferReopensAtTarget(t *testing.T) {
+	ctx := context.Background()
+	const n, segSize, maxPrefetch = 200, 64 << 10, 4
+	fp := fakepool.New()
+	configurePoolForFile(fp, n, segSize, fakepool.SegmentBehavior{})
+	mvf := newTestMVF(t, ctx, fp, n, segSize, maxPrefetch)
+	want := segments.FileBytes(n, segSize)
+
+	buf := make([]byte, segSize)
+	if _, err := mvf.ReadAt(buf, 0); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(buf, want[:segSize]) {
+		t.Fatal("head bytes differ")
+	}
+	jump := int64(40 * segSize) // 2.5 MB: inside forwardSkipLimit, far outside the 4-segment window
+	if _, err := mvf.ReadAt(buf, jump); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(buf, want[jump:jump+segSize]) {
+		t.Fatal("jump bytes differ")
+	}
+	if got := fp.BodyPriorityCalls(); got > 12 {
+		t.Fatalf("fetched %d articles for a head read and one jump; the gap was drained instead of skipped", got)
+	}
+}
+
+// A small forward skip inside the buffered window keeps the shared reader.
+func TestForwardSkipInsideBufferKeepsReader(t *testing.T) {
+	ctx := context.Background()
+	const n, segSize, maxPrefetch = 50, 64 << 10, 10
+	fp := fakepool.New()
+	configurePoolForFile(fp, n, segSize, fakepool.SegmentBehavior{})
+	mvf := newTestMVF(t, ctx, fp, n, segSize, maxPrefetch)
+	want := segments.FileBytes(n, segSize)
+
+	buf := make([]byte, 3*segSize) // consume three segments so the window has opened
+	if _, err := mvf.ReadAt(buf, 0); err != nil {
+		t.Fatal(err)
+	}
+	mvf.mu.Lock()
+	before := mvf.reader
+	mvf.mu.Unlock()
+
+	jump := int64(4 * segSize) // one segment past the read position
+	small := make([]byte, segSize)
+	if _, err := mvf.ReadAt(small, jump); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(small, want[jump:jump+segSize]) {
+		t.Fatal("bytes differ")
+	}
+	mvf.mu.Lock()
+	after := mvf.reader
+	mvf.mu.Unlock()
+	if before != after {
+		t.Fatal("a skip inside the buffered window must drain through the shared reader")
+	}
+}
+
+// An open-ended WebDAV range on a large file is playback: the window opens
+// fully rather than ramping.
+func TestOpenEndedRangeSkipsRamp(t *testing.T) {
+	ctx := context.WithValue(context.Background(), utils.RangeKey, "bytes=0-")
+	const n, segSize, maxPrefetch = 3000, 64 << 10, 16 // ~188 MB
+	fp := fakepool.New()
+	gate := make(chan struct{})
+	configurePoolForFile(fp, n, segSize, fakepool.SegmentBehavior{})
+	fp.SetBehavior(segments.MessageID(0), fakepool.SegmentBehavior{
+		Bytes: segments.Payload(0, segSize), ChunkSize: 4096, TailGate: gate,
+	})
+	mvf := newTestMVF(t, ctx, fp, n, segSize, maxPrefetch)
+	buf := make([]byte, 1024)
+	if _, err := mvf.ReadAt(buf, 0); err != nil {
+		t.Fatal(err)
+	}
+	// Segment 0's tail is still held; the manager keeps scheduling the rest of
+	// the window in the background, so give it a moment to get there.
+	deadline := time.Now().Add(2 * time.Second)
+	for fp.BodyPriorityCalls() < maxPrefetch && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := fp.BodyPriorityCalls(); got < maxPrefetch {
+		t.Fatalf("open-ended range must open the full window: %d fetches, want %d", got, maxPrefetch)
+	}
+	close(gate)
+}
+
+// Without a range (FUSE) the first read schedules only the base window.
+func TestNoRangeRamps(t *testing.T) {
+	ctx := context.Background()
+	const n, segSize, maxPrefetch = 3000, 64 << 10, 16
+	fp := fakepool.New()
+	gate := make(chan struct{})
+	configurePoolForFile(fp, n, segSize, fakepool.SegmentBehavior{})
+	fp.SetBehavior(segments.MessageID(0), fakepool.SegmentBehavior{
+		Bytes: segments.Payload(0, segSize), ChunkSize: 4096, TailGate: gate,
+	})
+	mvf := newTestMVF(t, ctx, fp, n, segSize, maxPrefetch)
+	buf := make([]byte, 1024)
+	if _, err := mvf.ReadAt(buf, 0); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond) // the manager must not schedule more even given time
+	if got := fp.BodyPriorityCalls(); got > 2 {
+		t.Fatalf("a probe read scheduled %d fetches, want the base window of 2", got)
+	}
+	close(gate)
+}

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -1975,19 +1975,6 @@ func (mvf *MetadataVirtualFile) ensureReader() error {
 	return nil
 }
 
-// rangeHint is the request length a WebDAV client declared, or 0 when the
-// caller gave no range (FUSE), so the reader can tell playback from probing.
-// An open-ended range means "to the end of the file".
-func (mvf *MetadataVirtualFile) rangeHint(start, end int64) int64 {
-	if rangeStr, ok := mvf.ctx.Value(utils.RangeKey).(string); !ok || rangeStr == "" {
-		return 0
-	}
-	if end < 0 || end >= mvf.meta.FileSize {
-		end = mvf.meta.FileSize - 1
-	}
-	return max(end-start+1, 0)
-}
-
 // getRequestRange gets the range for reader creation based on HTTP range or current position
 // Implements intelligent range limiting to prevent excessive memory usage when end=-1 or ranges are too large
 func (mvf *MetadataVirtualFile) getRequestRange() (start, end int64) {
@@ -2073,8 +2060,7 @@ func (mvf *MetadataVirtualFile) createUsenetReader(ctx context.Context, start, e
 	// always). See holes.go.
 	ur, err := usenet.NewUsenetReader(ctx, mvf.poolManager.GetPool, rg, mvf.maxPrefetch, mvf.streamTracker, mvf.streamID, mvf.segmentStore,
 		usenet.WithHoleHooks(mvf.holeHooks()),
-		usenet.WithSpeculativeBudget(mvf.poolManager.SpeculativeBudget()),
-		usenet.WithRangeHint(mvf.rangeHint(start, end)))
+		usenet.WithSpeculativeBudget(mvf.poolManager.SpeculativeBudget()))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -870,7 +870,10 @@ type MetadataVirtualFile struct {
 	// (nil when the active reader doesn't implement it), so the hot Read/ReadAt
 	// loops avoid repeating the type assertion every iteration. Kept in sync by
 	// setReader and the remux-wrap step; guarded by mvf.mu like reader.
-	bufOffReader      interface{ GetBufferedOffset() int64 }
+	bufOffReader interface{ GetBufferedOffset() int64 }
+	// bufAheadReader is mvf.reader pre-asserted to BufferedAhead, which says
+	// how far a forward skip can drain through the shared reader for free.
+	bufAheadReader    interface{ BufferedAhead() int64 }
 	readerInitialized bool
 	position          int64 // File position (what client sees after Seek)
 	originalRangeEnd  int64 // Original end requested by client (-1 for unbounded)
@@ -955,6 +958,7 @@ type interruptSlot struct{ i readerInterrupter }
 func (mvf *MetadataVirtualFile) setReader(r io.ReadCloser) {
 	mvf.reader = r
 	mvf.bufOffReader, _ = r.(interface{ GetBufferedOffset() int64 })
+	mvf.bufAheadReader, _ = r.(interface{ BufferedAhead() int64 })
 	slot := interruptSlot{}
 	if i, ok := r.(readerInterrupter); ok {
 		slot.i = i
@@ -1272,6 +1276,15 @@ func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte,
 		mvf.readAtSharedNext >= 0 &&
 		off > mvf.readAtSharedNext &&
 		off-mvf.readAtSharedNext <= forwardSkipLimit
+	// Draining is only free while the gap sits inside bytes the reader has
+	// already scheduled; past that, every skipped article is a download the
+	// caller never wanted, and a reader opened at the target is cheaper.
+	if forwardSkip && mvf.bufAheadReader != nil && off-mvf.readAtSharedNext > mvf.bufAheadReader.BufferedAhead() {
+		mvf.closeCurrentReader()
+		mvf.position = off
+		mvf.readAtSharedNext = off
+		forwardSkip = false
+	}
 	useShared := forwardSkip ||
 		(mvf.readAtSharedNext >= 0 && off == mvf.readAtSharedNext) ||
 		(mvf.readAtSharedNext == 0 && !mvf.readerInitialized && off == mvf.position)
@@ -1956,9 +1969,23 @@ func (mvf *MetadataVirtualFile) ensureReader() error {
 		mvf.reader = newSkipLimitReader(mvf.reader, start-rawStart, end-start+1)
 	}
 	mvf.bufOffReader, _ = mvf.reader.(interface{ GetBufferedOffset() int64 })
+	mvf.bufAheadReader, _ = mvf.reader.(interface{ BufferedAhead() int64 })
 
 	mvf.readerInitialized = true
 	return nil
+}
+
+// rangeHint is the request length a WebDAV client declared, or 0 when the
+// caller gave no range (FUSE), so the reader can tell playback from probing.
+// An open-ended range means "to the end of the file".
+func (mvf *MetadataVirtualFile) rangeHint(start, end int64) int64 {
+	if rangeStr, ok := mvf.ctx.Value(utils.RangeKey).(string); !ok || rangeStr == "" {
+		return 0
+	}
+	if end < 0 || end >= mvf.meta.FileSize {
+		end = mvf.meta.FileSize - 1
+	}
+	return max(end-start+1, 0)
 }
 
 // getRequestRange gets the range for reader creation based on HTTP range or current position
@@ -2046,7 +2073,8 @@ func (mvf *MetadataVirtualFile) createUsenetReader(ctx context.Context, start, e
 	// always). See holes.go.
 	ur, err := usenet.NewUsenetReader(ctx, mvf.poolManager.GetPool, rg, mvf.maxPrefetch, mvf.streamTracker, mvf.streamID, mvf.segmentStore,
 		usenet.WithHoleHooks(mvf.holeHooks()),
-		usenet.WithSpeculativeBudget(mvf.poolManager.SpeculativeBudget()))
+		usenet.WithSpeculativeBudget(mvf.poolManager.SpeculativeBudget()),
+		usenet.WithRangeHint(mvf.rangeHint(start, end)))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/nzbfilesystem/stream_bench_test.go
+++ b/internal/nzbfilesystem/stream_bench_test.go
@@ -355,9 +355,9 @@ func BenchmarkStreamUnderContention(b *testing.B) {
 		h.awaitQuietWire(500*time.Millisecond, 30*time.Second)
 		return []streambench.Metric{
 			// Single-stream throughput while an import saturates the normal lane.
-		// Read-ahead must keep its edge over import; 10 % covers run spread.
-		{Name: "stream_mbps", Unit: "MB/s", Value: mbps(off, elapsed), HigherIsBetter: true, Tolerance: 0.10},
-		info(streambench.Metric{Name: "stream_p50", Unit: "ms", Value: ms(lat.P(0.5))}),
+			// Read-ahead must keep its edge over import; 10 % covers run spread.
+			{Name: "stream_mbps", Unit: "MB/s", Value: mbps(off, elapsed), HigherIsBetter: true, Tolerance: 0.10},
+			info(streambench.Metric{Name: "stream_p50", Unit: "ms", Value: ms(lat.P(0.5))}),
 			info(streambench.Metric{Name: "stream_p99", Unit: "ms", Value: ms(lat.P(0.99))}),
 			{Name: "import_mbps", Unit: "MB/s", Value: mbps(importBytes.Load(), elapsed), HigherIsBetter: true},
 		}
@@ -395,6 +395,51 @@ func BenchmarkStreamFailover(b *testing.B) {
 			{Name: "miss_ttfb_mean", Unit: "ms", Value: ms(missLat.Mean()), Tolerance: 0.10},
 			info(streambench.Metric{Name: "miss_ttfb_p50", Unit: "ms", Value: ms(missLat.P(0.5))}),
 			info(streambench.Metric{Name: "bodies_per_miss", Unit: "count", Value: float64(h.bodies()-before) / float64(missLat.Count())}),
+		}
+	})
+}
+
+// BenchmarkStreamForwardSkip models "skip intro": read the head of a file,
+// jump 100 MB forward, read on. It reports the latency of the jump read and
+// how many articles the whole scenario fetched; a jump beyond the buffered
+// window should reopen at the target rather than drain the gap.
+func BenchmarkStreamForwardSkip(b *testing.B) {
+	p := profilePremium750K
+	h := newBenchHarness(b, p)
+	record(b, scenario("B9-forward-skip", p), func() []streambench.Metric {
+		before := h.bodies()
+		mvf := h.openFile(b, benchFileSegs, benchPrefetch, -1)
+		buf := make([]byte, 1<<20)
+		var off int64
+		for off < 2<<20 {
+			n, err := mvf.ReadAt(buf, off)
+			if err != nil {
+				b.Fatalf("head ReadAt: %v", err)
+			}
+			off += int64(n)
+		}
+		h.awaitQuietWire(500*time.Millisecond, 30*time.Second)
+		openArticles := float64(h.bodies() - before)
+
+		jump := off + 100<<20
+		start := time.Now()
+		if _, err := mvf.ReadAt(buf, jump); err != nil {
+			b.Fatalf("jump ReadAt: %v", err)
+		}
+		jumpLat := time.Since(start)
+		for off = jump + int64(len(buf)); off < jump+2<<20; {
+			n, err := mvf.ReadAt(buf, off)
+			if err != nil {
+				b.Fatalf("post-jump ReadAt: %v", err)
+			}
+			off += int64(n)
+		}
+		_ = mvf.Close()
+		h.awaitQuietWire(500*time.Millisecond, 30*time.Second)
+		return []streambench.Metric{
+			{Name: "jump_read_ms", Unit: "ms", Value: ms(jumpLat), Tolerance: 0.10},
+			{Name: "articles", Unit: "count", Value: float64(h.bodies() - before)},
+			info(streambench.Metric{Name: "open_articles", Unit: "count", Value: openArticles}),
 		}
 	})
 }

--- a/internal/nzbfilesystem/stream_bench_test.go
+++ b/internal/nzbfilesystem/stream_bench_test.go
@@ -22,13 +22,15 @@ import (
 // `make bench-stream`; results land in bench/results/<sha>.json and are
 // compared by `make bench-compare BASE=<sha>`.
 const (
-	benchFileSegs   = 400
-	benchPrefetch   = 60 // config default streaming.max_prefetch
-	benchSeqBytes   = 200 << 20
-	benchSeekReads  = 20
-	benchSeekSize   = 64 << 10
-	benchColdOpens  = 20
-	benchPauseSleep = 5 * time.Second
+	benchFileSegs = 400
+	benchPrefetch = 60 // config default streaming.max_prefetch
+	benchSeqBytes = 200 << 20
+	// benchStartupBytes separates a stream's opening phase from steady state.
+	benchStartupBytes = 16 << 20
+	benchSeekReads    = 20
+	benchSeekSize     = 64 << 10
+	benchColdOpens    = 20
+	benchPauseSleep   = 5 * time.Second
 )
 
 var benchProfiles = []benchProfile{profilePremium750K, profileSlow4M}
@@ -126,12 +128,22 @@ func BenchmarkStreamSequential(b *testing.B) {
 				beforeBytes := h.bytesWritten()
 				start := time.Now()
 				var read int64
-				for read < benchSeqBytes {
+				var startupDone time.Time
+				// Read well past the prefetch window so steady state is the wire,
+				// not buffered bytes: 200 MB on 750 KB articles, 600 MB on 4 MiB.
+				seqBytes := int64(200 << 20)
+				if p.ArticleSize >= 4<<20 {
+					seqBytes = 600 << 20
+				}
+				for read < seqBytes {
 					n, err := mvf.ReadAt(buf, read)
 					if err != nil && err != io.EOF {
 						b.Fatalf("ReadAt(%d): %v", read, err)
 					}
 					read += int64(n)
+					if read >= benchStartupBytes && startupDone.IsZero() {
+						startupDone = time.Now()
+					}
 					if err == io.EOF {
 						break
 					}
@@ -140,8 +152,14 @@ func BenchmarkStreamSequential(b *testing.B) {
 				_ = mvf.Close()
 				h.awaitQuietWire(500*time.Millisecond, 30*time.Second)
 				fetched := h.bytesWritten() - beforeBytes
+				// Startup is the time to the first 16 MB, where a fresh reader's
+				// window is still opening; steady state is everything after it,
+				// which is what sustained playback runs at.
+				startup := startupDone.Sub(start)
 				return []streambench.Metric{
-					{Name: "throughput", Unit: "MB/s", Value: mbps(read, elapsed), HigherIsBetter: true},
+					{Name: "startup_ms", Unit: "ms", Value: ms(startup), Tolerance: 0.10},
+					{Name: "throughput", Unit: "MB/s", Value: mbps(read-benchStartupBytes, elapsed-startup), HigherIsBetter: true},
+					info(streambench.Metric{Name: "throughput_total", Unit: "MB/s", Value: mbps(read, elapsed), HigherIsBetter: true}),
 					{Name: "waste_ratio", Unit: "ratio", Value: float64(fetched) / float64(read)},
 				}
 			})
@@ -339,6 +357,7 @@ func BenchmarkStreamUnderContention(b *testing.B) {
 		var lat streambench.Samples
 		start := time.Now()
 		var off int64
+		var startupDone time.Time
 		for off < 100<<20 {
 			t0 := time.Now()
 			n, err := mvf.ReadAt(buf, off)
@@ -347,8 +366,12 @@ func BenchmarkStreamUnderContention(b *testing.B) {
 			}
 			lat.Add(time.Since(t0))
 			off += int64(n)
+			if off >= benchStartupBytes && startupDone.IsZero() {
+				startupDone = time.Now()
+			}
 		}
 		elapsed := time.Since(start)
+		startup := startupDone.Sub(start)
 		cancel()
 		iwg.Wait()
 		_ = mvf.Close()
@@ -356,7 +379,8 @@ func BenchmarkStreamUnderContention(b *testing.B) {
 		return []streambench.Metric{
 			// Single-stream throughput while an import saturates the normal lane.
 			// Read-ahead must keep its edge over import; 10 % covers run spread.
-			{Name: "stream_mbps", Unit: "MB/s", Value: mbps(off, elapsed), HigherIsBetter: true, Tolerance: 0.10},
+			{Name: "stream_mbps", Unit: "MB/s", Value: mbps(off-benchStartupBytes, elapsed-startup), HigherIsBetter: true, Tolerance: 0.10},
+			info(streambench.Metric{Name: "stream_startup_ms", Unit: "ms", Value: ms(startup)}),
 			info(streambench.Metric{Name: "stream_p50", Unit: "ms", Value: ms(lat.P(0.5))}),
 			info(streambench.Metric{Name: "stream_p99", Unit: "ms", Value: ms(lat.P(0.99))}),
 			{Name: "import_mbps", Unit: "MB/s", Value: mbps(importBytes.Load(), elapsed), HigherIsBetter: true},

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -124,24 +124,21 @@ func WithSpeculativeBudget(b SpecBudget) ReaderOption {
 }
 
 const (
-	// rampBaseSegments is the read-ahead a fresh streaming reader opens with,
+	// rampBaseSegments is the read-ahead a fresh streaming reader opens with
 	// and keeps until the caller has read its first byte. Holding the fan-out
-	// back that long also keeps the demand article from queueing behind a
-	// window of speculative ones on the same connections.
+	// back that long keeps the demand article from queueing behind a window
+	// of speculative ones on the same connections, and a probe that reads a
+	// few hundred KB and leaves drags almost nothing behind it.
 	rampBaseSegments = 2
-	// rampStep1Bytes/rampStep2Bytes are the read positions at which the
-	// window widens to rampStep1Segments and rampStep2Segments before
-	// opening fully. A probe that reads a few hundred KB and leaves drags
-	// only a handful of articles behind it; a player is at full speed
-	// within its first couple of MB.
-	rampStep1Bytes    = 512 << 10
-	rampStep1Segments = 8
-	rampStep2Bytes    = 2 << 20
-	rampStep2Segments = 32
-	// streamingIntentBytes is the request length at or above which a caller
-	// is clearly playing, not probing: the window opens fully as soon as the
-	// first byte has been read.
-	streamingIntentBytes = 128 << 20
+	// rampOpeningSegments is the window between the first byte and the first
+	// consumed segment: wide enough that startup runs near full speed, narrow
+	// enough that a probe reading a partial article does not fetch a whole
+	// window on the way out.
+	rampOpeningSegments = 16
+	// streamingIntentBytes is the declared request length at or above which
+	// a caller is playing, not probing: the window opens fully as soon as the
+	// first byte has been read. rclone's chunked reads declare 32 MB.
+	streamingIntentBytes = 8 << 20
 )
 
 // WithRangeHint tells the reader how many bytes the caller asked for. At or
@@ -424,12 +421,9 @@ func (b *UsenetReader) Read(p []byte) (int, error) {
 		before := b.totalBytesRead
 		b.totalBytesRead += int64(nn)
 		totalRead := b.totalBytesRead
-		// The read-ahead window widens with bytes read; wake the manager when
-		// a step boundary is crossed so it is not left waiting for the next
-		// segment rotation.
-		widened := nn > 0 && (before == 0 ||
-			(before < rampStep1Bytes && totalRead >= rampStep1Bytes) ||
-			(before < rampStep2Bytes && totalRead >= rampStep2Bytes))
+		// The read-ahead window widens once the first byte has been read; wake
+		// the manager so it is not left waiting for the next segment rotation.
+		widened := nn > 0 && before == 0
 		b.mu.Unlock()
 		if widened {
 			b.cond.Signal()
@@ -497,8 +491,8 @@ func IsArticleNotFound(err error) bool {
 }
 
 // windowFor is how many segments may be scheduled ahead of the read position
-// given how many bytes the caller has read since the reader was created.
-func (b *UsenetReader) windowFor(bytesRead int64) int {
+// given what the caller has read since the reader was created.
+func (b *UsenetReader) windowFor(bytesRead int64, consumedSegments int) int {
 	if !b.priority {
 		return b.maxPrefetch
 	}
@@ -507,10 +501,8 @@ func (b *UsenetReader) windowFor(bytesRead int64) int {
 	case bytesRead == 0:
 		w = rampBaseSegments
 	case b.rangeHint >= streamingIntentBytes:
-	case bytesRead < rampStep1Bytes:
-		w = rampStep1Segments
-	case bytesRead < rampStep2Bytes:
-		w = rampStep2Segments
+	case consumedSegments == 0:
+		w = rampOpeningSegments
 	}
 	return min(b.maxPrefetch, w)
 }
@@ -753,7 +745,7 @@ func (b *UsenetReader) downloadManager(ctx context.Context) {
 		// Limit how far ahead we prefetch beyond the current read position
 		currentRead := b.rg.GetCurrentIndex()
 		ahead := b.nextToDownload - currentRead
-		if ahead >= b.windowFor(b.totalBytesRead) {
+		if ahead >= b.windowFor(b.totalBytesRead, currentRead) {
 			b.cond.Wait()
 			b.mu.Unlock()
 			if ctx.Err() != nil {

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -124,31 +124,23 @@ func WithSpeculativeBudget(b SpecBudget) ReaderOption {
 }
 
 const (
-	// rampBaseSegments is the read-ahead a fresh streaming reader opens with
-	// and keeps until the caller has read its first byte. Holding the fan-out
-	// back that long keeps the demand article from queueing behind a window
-	// of speculative ones on the same connections, and a probe that reads a
-	// few hundred KB and leaves drags almost nothing behind it.
-	rampBaseSegments = 2
-	// rampOpeningSegments is the window between the first byte and the first
-	// consumed segment: wide enough that startup runs near full speed, narrow
-	// enough that a probe reading a partial article does not fetch a whole
-	// window on the way out.
-	rampOpeningSegments = 16
-	// streamingIntentBytes is the declared request length at or above which
-	// a caller is playing, not probing: the window opens fully as soon as the
-	// first byte has been read. rclone's chunked reads declare 32 MB.
-	streamingIntentBytes = 8 << 20
+	// largeArticleHoldSegments is the read-ahead a fresh streaming reader
+	// opens with on large-article posts, kept until the caller has read its
+	// first byte. Holding the fan-out back keeps the demand article from
+	// queueing behind a window of speculative ones on the same connections;
+	// on 4 MiB parts that is the difference between seconds and one round
+	// trip to first byte. On small articles the queueing costs a few
+	// milliseconds and the hold would only slow startup, so it is skipped.
+	largeArticleHoldSegments = 2
+	// largeArticleBytes is the article size from which the hold applies.
+	largeArticleBytes = 2 << 20
+	// openingSegments is the window before the first byte on small-article
+	// posts: wide enough that startup runs at full speed once bytes flow,
+	// narrow enough that a handle closed before its first byte arrives has
+	// not fanned a whole window out. Any consumption opens the window fully;
+	// a narrower ramp was measured to cost 16-25 % of a 16 MB startup.
+	openingSegments = 16
 )
-
-// WithRangeHint tells the reader how many bytes the caller asked for. At or
-// above streamingIntentBytes the read-ahead window opens fully at once;
-// below it, or unknown (0), the window ramps from rampBaseSegments.
-func WithRangeHint(bytes int64) ReaderOption {
-	return func(r *UsenetReader) {
-		r.rangeHint = bytes
-	}
-}
 
 // ConnBudget grants connection tokens for import segment fetches.
 // Implemented by pool.Manager (AcquireImportConnection).
@@ -226,7 +218,7 @@ type UsenetReader struct {
 	priority       bool         // true (streaming) = priority lane; false (import) = normal lane
 	budget         ConnBudget   // optional; gates import fetches on the global connection budget
 	specBudget     SpecBudget   // optional; bounds speculative fetches pool-wide (streaming only)
-	rangeHint      int64        // bytes the caller asked for; 0 = unknown
+	articleSize    int64        // decoded size of the range's first article; drives the first-byte hold
 	scheduledBytes int64        // usable bytes of every segment scheduled so far
 	cond           *sync.Cond   // Signals downloadManager when reader advances
 
@@ -492,19 +484,14 @@ func IsArticleNotFound(err error) bool {
 
 // windowFor is how many segments may be scheduled ahead of the read position
 // given what the caller has read since the reader was created.
-func (b *UsenetReader) windowFor(bytesRead int64, consumedSegments int) int {
-	if !b.priority {
+func (b *UsenetReader) windowFor(bytesRead int64) int {
+	if !b.priority || bytesRead > 0 {
 		return b.maxPrefetch
 	}
-	w := b.maxPrefetch
-	switch {
-	case bytesRead == 0:
-		w = rampBaseSegments
-	case b.rangeHint >= streamingIntentBytes:
-	case consumedSegments == 0:
-		w = rampOpeningSegments
+	if b.articleSize >= largeArticleBytes {
+		return min(b.maxPrefetch, largeArticleHoldSegments)
 	}
-	return min(b.maxPrefetch, w)
+	return min(b.maxPrefetch, openingSegments)
 }
 
 // BufferedAhead reports bytes scheduled for fetch beyond what the caller has
@@ -728,6 +715,11 @@ func (b *UsenetReader) downloadManager(ctx context.Context) {
 	}
 
 	totalSegments := b.rg.Len()
+	if first, err := b.rg.GetSegment(0); err == nil && first != nil {
+		b.mu.Lock()
+		b.articleSize = first.SegmentSize
+		b.mu.Unlock()
+	}
 
 	for ctx.Err() == nil {
 		b.mu.Lock()
@@ -745,7 +737,7 @@ func (b *UsenetReader) downloadManager(ctx context.Context) {
 		// Limit how far ahead we prefetch beyond the current read position
 		currentRead := b.rg.GetCurrentIndex()
 		ahead := b.nextToDownload - currentRead
-		if ahead >= b.windowFor(b.totalBytesRead, currentRead) {
+		if ahead >= b.windowFor(b.totalBytesRead) {
 			b.cond.Wait()
 			b.mu.Unlock()
 			if ctx.Err() != nil {

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -123,6 +123,26 @@ func WithSpeculativeBudget(b SpecBudget) ReaderOption {
 	}
 }
 
+const (
+	// rampBaseSegments is the read-ahead a fresh streaming reader opens with.
+	// It quadruples per consumed segment, so sustained reading reaches the
+	// full window within three articles while a probe that reads a couple of
+	// MB and leaves drags almost nothing behind it.
+	rampBaseSegments = 2
+	// streamingIntentBytes is the request length at or above which a caller
+	// is clearly playing, not probing, and gets the full window at once.
+	streamingIntentBytes = 128 << 20
+)
+
+// WithRangeHint tells the reader how many bytes the caller asked for. At or
+// above streamingIntentBytes the read-ahead window opens fully at once;
+// below it, or unknown (0), the window ramps from rampBaseSegments.
+func WithRangeHint(bytes int64) ReaderOption {
+	return func(r *UsenetReader) {
+		r.rangeHint = bytes
+	}
+}
+
 // ConnBudget grants connection tokens for import segment fetches.
 // Implemented by pool.Manager (AcquireImportConnection).
 type ConnBudget interface {
@@ -199,6 +219,8 @@ type UsenetReader struct {
 	priority       bool         // true (streaming) = priority lane; false (import) = normal lane
 	budget         ConnBudget   // optional; gates import fetches on the global connection budget
 	specBudget     SpecBudget   // optional; bounds speculative fetches pool-wide (streaming only)
+	rangeHint      int64        // bytes the caller asked for; 0 = unknown
+	scheduledBytes int64        // usable bytes of every segment scheduled so far
 	cond           *sync.Cond   // Signals downloadManager when reader advances
 
 	// Prefetch-based download tracking
@@ -454,6 +476,26 @@ func IsArticleNotFound(err error) bool {
 	return errors.Is(err, nntppool.ErrArticleNotFound)
 }
 
+// windowFor is how many segments may be scheduled ahead of the read position
+// once consumed segments have been read since the reader was created.
+func (b *UsenetReader) windowFor(consumed int) int {
+	if !b.priority || b.rangeHint >= streamingIntentBytes {
+		return b.maxPrefetch
+	}
+	if consumed >= 16 {
+		return b.maxPrefetch
+	}
+	return min(b.maxPrefetch, rampBaseSegments<<(2*consumed))
+}
+
+// BufferedAhead reports bytes scheduled for fetch beyond what the caller has
+// read: the distance a forward skip can cover without a new reader.
+func (b *UsenetReader) BufferedAhead() int64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return max(b.scheduledBytes-b.totalBytesRead, 0)
+}
+
 func (b *UsenetReader) GetBufferedOffset() int64 {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -684,7 +726,7 @@ func (b *UsenetReader) downloadManager(ctx context.Context) {
 		// Limit how far ahead we prefetch beyond the current read position
 		currentRead := b.rg.GetCurrentIndex()
 		ahead := b.nextToDownload - currentRead
-		if ahead >= b.maxPrefetch {
+		if ahead >= b.windowFor(currentRead) {
 			b.cond.Wait()
 			b.mu.Unlock()
 			if ctx.Err() != nil {
@@ -722,6 +764,9 @@ func (b *UsenetReader) downloadManager(ctx context.Context) {
 			releaseSlot()
 			continue
 		}
+		b.mu.Lock()
+		b.scheduledBytes += seg.End - seg.Start + 1
+		b.mu.Unlock()
 
 		b.inFlight.Add(1)
 		go func(segIdx int, s *segment) {

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -124,13 +124,23 @@ func WithSpeculativeBudget(b SpecBudget) ReaderOption {
 }
 
 const (
-	// rampBaseSegments is the read-ahead a fresh streaming reader opens with.
-	// It quadruples per consumed segment, so sustained reading reaches the
-	// full window within three articles while a probe that reads a couple of
-	// MB and leaves drags almost nothing behind it.
+	// rampBaseSegments is the read-ahead a fresh streaming reader opens with,
+	// and keeps until the caller has read its first byte. Holding the fan-out
+	// back that long also keeps the demand article from queueing behind a
+	// window of speculative ones on the same connections.
 	rampBaseSegments = 2
+	// rampStep1Bytes/rampStep2Bytes are the read positions at which the
+	// window widens to rampStep1Segments and rampStep2Segments before
+	// opening fully. A probe that reads a few hundred KB and leaves drags
+	// only a handful of articles behind it; a player is at full speed
+	// within its first couple of MB.
+	rampStep1Bytes    = 512 << 10
+	rampStep1Segments = 8
+	rampStep2Bytes    = 2 << 20
+	rampStep2Segments = 32
 	// streamingIntentBytes is the request length at or above which a caller
-	// is clearly playing, not probing, and gets the full window at once.
+	// is clearly playing, not probing: the window opens fully as soon as the
+	// first byte has been read.
 	streamingIntentBytes = 128 << 20
 )
 
@@ -411,9 +421,19 @@ func (b *UsenetReader) Read(p []byte) (int, error) {
 		n += nn
 
 		b.mu.Lock()
+		before := b.totalBytesRead
 		b.totalBytesRead += int64(nn)
 		totalRead := b.totalBytesRead
+		// The read-ahead window widens with bytes read; wake the manager when
+		// a step boundary is crossed so it is not left waiting for the next
+		// segment rotation.
+		widened := nn > 0 && (before == 0 ||
+			(before < rampStep1Bytes && totalRead >= rampStep1Bytes) ||
+			(before < rampStep2Bytes && totalRead >= rampStep2Bytes))
 		b.mu.Unlock()
+		if widened {
+			b.cond.Signal()
+		}
 
 		if err != nil {
 			if errors.Is(err, io.EOF) {
@@ -477,15 +497,22 @@ func IsArticleNotFound(err error) bool {
 }
 
 // windowFor is how many segments may be scheduled ahead of the read position
-// once consumed segments have been read since the reader was created.
-func (b *UsenetReader) windowFor(consumed int) int {
-	if !b.priority || b.rangeHint >= streamingIntentBytes {
+// given how many bytes the caller has read since the reader was created.
+func (b *UsenetReader) windowFor(bytesRead int64) int {
+	if !b.priority {
 		return b.maxPrefetch
 	}
-	if consumed >= 16 {
-		return b.maxPrefetch
+	w := b.maxPrefetch
+	switch {
+	case bytesRead == 0:
+		w = rampBaseSegments
+	case b.rangeHint >= streamingIntentBytes:
+	case bytesRead < rampStep1Bytes:
+		w = rampStep1Segments
+	case bytesRead < rampStep2Bytes:
+		w = rampStep2Segments
 	}
-	return min(b.maxPrefetch, rampBaseSegments<<(2*consumed))
+	return min(b.maxPrefetch, w)
 }
 
 // BufferedAhead reports bytes scheduled for fetch beyond what the caller has
@@ -726,7 +753,7 @@ func (b *UsenetReader) downloadManager(ctx context.Context) {
 		// Limit how far ahead we prefetch beyond the current read position
 		currentRead := b.rg.GetCurrentIndex()
 		ahead := b.nextToDownload - currentRead
-		if ahead >= b.windowFor(currentRead) {
+		if ahead >= b.windowFor(b.totalBytesRead) {
 			b.cond.Wait()
 			b.mu.Unlock()
 			if ctx.Err() != nil {

--- a/internal/usenet/usenet_reader_ramp_test.go
+++ b/internal/usenet/usenet_reader_ramp_test.go
@@ -1,0 +1,103 @@
+package usenet
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/pool"
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/altmount/internal/testsupport/segments"
+)
+
+func rampPool(n, segSize int, latency time.Duration) *fakepool.Client {
+	fp := fakepool.New()
+	for i := 0; i < n; i++ {
+		fp.SetBehavior(segments.MessageID(i), fakepool.SegmentBehavior{Bytes: segments.Payload(i, segSize), Latency: latency})
+	}
+	return fp
+}
+
+func newRampReader(t *testing.T, ctx context.Context, fp *fakepool.Client, rg *segmentRange, maxPrefetch int, opts ...ReaderOption) *UsenetReader {
+	t.Helper()
+	getter := func() (pool.NntpClient, error) { return fp, nil }
+	ur, err := NewUsenetReader(ctx, getter, rg, maxPrefetch, noopMetrics{}, "ramp-test", nil, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ur.Close() })
+	return ur
+}
+
+// A fresh reader without streaming intent opens only a slip of read-ahead
+// until the caller consumes segments.
+func TestFreshReaderRampsFromABaseWindow(t *testing.T) {
+	ctx := context.Background()
+	const nSegs, segSize, maxPrefetch = 40, 256, 60
+	fp := rampPool(nSegs, segSize, 0)
+	gate := make(chan struct{})
+	fp.SetBehavior(segments.MessageID(0), fakepool.SegmentBehavior{
+		Bytes: segments.Payload(0, segSize), ChunkSize: 64, TailGate: gate,
+	})
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+	ur := newRampReader(t, ctx, fp, rg, maxPrefetch)
+	ur.Start()
+
+	time.Sleep(100 * time.Millisecond) // let the manager schedule what it will
+	if got := fp.BodyPriorityCalls(); got > rampBaseSegments {
+		t.Fatalf("scheduled %d fetches before any byte was consumed, want <= %d", got, rampBaseSegments)
+	}
+	if got := ur.BufferedAhead(); got != int64(rampBaseSegments*segSize) {
+		t.Fatalf("BufferedAhead = %d, want %d", got, rampBaseSegments*segSize)
+	}
+
+	close(gate)
+	got, err := io.ReadAll(ur)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, segments.FileBytes(nSegs, segSize)) {
+		t.Fatal("payload differs")
+	}
+	if fp.MaxInFlight() <= int32(rampBaseSegments) {
+		t.Fatalf("window never grew past the base: max in flight %d", fp.MaxInFlight())
+	}
+	if ur.BufferedAhead() != 0 {
+		t.Fatalf("BufferedAhead after full read = %d", ur.BufferedAhead())
+	}
+}
+
+// A range hint at or above the streaming-intent threshold opens the window
+// fully at once.
+func TestStreamSizedRangeHintSkipsTheRamp(t *testing.T) {
+	ctx := context.Background()
+	const nSegs, segSize, maxPrefetch = 30, 128, 12
+	fp := rampPool(nSegs, segSize, 30*time.Millisecond)
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+	ur := newRampReader(t, ctx, fp, rg, maxPrefetch, WithRangeHint(streamingIntentBytes))
+	ur.Start()
+	if _, err := io.ReadAll(ur); err != nil {
+		t.Fatal(err)
+	}
+	if fp.MaxInFlight() != int32(maxPrefetch) {
+		t.Fatalf("max in flight = %d, want the full window %d", fp.MaxInFlight(), maxPrefetch)
+	}
+}
+
+// Import readers read whole files and keep the full window from the start.
+func TestImportReaderDoesNotRamp(t *testing.T) {
+	ctx := context.Background()
+	const nSegs, segSize, maxPrefetch = 30, 128, 8
+	fp := rampPool(nSegs, segSize, 30*time.Millisecond)
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+	ur := newRampReader(t, ctx, fp, rg, maxPrefetch, WithImportProfile(nil))
+	ur.Start()
+	if _, err := io.ReadAll(ur); err != nil {
+		t.Fatal(err)
+	}
+	if fp.MaxInFlight() != int32(maxPrefetch) {
+		t.Fatalf("import max in flight = %d, want %d", fp.MaxInFlight(), maxPrefetch)
+	}
+}

--- a/internal/usenet/usenet_reader_ramp_test.go
+++ b/internal/usenet/usenet_reader_ramp_test.go
@@ -31,12 +31,40 @@ func newRampReader(t *testing.T, ctx context.Context, fp *fakepool.Client, rg *s
 	return ur
 }
 
-// A fresh reader without streaming intent opens only a slip of read-ahead
-// until the caller consumes segments.
-func TestFreshReaderRampsFromABaseWindow(t *testing.T) {
+// A fresh reader on a large-article post holds the fan-out to a slip until
+// the first byte has been read, so the demand article has the wire to itself.
+func TestFreshReaderHoldsFanOutOnLargeArticles(t *testing.T) {
+	ctx := context.Background()
+	const nSegs, segSize, maxPrefetch = 4, largeArticleBytes, 60
+	fp := rampPool(nSegs, segSize, 0)
+	gate := make(chan struct{})
+	fp.SetBehavior(segments.MessageID(0), fakepool.SegmentBehavior{
+		Bytes: segments.Payload(0, segSize), ChunkSize: 64 << 10, TailGate: gate,
+	})
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+	ur := newRampReader(t, ctx, fp, rg, maxPrefetch)
+	ur.Start()
+
+	time.Sleep(100 * time.Millisecond)
+	if got := fp.BodyPriorityCalls(); got > largeArticleHoldSegments {
+		t.Fatalf("scheduled %d fetches before any byte was consumed, want <= %d", got, largeArticleHoldSegments)
+	}
+	close(gate)
+	got, err := io.ReadAll(ur)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, segments.FileBytes(nSegs, segSize)) {
+		t.Fatal("payload differs")
+	}
+}
+
+// A fresh reader on a small-article post opens the opening window, not the
+// full one, until the caller has read its first byte.
+func TestFreshReaderOpensTheOpeningWindowBeforeFirstByte(t *testing.T) {
 	ctx := context.Background()
 	const nSegs, segSize, maxPrefetch = 40, 256, 60
-	fp := rampPool(nSegs, segSize, 0)
+	fp := rampPool(nSegs, segSize, 10*time.Millisecond)
 	gate := make(chan struct{})
 	fp.SetBehavior(segments.MessageID(0), fakepool.SegmentBehavior{
 		Bytes: segments.Payload(0, segSize), ChunkSize: 64, TailGate: gate,
@@ -46,11 +74,11 @@ func TestFreshReaderRampsFromABaseWindow(t *testing.T) {
 	ur.Start()
 
 	time.Sleep(100 * time.Millisecond) // let the manager schedule what it will
-	if got := fp.BodyPriorityCalls(); got > rampBaseSegments {
-		t.Fatalf("scheduled %d fetches before any byte was consumed, want <= %d", got, rampBaseSegments)
+	if got := fp.BodyPriorityCalls(); got > openingSegments {
+		t.Fatalf("scheduled %d fetches before the first byte was read, want <= %d", got, openingSegments)
 	}
-	if got := ur.BufferedAhead(); got != int64(rampBaseSegments*segSize) {
-		t.Fatalf("BufferedAhead = %d, want %d", got, rampBaseSegments*segSize)
+	if got := ur.BufferedAhead(); got != int64(openingSegments*segSize) {
+		t.Fatalf("BufferedAhead = %d, want %d", got, openingSegments*segSize)
 	}
 
 	close(gate)
@@ -61,28 +89,11 @@ func TestFreshReaderRampsFromABaseWindow(t *testing.T) {
 	if !bytes.Equal(got, segments.FileBytes(nSegs, segSize)) {
 		t.Fatal("payload differs")
 	}
-	if fp.MaxInFlight() <= int32(rampBaseSegments) {
-		t.Fatalf("window never grew past the base: max in flight %d", fp.MaxInFlight())
+	if fp.MaxInFlight() <= int32(openingSegments) {
+		t.Fatalf("window never grew past the opening window: max in flight %d", fp.MaxInFlight())
 	}
 	if ur.BufferedAhead() != 0 {
 		t.Fatalf("BufferedAhead after full read = %d", ur.BufferedAhead())
-	}
-}
-
-// A range hint at or above the streaming-intent threshold opens the window
-// fully at once.
-func TestStreamSizedRangeHintSkipsTheRamp(t *testing.T) {
-	ctx := context.Background()
-	const nSegs, segSize, maxPrefetch = 30, 128, 12
-	fp := rampPool(nSegs, segSize, 30*time.Millisecond)
-	rg := buildEagerRange(ctx, t, nSegs, segSize)
-	ur := newRampReader(t, ctx, fp, rg, maxPrefetch, WithRangeHint(streamingIntentBytes))
-	ur.Start()
-	if _, err := io.ReadAll(ur); err != nil {
-		t.Fatal(err)
-	}
-	if fp.MaxInFlight() != int32(maxPrefetch) {
-		t.Fatalf("max in flight = %d, want the full window %d", fp.MaxInFlight(), maxPrefetch)
 	}
 }
 


### PR DESCRIPTION
Stacked on #897 → #896 → #895 → #894.

## Summary
- A fresh streaming reader holds its fan-out until the caller has read its first byte: to 2 segments on large-article posts (≥ 2 MiB parts), 16 otherwise; after the first byte the window opens fully. On 4 MiB parts the demand article no longer queues behind 59 speculative ones on the same connections.
- A forward jump that is inside the 16 MB skip limit but beyond what the shared reader has actually scheduled (`UsenetReader.BufferedAhead`) now reopens at the target instead of downloading every article in the gap.
- New bench scenario B9 (open, read 2 MB, jump 100 MB, read on) and B2/B6 now report a gated `startup_ms` (time to the first 16 MB) separately from steady-state throughput; the slow profile reads 600 MB so steady state measures the wire, not the buffered window.

## What was tried and dropped
The spec's consumption-keyed ramp (2 → 8 → 32 → full as segments are consumed) was implemented and measured: it cut articles per probe from 60 to 2 but cost 16-25 % of the time to the first 16 MB on small-article posts, because any window that stays narrow until a segment is consumed leaves a round-trip bubble before the window is full. Speed wins; the first-byte hold is the part that measured as a pure gain. Commits in this branch show the iterations.

## Simulated benchmark (medians of 3)

vs the committed baseline:

| Scenario | Metric | base | this PR |
|---|---|---|---|
| B1 cold open, premium | ttfb mean (ms) | 146 | 45 |
| B1 cold open, slow-4m | ttfb mean (ms) | 3907 | 3722 (see note) |
| B2 sequential, premium | steady MB/s | 219 | 264 |
| B2 sequential, slow-4m | steady MB/s | 35 | 56 |
| B2 sequential, slow-4m | fetched/read | 2.21 | 1.52 |
| B4 four streams | min stream MB/s | 78 | 84 |
| B4 four streams | stall p99 (ms) | 181 | 133 |
| B6 contention | import MB/s | 136 | 146 |

vs #897 for the metrics that did not exist in the baseline (sampled on #897 with this PR's bench code):

| Scenario | Metric | #897 | this PR |
|---|---|---|---|
| B2 premium | startup to 16 MB (ms) | 245 | 219 |
| B2 premium | steady MB/s | 270 | 264 |
| B2 slow-4m | startup to 16 MB (ms) | 2877 | 1662 |
| B2 slow-4m | steady MB/s | 52 | 56 |
| B6 | stream MB/s under import | 245 | 251 |
| B9 | articles for open + jump | 66 | 66 |

Note on B1 slow-4m: the scenario opens 20 handles back to back; each open now fetches its full window after the first byte, and the next open's demand article queues behind the previous handle's still-draining 240 MB tail. With the window held at 2 for the whole scenario the same loop measured 115 ms. Cancelling in-flight bodies when a handle closes is the body-depth PR's job. B9 shows the same effect: the 2 MB head read pulls the full window, so the jump saves nothing yet.

## Live A/B (dev server, real providers, single samples)

| file | ttfb #897 | ttfb this PR | seek p50 #897 | seek p50 this PR | MB/s #897 | MB/s this PR |
|---|---|---|---|---|---|---|
| Supergirl S04E21 1080p | 111 | 75 | 73 | 66 | 52.0 | 52.0 |
| Avatar Fire and Ash 1080p | 67 | 96 | 82 | 70 | 119.4 | 126.4 |
| The Penguin S01E08 2160p remux | 83 | 117 | 104 | 80 | 124.7 | 127.8 |

## Test plan
- [x] reader tests: large-article hold before first byte; opening window on small articles then full; import readers unaffected; `BufferedAhead` accounting
- [x] `MetadataVirtualFile` tests: jump beyond the buffer reopens (≤ 12 fetches instead of ≥ 44); skip inside the buffer keeps the reader; head read fans out at most 16 before the first byte
- [x] `go test -race` on `internal/usenet`, `internal/nzbfilesystem`
- [x] benchmark and live tables above