### PR TITLE
fix(deps): bump gopar-turbo to v0.2.1 for libc++ cross-link

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/hanwen/go-fuse/v2 v2.9.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v5 v5.8.0
-	github.com/javi11/gopar-turbo v0.2.0
+	github.com/javi11/gopar-turbo v0.2.1
 	github.com/javi11/nntppool/v4 v4.20.1
 	github.com/javi11/nxg v0.1.0
 	github.com/javi11/nzbparser v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -378,6 +378,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/javi11/gopar-turbo v0.2.0 h1:pTlGPTZ3VR+zhhh4gb3BgzPm+cybFGbRnCTimVUOu8U=
 github.com/javi11/gopar-turbo v0.2.0/go.mod h1:fOQZIbPz+ADJ8vGAzVLXvQhsOsE08hvAcev8nQvBFfY=
+github.com/javi11/gopar-turbo v0.2.1 h1:0xUZtofwBcjxle6QIl9EZAwxmLtWkECMM69tQhmc9iA=
+github.com/javi11/gopar-turbo v0.2.1/go.mod h1:fOQZIbPz+ADJ8vGAzVLXvQhsOsE08hvAcev8nQvBFfY=
 github.com/javi11/nntppool/v4 v4.20.1 h1:tAJ36VPw7L5s9XOdojPpAlTCh2Plg3A4MyDROcK2Mu4=
 github.com/javi11/nntppool/v4 v4.20.1/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
 github.com/javi11/nxg v0.1.0 h1:CTThldYlaVIPIhpkrMw0HcTD0NLrW1uYMoDILjjEOtM=


### PR DESCRIPTION
Fixes the `Publish Dev CLI Binaries / build-cli` failures on `linux/amd64`, `linux/arm64` and `windows/amd64` (e.g. [run 33863407245](https://github.com/javi11/altmount/actions/runs/33863407245/job/100998985898)).

## Root cause

`gopar-turbo`'s prebuilt `libgf16_{linux_amd64,linux_arm64,windows_amd64}.a` are GCC-built, so `gf16mul.cpp`'s `std::vector<Galois16Methods>` instantiation references the libstdc++-internal helper `std::__throw_length_error(char const*)`. Our CLI cross-builds link with `zig cc`, whose `-lstdc++` is LLVM **libc++**, which has no such symbol:

```
ld.lld: error: undefined symbol: std::__throw_length_error(char const*)
>>> referenced by gf16mul.cpp
>>>               gf16mul.cpp.o:(std::vector<Galois16Methods>::_M_realloc_insert<Galois16Methods>(...))
    in archive libgf16_linux_amd64.a
```

`darwin` was unaffected (its archive is clang/libc++-built) and the Docker images were unaffected (alpine `g++` supplies real libstdc++) — which matches exactly which jobs failed. Introduced by #829, which added the `gopar-turbo` dependency.

## Fix

Fixed upstream in javi11/gopar-turbo#4, released as `v0.2.1`. The helper now ships in a separate `libgf16_compat_<platform>.a` listed **after** `-lstdc++` in the cgo LDFLAGS: archives are only searched for symbols still undefined at that point, so libstdc++ builds resolve it from `-lstdc++` and never extract the member, while libc++ builds pick it up and link.

## Verification

Real CLI build (`-tags=cli`), zig 0.16.0, against published `v0.2.1`:

| target | before | after |
|---|---|---|
| `linux/amd64` (`x86_64-linux-musl`) | undefined symbol | OK |
| `linux/arm64` (`aarch64-linux-musl`) | undefined symbol | OK |
| `windows/amd64` (`x86_64-windows-gnu`) | undefined symbol | OK |
| `darwin` (native) | OK | OK |

Upstream `test` workflow is green on every native GCC/MinGW/clang target, confirming the libstdc++ link path is untouched.