### PR TITLE
feat(segcache): in-memory tier for decoded articles

### DIFF
--- a/bench/results/phase6-memory-segcache.json
+++ b/bench/results/phase6-memory-segcache.json
@@ -1,0 +1,348 @@
+{
+  "git_sha": "cf096fa0",
+  "timestamp": "2026-09-04T15:52:48.039657Z",
+  "scenarios": [
+    {
+      "name": "B1-cold-open/premium-750k",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 46.037539,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 47.74175,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 57.252042,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 60,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B1-cold-open/slow-4m",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 3820.662541,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 3902.631375,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 5214.910708,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 60,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/premium-750k",
+      "metrics": [
+        {
+          "name": "startup_ms",
+          "unit": "ms",
+          "value": 229.520541,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 260.12903955481175,
+          "higher_is_better": true
+        },
+        {
+          "name": "throughput_total",
+          "unit": "MB/s",
+          "value": 220.14933279616895,
+          "higher_is_better": true,
+          "informational": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 1.235035972595215,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/slow-4m",
+      "metrics": [
+        {
+          "name": "startup_ms",
+          "unit": "ms",
+          "value": 1595.944625,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 46.77750889438227,
+          "higher_is_better": true
+        },
+        {
+          "name": "throughput_total",
+          "unit": "MB/s",
+          "value": 42.62134988048728,
+          "higher_is_better": true,
+          "informational": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 1.4828615808486938,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/premium-750k",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 155.654375,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 165.887042,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1.05,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/slow-4m",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 1648.820084,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 1692.25375,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/premium-750k",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/slow-4m",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B4-four-streams/premium-750k",
+      "metrics": [
+        {
+          "name": "min_stream_mbps",
+          "unit": "MB/s",
+          "value": 192.58447063498667,
+          "higher_is_better": true,
+          "tolerance": 0.12
+        },
+        {
+          "name": "max_stream_mbps",
+          "unit": "MB/s",
+          "value": 192.60354246065472,
+          "higher_is_better": true
+        },
+        {
+          "name": "stall_p99",
+          "unit": "ms",
+          "value": 47.4465,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B5-two-handles/premium-750k",
+      "metrics": [
+        {
+          "name": "duplicate_bodies",
+          "unit": "count",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B6-contention/premium-750k",
+      "metrics": [
+        {
+          "name": "stream_mbps",
+          "unit": "MB/s",
+          "value": 225.73542869342705,
+          "higher_is_better": true,
+          "tolerance": 0.15
+        },
+        {
+          "name": "stream_startup_ms",
+          "unit": "ms",
+          "value": 241.159583,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "stream_p50",
+          "unit": "ms",
+          "value": 0.0355,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "stream_p99",
+          "unit": "ms",
+          "value": 68.035291,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "import_mbps",
+          "unit": "MB/s",
+          "value": 138.7820603787593,
+          "higher_is_better": true
+        }
+      ]
+    },
+    {
+      "name": "B7-failover/premium-750k",
+      "metrics": [
+        {
+          "name": "miss_ttfb_mean",
+          "unit": "ms",
+          "value": 166.898443,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "miss_ttfb_p50",
+          "unit": "ms",
+          "value": 159.076416,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "bodies_per_miss",
+          "unit": "count",
+          "value": 1,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B9-forward-skip/premium-750k",
+      "metrics": [
+        {
+          "name": "jump_read_ms",
+          "unit": "ms",
+          "value": 155.948125,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 66,
+          "higher_is_better": false
+        },
+        {
+          "name": "open_articles",
+          "unit": "count",
+          "value": 62,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B10-replay/premium-750k",
+      "metrics": [
+        {
+          "name": "replay_bytes_fetched_mb",
+          "unit": "MB",
+          "value": 31.24789810180664,
+          "higher_is_better": false
+        },
+        {
+          "name": "replay_read_ms",
+          "unit": "ms",
+          "value": 4.233208,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        }
+      ]
+    }
+  ]
+}

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -38,6 +38,14 @@ streaming:
     enabled: true # Automatically hide files from mounts after repeated failures
     threshold: 3 # Number of streaming failures before masking a file
 
+# Segment cache: decoded articles kept for reuse across handles and re-opens.
+segment_cache:
+  memory_mb: 256 # In-memory tier in front of the disk cache; on even when the disk cache is off (0 disables)
+  enabled: false # Disk tier
+  cache_path: /tmp/altmount-segcache
+  max_size_gb: 10
+  expiry_hours: 24
+
 # RClone configuration (optional)
 rclone:
   # Base path for rclone configuration directory

--- a/docs/superpowers/plans/2026-09-04-streaming-body-depth.md
+++ b/docs/superpowers/plans/2026-09-04-streaming-body-depth.md
@@ -1,0 +1,59 @@
+# Stream Body Depth and Abandoned-Drain Abort Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop a closed handle's read-ahead from draining through the wire after a seek or episode change, and bound how many stream bodies queue on one connection ahead of a demand read (spec phase 7, defect D9, plus the tail effect measured in phases 4 and 5).
+
+**Architecture (nntppool, released as v4.22.0):**
+1. **Abandoned-drain abort.** In `readerLoop`, a body whose request context is done is currently drained to `io.Discard`. When the bytes still to come exceed `Provider.AbortDrainBytes` (default 1 MiB; 0 keeps the old behaviour), the reader closes the connection instead. Pending neighbours fail with `ErrConnectionDied` and the existing connection-death retry re-dispatches the ones still wanted; the slot reconnects (TLS resumption from phase 1 makes that one round trip). Articles under the threshold keep draining, since a reconnect costs more than 94 ms of 750 KB. Remaining bytes come from the yEnc part size the decoder already parsed minus bytes decoded; when the size is unknown, drain as before.
+2. **Stream body depth.** `Provider.StreamInflight` (default `min(Inflight, 4)`) caps priority-lane bodies in flight per connection through a second semaphore taken alongside `bodySem`, so a demand read never queues behind more than three stream bodies on its connection. Normal-lane (import) bodies keep `Inflight`.
+
+**Architecture (altmount):** `ToNNTPProvider` sets `StreamInflight` from a new `providers[].stream_inflight_requests` (default 4) and leaves `AbortDrainBytes` at the library default. New bench scenario B11 measures the seek pattern the abort targets.
+
+**Spec:** `docs/superpowers/specs/2026-09-04-streaming-demand-shaping-design.md` (Phase 7)
+
+## Global Constraints
+
+- No competitor names in code, comments, commits, PRs.
+- Conventional Commits; branch `feat/streaming-body-depth` from `feat/streaming-memory-segcache`; nntppool branch `feat/abort-drain-stream-depth`.
+- `make bench-compare BASE=baseline-main`: no regressions; B1 slow-4m cold open and B11 must improve; B2/B6 steady state must hold.
+- No `replace` in `go.mod` when the PR is marked ready.
+
+---
+
+### Task 1: B11 seek scenario, pre-sampled
+
+`BenchmarkStreamSeekAndResume` (both profiles): open, read 8 MB at 0, then five times: jump forward 500 MB, read 8 MB. Metrics: `seek_read_ms` mean of the five (gated, tolerance 0.10), `bytes_fetched_mb` for the whole scenario (gated), expected today to include the abandoned windows.
+
+- [ ] Add, commit `test(bench): seek-and-resume scenario`, sample once on this branch.
+
+### Task 2: nntppool abandoned-drain abort
+
+**Files:** `~/mio/nntppool/nntp.go` (`Provider.AbortDrainBytes`, `NNTPConnection.abortDrainBytes`, readerLoop drain callback), `~/mio/nntppool/abort_drain_test.go`.
+
+In the drain callback, once `deliver` has flipped to false: `remaining := decoder.expectedRemaining()` (part size minus bytes decoded, -1 when unknown); if `remaining > c.abortDrainBytes && c.abortDrainBytes > 0`, return a sentinel deadline in the past so `feedUntilDone` returns a timeout, and mark `c.abortDrain = true` so the timeout handling closes the connection with `connDiedErr` rather than treating it as a stall. Verify how `readerLoop` turns read errors into connection death (`nntp.go:1499-1518`) and reuse that path.
+
+- [ ] Test with a `net.Pipe` server (pattern: `TestClient_BodyPriority`): serve a 4 MB yEnc body slowly (writer sleeps per 64 KB); cancel the request context after the first chunk; assert the server sees its connection closed within 500 ms and that a following `Body` on the client succeeds (new connection). Second test: 200 KB body, cancel, assert the connection is *not* closed (drained) and the next request reuses it (server connection count stays 1).
+- [ ] Implement; `go test ./ -run 'AbortDrain|BodyPriority|Slow'`; commit `feat(conn): abort draining an abandoned body when more than AbortDrainBytes remain`.
+
+### Task 3: nntppool stream body depth
+
+**Files:** `~/mio/nntppool/nntp.go` (`Provider.StreamInflight`, `NNTPConnection.prioBodySem`, writer acquire/release paths), `~/mio/nntppool/stream_depth_test.go`.
+
+Where the writer takes `bodySem` for a body-bearing request (`nntp.go:~992`), also take `prioBodySem` when `req.priority`; release both where `bodySem` is released. `Request` must carry `priority bool` (set in `tryGroupTimeout` from the lane). Default `StreamInflight = min(Inflight, 4)`; `StreamInflight >= Inflight` disables the extra bound.
+
+- [ ] Test: single connection, `Inflight: 10, StreamInflight: 2`, server holds bodies until released; issue 4 `BodyPriority`; assert the server has received only 2 BODY commands until one completes. Control: 4 `Body` (normal) → all 4 received.
+- [ ] Implement; full nntppool suite; commit `feat(conn): cap priority-lane bodies per connection with StreamInflight`; tag `v4.22.0` after altmount validation (Task 5).
+
+### Task 4: altmount wiring
+
+**Files:** `internal/config/manager.go` (`ProviderConfig.StreamInflightRequests`, `ToNNTPProvider`), `internal/config/provider_nntp_test.go`, `config.sample.yaml`, `frontend/src/types/config.ts` (optional field), bench harness (`benchProfile.StreamInflight`).
+
+- [ ] Tests: default 4; explicit value passes through; capped at `inflight_requests`.
+- [ ] Commit `feat(pool): stream_inflight_requests per provider`.
+
+### Task 5: Benchmark, live, release, PR
+
+- [ ] `go mod edit -replace` to `~/mio/nntppool`, `make bench-stream`, compare. Expect: B11 bytes fetched down sharply on slow-4m and seek read time down; B1 slow-4m cold open well under 1 s (the next open no longer queues behind the previous handle's tail); B2/B6 steady state within tolerance. If B2 steady state on the premium profile drops with `StreamInflight 4`, raise the default to 6 and re-measure before accepting.
+- [ ] Live: `bench-live.sh body-depth`; additionally seek-storm one 2160p file with ten ranged reads 1 GB apart and compare provider bytes delivered before/after (dashboard metrics or the pool stats endpoint).
+- [ ] Release nntppool v4.22.0 (fast-forward `main`, tag, push), drop the replace, `go get`, commit `chore(deps): nntppool v4.22.0`, push, `gh pr create --base feat/streaming-memory-segcache`.

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -213,6 +213,21 @@ type SegmentCacheConfig struct {
 	// eviction. Set to 0 to disable expiry (cache forever, bounded only by
 	// MaxSizeGB via LRU eviction). Left unset (nil) it defaults to 24 hours.
 	ExpiryHours *int `yaml:"expiry_hours" mapstructure:"expiry_hours" json:"expiry_hours"`
+	// MemoryMB bounds the in-memory tier of decoded articles that sits in
+	// front of the disk cache and is on even when the disk cache is off.
+	// Left unset (nil) it defaults to 256; an explicit 0 disables it.
+	MemoryMB *int `yaml:"memory_mb" mapstructure:"memory_mb" json:"memory_mb"`
+}
+
+// defaultSegmentCacheMemoryMB is the memory tier size when memory_mb is unset.
+const defaultSegmentCacheMemoryMB = 256
+
+// MemoryBytes is the memory tier budget in bytes (0 = disabled).
+func (c SegmentCacheConfig) MemoryBytes() int64 {
+	if c.MemoryMB == nil {
+		return int64(defaultSegmentCacheMemoryMB) << 20
+	}
+	return int64(max(*c.MemoryMB, 0)) << 20
 }
 
 // WebDAVConfig represents WebDAV server configuration
@@ -1011,6 +1026,10 @@ func (c *Config) Validate() error {
 	if c.SegmentCache.ExpiryHours == nil {
 		defaultExpiryHours := 24
 		c.SegmentCache.ExpiryHours = &defaultExpiryHours
+	}
+	if c.SegmentCache.MemoryMB == nil {
+		memoryMB := defaultSegmentCacheMemoryMB
+		c.SegmentCache.MemoryMB = &memoryMB
 	}
 
 	if c.Import.MaxProcessorWorkers <= 0 {

--- a/internal/nzbfilesystem/segcache/memory.go
+++ b/internal/nzbfilesystem/segcache/memory.go
@@ -1,0 +1,170 @@
+package segcache
+
+import (
+	"container/list"
+	"hash/fnv"
+	"sync"
+	"sync/atomic"
+)
+
+// MemoryCache keeps recently decoded articles in memory, keyed by message-ID
+// and bounded by bytes. It sits in front of the disk cache so a probe
+// followed by playback, or a second handle on the same title, is served
+// without a round trip.
+//
+// Lookups take only a read lock on their shard and mark the entry touched;
+// recency is applied lazily by the eviction sweep (CLOCK, second chance), so
+// a single stream driving thousands of lookups a second never contends on
+// the recency list. Lock order is orderMu, then a shard mutex, never the
+// reverse: two puts of one id must not interleave and leak bytes against
+// the budget.
+type MemoryCache struct {
+	shards [memShards]memShard
+
+	orderMu  sync.Mutex
+	order    *list.List // front = most recently inserted or second-chanced
+	size     int64
+	capacity int64
+}
+
+const memShards = 16
+
+// memEntryOverhead is the fixed bookkeeping charged per entry so thousands
+// of small articles are not invisible to the budget.
+const memEntryOverhead = 128
+
+type memShard struct {
+	mu sync.RWMutex
+	m  map[string]*memEntry
+}
+
+type memEntry struct {
+	id      string
+	data    []byte
+	touched atomic.Bool
+	elem    *list.Element
+}
+
+func NewMemoryCache(maxBytes int64) *MemoryCache {
+	m := &MemoryCache{order: list.New(), capacity: max(maxBytes, 0)}
+	for i := range m.shards {
+		m.shards[i].m = make(map[string]*memEntry)
+	}
+	return m
+}
+
+func (m *MemoryCache) shard(id string) *memShard {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(id))
+	return &m.shards[h.Sum32()%memShards]
+}
+
+func entryCost(data []byte) int64 { return int64(cap(data)) + memEntryOverhead }
+
+// Get returns the cached article and marks it recently used.
+func (m *MemoryCache) Get(id string) ([]byte, bool) {
+	if m == nil {
+		return nil, false
+	}
+	s := m.shard(id)
+	s.mu.RLock()
+	e, ok := s.m[id]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	e.touched.Store(true)
+	return e.data, true
+}
+
+// Put stores an article, evicting the least recently used entries as needed.
+// The budget charges capacity, not length, since that is the memory held.
+// An article larger than the whole budget is not cached rather than
+// thrashing everything else out.
+func (m *MemoryCache) Put(id string, data []byte) {
+	if m == nil || len(data) == 0 {
+		return
+	}
+	cost := entryCost(data)
+	m.orderMu.Lock()
+	defer m.orderMu.Unlock()
+	if m.capacity <= 0 || cost > m.capacity {
+		return
+	}
+	s := m.shard(id)
+	s.mu.Lock()
+	if old, ok := s.m[id]; ok {
+		m.order.Remove(old.elem)
+		m.size -= entryCost(old.data)
+	}
+	e := &memEntry{id: id, data: data}
+	e.elem = m.order.PushFront(e)
+	s.m[id] = e
+	m.size += cost
+	s.mu.Unlock()
+	m.evictLocked()
+}
+
+// evictLocked walks from the cold end until the cache fits its budget. A
+// touched entry is cleared and moved to the front instead of dropped; the
+// walk is bounded so a second pass over the same entry does evict it.
+func (m *MemoryCache) evictLocked() {
+	chances := m.order.Len()
+	for m.size > m.capacity && m.order.Len() > 0 {
+		back := m.order.Back()
+		e := back.Value.(*memEntry)
+		if chances > 0 && e.touched.CompareAndSwap(true, false) {
+			m.order.MoveToFront(back)
+			chances--
+			continue
+		}
+		m.order.Remove(back)
+		s := m.shard(e.id)
+		s.mu.Lock()
+		if s.m[e.id] == e {
+			delete(s.m, e.id)
+		}
+		s.mu.Unlock()
+		m.size -= entryCost(e.data)
+	}
+}
+
+// SetCapacity changes the byte budget, evicting immediately when shrinking.
+func (m *MemoryCache) SetCapacity(maxBytes int64) {
+	if m == nil {
+		return
+	}
+	m.orderMu.Lock()
+	defer m.orderMu.Unlock()
+	m.capacity = max(maxBytes, 0)
+	m.evictLocked()
+}
+
+func (m *MemoryCache) Capacity() int64 {
+	if m == nil {
+		return 0
+	}
+	m.orderMu.Lock()
+	defer m.orderMu.Unlock()
+	return m.capacity
+}
+
+// Size is the bytes currently charged to the budget.
+func (m *MemoryCache) Size() int64 {
+	if m == nil {
+		return 0
+	}
+	m.orderMu.Lock()
+	defer m.orderMu.Unlock()
+	return m.size
+}
+
+// Len is the number of cached articles.
+func (m *MemoryCache) Len() int {
+	if m == nil {
+		return 0
+	}
+	m.orderMu.Lock()
+	defer m.orderMu.Unlock()
+	return m.order.Len()
+}

--- a/internal/nzbfilesystem/segcache/memory_test.go
+++ b/internal/nzbfilesystem/segcache/memory_test.go
@@ -1,0 +1,78 @@
+package segcache
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func mb(n int) []byte { return bytes.Repeat([]byte{1}, n<<20) }
+
+func TestMemoryCacheHitAndMiss(t *testing.T) {
+	c := NewMemoryCache(8 << 20)
+	if _, ok := c.Get("a"); ok {
+		t.Fatal("empty cache must miss")
+	}
+	c.Put("a", []byte{1, 2, 3})
+	got, ok := c.Get("a")
+	if !ok || !bytes.Equal(got, []byte{1, 2, 3}) {
+		t.Fatalf("hit: %v %v", got, ok)
+	}
+}
+
+func TestMemoryCacheStaysWithinBudget(t *testing.T) {
+	c := NewMemoryCache(4 << 20)
+	for i := 0; i < 10; i++ {
+		c.Put(fmt.Sprint(i), mb(1))
+	}
+	if c.Len() > 3 || c.Size() > 4<<20 {
+		t.Fatalf("len=%d size=%d over a 4 MB budget", c.Len(), c.Size())
+	}
+	if _, ok := c.Get("9"); !ok {
+		t.Fatal("the newest entry must survive")
+	}
+}
+
+func TestMemoryCacheSecondChanceKeepsTouchedEntries(t *testing.T) {
+	c := NewMemoryCache(3<<20 + 3*memEntryOverhead)
+	c.Put("old-touched", mb(1))
+	c.Put("old-cold", mb(1))
+	c.Put("mid", mb(1))
+	c.Get("old-touched") // marks it recently used
+	c.Put("new", mb(1))  // forces one eviction
+	if _, ok := c.Get("old-touched"); !ok {
+		t.Fatal("a touched entry must get a second chance")
+	}
+	if _, ok := c.Get("old-cold"); ok {
+		t.Fatal("the untouched oldest entry must be the one evicted")
+	}
+}
+
+func TestMemoryCacheSkipsOversizeAndReplacesInPlace(t *testing.T) {
+	c := NewMemoryCache(2 << 20)
+	c.Put("huge", mb(3))
+	if c.Len() != 0 {
+		t.Fatal("an article larger than the budget must not be cached")
+	}
+	c.Put("a", mb(1))
+	c.Put("a", mb(1))
+	if c.Len() != 1 || c.Size() != int64(1<<20)+memEntryOverhead {
+		t.Fatalf("replace must not leak: len=%d size=%d", c.Len(), c.Size())
+	}
+}
+
+func TestMemoryCacheShrinkEvicts(t *testing.T) {
+	c := NewMemoryCache(8 << 20)
+	for i := 0; i < 6; i++ {
+		c.Put(fmt.Sprint(i), mb(1))
+	}
+	c.SetCapacity(2 << 20)
+	if c.Len() > 1 || c.Size() > 2<<20 {
+		t.Fatalf("shrink must evict: len=%d size=%d", c.Len(), c.Size())
+	}
+	var nilCache *MemoryCache
+	nilCache.Put("x", mb(1))
+	if _, ok := nilCache.Get("x"); ok {
+		t.Fatal("nil cache must be inert")
+	}
+}

--- a/internal/nzbfilesystem/segcache/source.go
+++ b/internal/nzbfilesystem/segcache/source.go
@@ -1,18 +1,23 @@
 package segcache
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/usenet"
 )
 
-// Source is a thin wrapper around an atomic Manager pointer that resolves the
-// active SegmentStore on demand. It is the single value threaded through the
-// application instead of passing raw atomic pointers and getter closures.
+// Source resolves the SegmentStore readers use: a memory tier that is on by
+// default, in front of the optional disk cache owned by Manager. It is the
+// single value threaded through the application instead of passing raw
+// atomic pointers and getter closures.
 type Source struct {
 	ptr    atomic.Pointer[Manager]
 	getCfg config.ConfigGetter
+
+	once   sync.Once
+	tiered *TieredStore
 }
 
 // NewSource creates a Source. getCfg must not be nil.
@@ -20,19 +25,24 @@ func NewSource(getCfg config.ConfigGetter) *Source {
 	return &Source{getCfg: getCfg}
 }
 
-// Store resolves the current SegmentStore. Returns nil if the cache is
-// disabled in config or no manager has been loaded yet.
-// Call once at file-open time and pass the result to UsenetReader.
+// Store resolves the current SegmentStore: nil only when both the memory
+// and the disk tier are disabled. Call once at file-open time and pass the
+// result to UsenetReader. Capacity changes in config apply on the next open.
 func (s *Source) Store() usenet.SegmentStore {
-	mgr := s.ptr.Load()
-	if mgr == nil {
-		return nil
-	}
 	cfg := s.getCfg()
-	if cfg.SegmentCache.Enabled == nil || !*cfg.SegmentCache.Enabled {
+	memBytes := int64(cfg.SegmentCache.MemoryBytes())
+
+	var disk usenet.SegmentStore
+	if mgr := s.ptr.Load(); mgr != nil && cfg.SegmentCache.Enabled != nil && *cfg.SegmentCache.Enabled {
+		disk = mgr.Cache()
+	}
+	if memBytes <= 0 && disk == nil {
 		return nil
 	}
-	return mgr.Cache()
+	s.once.Do(func() { s.tiered = NewTieredStore(NewMemoryCache(memBytes)) })
+	s.tiered.Memory().SetCapacity(memBytes)
+	s.tiered.SetDisk(disk)
+	return s.tiered
 }
 
 // Swap replaces the active manager. Pass nil to unload the current manager.
@@ -44,4 +54,12 @@ func (s *Source) Swap(mgr *Manager) {
 // Manager returns the current manager for stats access. May be nil.
 func (s *Source) Manager() *Manager {
 	return s.ptr.Load()
+}
+
+// Memory returns the memory tier for stats, or nil before the first open.
+func (s *Source) Memory() *MemoryCache {
+	if s.tiered == nil {
+		return nil
+	}
+	return s.tiered.Memory()
 }

--- a/internal/nzbfilesystem/segcache/tiered.go
+++ b/internal/nzbfilesystem/segcache/tiered.go
@@ -1,0 +1,96 @@
+package segcache
+
+import (
+	"sync/atomic"
+
+	"github.com/javi11/altmount/internal/usenet"
+)
+
+// TieredStore is the SegmentStore readers see: a memory tier in front of an
+// optional disk tier. Reads try memory, then disk (promoting the hit);
+// writes land in memory at once and reach disk through a bounded async
+// writer, so a 750 KB file write never sits on the download goroutine.
+type TieredStore struct {
+	mem     *MemoryCache
+	disk    atomic.Pointer[diskRef]
+	writes  chan diskWrite
+	dropped atomic.Int64
+}
+
+type diskRef struct{ store usenet.SegmentStore }
+
+type diskWrite struct {
+	id   string
+	data []byte
+}
+
+// diskWriteQueue bounds how many decoded articles wait for the disk. A full
+// queue drops the write (the memory tier still has the bytes) rather than
+// stalling playback behind a slow disk.
+const diskWriteQueue = 64
+
+func NewTieredStore(mem *MemoryCache) *TieredStore {
+	t := &TieredStore{mem: mem, writes: make(chan diskWrite, diskWriteQueue)}
+	go t.writer()
+	return t
+}
+
+// SetDisk installs or removes (nil) the disk tier.
+func (t *TieredStore) SetDisk(d usenet.SegmentStore) {
+	if d == nil {
+		t.disk.Store(nil)
+		return
+	}
+	t.disk.Store(&diskRef{store: d})
+}
+
+func (t *TieredStore) diskStore() usenet.SegmentStore {
+	if r := t.disk.Load(); r != nil {
+		return r.store
+	}
+	return nil
+}
+
+// Get returns the article from memory, else from disk (promoting it).
+func (t *TieredStore) Get(id string) ([]byte, bool) {
+	if data, ok := t.mem.Get(id); ok {
+		return data, true
+	}
+	d := t.diskStore()
+	if d == nil {
+		return nil, false
+	}
+	data, ok := d.Get(id)
+	if ok {
+		t.mem.Put(id, data)
+	}
+	return data, ok
+}
+
+// Put stores the article in memory now and on disk asynchronously.
+func (t *TieredStore) Put(id string, data []byte) error {
+	t.mem.Put(id, data)
+	if t.diskStore() == nil {
+		return nil
+	}
+	select {
+	case t.writes <- diskWrite{id: id, data: data}:
+	default:
+		t.dropped.Add(1)
+	}
+	return nil
+}
+
+// Dropped counts disk writes skipped because the queue was full.
+func (t *TieredStore) Dropped() int64 { return t.dropped.Load() }
+
+// Memory exposes the memory tier for stats and capacity changes.
+func (t *TieredStore) Memory() *MemoryCache { return t.mem }
+
+func (t *TieredStore) writer() {
+	for w := range t.writes {
+		if d := t.diskStore(); d != nil {
+			_ = d.Put(w.id, w.data)
+		}
+	}
+}

--- a/internal/nzbfilesystem/segcache/tiered_test.go
+++ b/internal/nzbfilesystem/segcache/tiered_test.go
@@ -1,0 +1,86 @@
+package segcache
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type fakeDisk struct {
+	mu   sync.Mutex
+	m    map[string][]byte
+	gets atomic.Int64
+}
+
+func newFakeDisk() *fakeDisk { return &fakeDisk{m: map[string][]byte{}} }
+
+func (d *fakeDisk) Get(id string) ([]byte, bool) {
+	d.gets.Add(1)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	v, ok := d.m[id]
+	return v, ok
+}
+
+func (d *fakeDisk) Put(id string, data []byte) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.m[id] = data
+	return nil
+}
+
+func (d *fakeDisk) has(id string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	_, ok := d.m[id]
+	return ok
+}
+
+func TestTieredMemoryHitAvoidsDisk(t *testing.T) {
+	disk := newFakeDisk()
+	ts := NewTieredStore(NewMemoryCache(8 << 20))
+	ts.SetDisk(disk)
+	_ = ts.Put("a", []byte{1})
+	if _, ok := ts.Get("a"); !ok || disk.gets.Load() != 0 {
+		t.Fatalf("memory hit must not touch disk (gets=%d)", disk.gets.Load())
+	}
+}
+
+func TestTieredDiskHitIsPromoted(t *testing.T) {
+	disk := newFakeDisk()
+	_ = disk.Put("b", []byte{2})
+	ts := NewTieredStore(NewMemoryCache(8 << 20))
+	ts.SetDisk(disk)
+	if _, ok := ts.Get("b"); !ok {
+		t.Fatal("disk hit expected")
+	}
+	if _, ok := ts.Get("b"); !ok || disk.gets.Load() != 1 {
+		t.Fatalf("second lookup must be served from memory (disk gets=%d)", disk.gets.Load())
+	}
+}
+
+func TestTieredPutReachesDiskAsynchronously(t *testing.T) {
+	disk := newFakeDisk()
+	ts := NewTieredStore(NewMemoryCache(8 << 20))
+	ts.SetDisk(disk)
+	_ = ts.Put("c", []byte{3})
+	deadline := time.Now().Add(2 * time.Second)
+	for !disk.has("c") && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if !disk.has("c") {
+		t.Fatal("disk write never arrived")
+	}
+}
+
+func TestTieredWithoutDiskIsMemoryOnly(t *testing.T) {
+	ts := NewTieredStore(NewMemoryCache(8 << 20))
+	_ = ts.Put("d", []byte{4})
+	if _, ok := ts.Get("d"); !ok || ts.Dropped() != 0 {
+		t.Fatal("memory-only store must serve and not count drops")
+	}
+	if _, ok := ts.Get("missing"); ok {
+		t.Fatal("miss expected")
+	}
+}

--- a/internal/nzbfilesystem/stream_bench_harness_test.go
+++ b/internal/nzbfilesystem/stream_bench_harness_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/javi11/altmount/internal/pool"
 	"github.com/javi11/altmount/internal/streambench"
 	"github.com/javi11/altmount/internal/testsupport/nntpserver"
+	"github.com/javi11/altmount/internal/usenet"
 	"github.com/javi11/nntppool/v4"
 )
 
@@ -77,6 +78,9 @@ type benchHarness struct {
 	cancel  context.CancelFunc
 	profile benchProfile
 	streams *benchStreams
+	// store, when set, is handed to every file opened afterwards as its
+	// segment store (nil = no cache, the default for most scenarios).
+	store usenet.SegmentStore
 }
 
 // newBenchHarness starts one simulated provider per cfg (defaults to a
@@ -180,6 +184,7 @@ func (h *benchHarness) openFile(tb testing.TB, nSegs, maxPrefetch int, rangeEnd 
 		originalRangeEnd: rangeEnd,
 		streamTracker:    noopStreamTracker{},
 		streamID:         "bench-stream",
+		segmentStore:     h.store,
 	}
 	tb.Cleanup(func() { _ = mvf.Close() })
 	return mvf

--- a/internal/nzbfilesystem/stream_bench_store_test.go
+++ b/internal/nzbfilesystem/stream_bench_store_test.go
@@ -1,7 +1,12 @@
 package nzbfilesystem
 
-import "github.com/javi11/altmount/internal/usenet"
+import (
+	"github.com/javi11/altmount/internal/nzbfilesystem/segcache"
+	"github.com/javi11/altmount/internal/usenet"
+)
 
 // benchReplayStore is the segment store the replay scenario opens files
-// with. Nil until a shared cache tier exists.
-func benchReplayStore() usenet.SegmentStore { return nil }
+// with: the default memory tier, no disk.
+func benchReplayStore() usenet.SegmentStore {
+	return segcache.NewTieredStore(segcache.NewMemoryCache(256 << 20))
+}

--- a/internal/nzbfilesystem/stream_bench_store_test.go
+++ b/internal/nzbfilesystem/stream_bench_store_test.go
@@ -1,0 +1,7 @@
+package nzbfilesystem
+
+import "github.com/javi11/altmount/internal/usenet"
+
+// benchReplayStore is the segment store the replay scenario opens files
+// with. Nil until a shared cache tier exists.
+func benchReplayStore() usenet.SegmentStore { return nil }

--- a/internal/nzbfilesystem/stream_bench_test.go
+++ b/internal/nzbfilesystem/stream_bench_test.go
@@ -468,3 +468,41 @@ func BenchmarkStreamForwardSkip(b *testing.B) {
 		}
 	})
 }
+
+// BenchmarkStreamReplay reads the head of a file, closes it, and reads the
+// same head again through a fresh handle: the media-server pattern of a
+// probe followed by playback. With a memory tier the second pass should
+// fetch nothing.
+func BenchmarkStreamReplay(b *testing.B) {
+	p := profilePremium750K
+	h := newBenchHarness(b, p)
+	h.store = benchReplayStore()
+	const head = 32 << 20
+	readHead := func() time.Duration {
+		mvf := h.openFile(b, benchFileSegs, benchPrefetch, -1)
+		buf := make([]byte, 1<<20)
+		start := time.Now()
+		var off int64
+		for off < head {
+			n, err := mvf.ReadAt(buf, off)
+			if err != nil {
+				b.Fatalf("ReadAt: %v", err)
+			}
+			off += int64(n)
+		}
+		d := time.Since(start)
+		_ = mvf.Close()
+		h.awaitQuietWire(500*time.Millisecond, 30*time.Second)
+		return d
+	}
+	record(b, scenario("B10-replay", p), func() []streambench.Metric {
+		readHead()
+		before := h.bytesWritten()
+		replay := readHead()
+		fetched := float64(h.bytesWritten()-before) / (1 << 20)
+		return []streambench.Metric{
+			{Name: "replay_bytes_fetched_mb", Unit: "MB", Value: fetched},
+			{Name: "replay_read_ms", Unit: "ms", Value: ms(replay), Tolerance: 0.10},
+		}
+	})
+}

--- a/internal/usenet/segment_store_hit_test.go
+++ b/internal/usenet/segment_store_hit_test.go
@@ -1,0 +1,60 @@
+package usenet
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/pool"
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/altmount/internal/testsupport/segments"
+)
+
+type mapStore struct{ m map[string][]byte }
+
+func (s mapStore) Get(id string) ([]byte, bool) { v, ok := s.m[id]; return v, ok }
+func (s mapStore) Put(id string, data []byte) error {
+	s.m[id] = data
+	return nil
+}
+
+// A segment served from the store must reach the reader without a fetch, for
+// streaming and import readers alike.
+func TestSegmentStoreHitIsServedWithoutFetch(t *testing.T) {
+	for _, imp := range []bool{false, true} {
+		ctx := context.Background()
+		const n, segSize = 3, 256
+		fp := fakepool.New()
+		store := mapStore{m: map[string][]byte{}}
+		for i := 0; i < n; i++ {
+			store.m[segments.MessageID(i)] = segments.Payload(i, segSize)
+		}
+		rg := buildEagerRange(ctx, t, n, segSize)
+		getter := func() (pool.NntpClient, error) { return fp, nil }
+		opts := []ReaderOption{withFlightMap(newFlightMap())}
+		if imp {
+			opts = append(opts, WithImportProfile(nil))
+		}
+		ur, err := NewUsenetReader(ctx, getter, rg, 4, noopMetrics{}, "store-test", store, opts...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ur.Start()
+		done := make(chan []byte, 1)
+		go func() { got, _ := io.ReadAll(ur); done <- got }()
+		select {
+		case got := <-done:
+			if !bytes.Equal(got, segments.FileBytes(n, segSize)) {
+				t.Fatalf("import=%v: bytes differ", imp)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatalf("import=%v: read hung on a store hit", imp)
+		}
+		if fp.BodyPriorityCalls()+fp.BodyCalls() != 0 {
+			t.Fatalf("import=%v: store hits must not fetch", imp)
+		}
+		_ = ur.Close()
+	}
+}

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -541,6 +541,9 @@ func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segmen
 				"segment_id", seg.Id,
 				"size_bytes", len(data),
 			)
+			// The fetch path publishes as it streams; a hit has nothing to
+			// stream, so hand the bytes to the segment here.
+			seg.SetData(data)
 			return data, nil
 		}
 	}


### PR DESCRIPTION
Stacked on #899 → #898 → #897 → #896 → #895 → #894.

## Summary
- `segcache.MemoryCache`: a sharded, byte-bounded cache of decoded articles keyed by message-ID with CLOCK (second-chance) eviction. Lookups take a read lock on their shard and mark the entry; recency is applied lazily by the sweep, so a stream driving thousands of lookups a second never contends on the recency list. Budget charges capacity plus a fixed per-entry overhead; an article larger than the budget is not cached.
- `segcache.TieredStore` is what readers now get from `segcache.Source`: memory first, then the disk cache (hits are promoted), and disk writes go through a bounded async writer (queue 64, drop and count on overflow) instead of a synchronous 750 KB file write on the download goroutine.
- The memory tier is **on by default** (`segment_cache.memory_mb: 256`, `0` disables) even with the disk cache off. `config.sample.yaml` gains a documented `segment_cache` block. The per-handle random-read cache stays (cheap, still useful with the tier disabled).
- **Bug found by the new replay scenario and fixed here:** since the progressive-delivery PR, a segment served from the segment store was never published to a streaming reader, so a cache hit hung the read. Nothing in the stack had exercised a store until B10. Regression test added (`TestSegmentStoreHitIsServedWithoutFetch`); it also covers import readers.

## Simulated benchmark (medians of 3)

New scenario B10 (read a 32 MB head, close, reopen, read it again); pre-sampled on #899 with no store:

| Metric | #899 | this PR |
|---|---|---|
| replay read time (ms) | 242 | 4.2 |
| bytes fetched during replay (MB) | 75 | 31 (the read-ahead window past the cached region; the replayed bytes themselves fetch nothing) |

Everything else unchanged within tolerance: B2 steady 260 MB/s premium, 47 MB/s slow; B5 duplicates 0; B6 import 139 MB/s; no REGRESSION rows.

## Live (dev server, real providers)

Warm replay of a 64 MB head on a 2160p remux: 0.82 s cold → 0.09 s warm.

The standard table read 89-91 MB/s on the two large files versus 113-128 earlier today; the #899 build run immediately afterwards read 88 and 68 MB/s, so that is the provider at this hour, not this PR.

| file | ttfb #899 | ttfb this PR | seek p50 #899 | seek p50 this PR |
|---|---|---|---|---|
| Supergirl S04E21 1080p | 66 | 105 / 77 | 74 | 70 / 80 |
| Avatar Fire and Ash 1080p | 73 | 67 / 64 | 76 | 76 / 94 |
| The Penguin S01E08 2160p remux | 79 | 62 / 74 | 78 | 78 / 255 (one outlier, second sample 78) |

## Test plan
- [x] memory cache: hit/miss, budget bound, second chance, oversize skip, in-place replace, shrink
- [x] tiered store: memory hit avoids disk, disk hit promoted, async write arrives, memory-only mode
- [x] store-hit regression test for streaming and import readers
- [x] `go test -race` on `internal/nzbfilesystem/...`, `internal/usenet`, `internal/config`
- [x] benchmark and live checks above