### PR TITLE
feat(pool): abort abandoned drains, cap stream bodies per connection, byte-cap read-ahead

### DIFF
--- a/bench/results/phase7-body-depth.json
+++ b/bench/results/phase7-body-depth.json
@@ -1,0 +1,384 @@
+{
+  "git_sha": "91655e8e",
+  "timestamp": "2026-09-04T16:27:33.267956Z",
+  "scenarios": [
+    {
+      "name": "B1-cold-open/premium-750k",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 46.416623,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 44.572125,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 55.324375,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 60,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B1-cold-open/slow-4m",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 116.576012,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 115.334584,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 128.086167,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 25.95,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/premium-750k",
+      "metrics": [
+        {
+          "name": "startup_ms",
+          "unit": "ms",
+          "value": 197.398417,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 256.16856657959084,
+          "higher_is_better": true
+        },
+        {
+          "name": "throughput_total",
+          "unit": "MB/s",
+          "value": 219.3912523497146,
+          "higher_is_better": true,
+          "informational": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 1.235035972595215,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/slow-4m",
+      "metrics": [
+        {
+          "name": "startup_ms",
+          "unit": "ms",
+          "value": 3107.485792,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 59.482394948765375,
+          "higher_is_better": true
+        },
+        {
+          "name": "throughput_total",
+          "unit": "MB/s",
+          "value": 46.436164639808695,
+          "higher_is_better": true,
+          "informational": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 1.1173800563812255,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/premium-750k",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 156.974083,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 166.169709,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1.05,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/slow-4m",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 1643.962625,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 1666.99275,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/premium-750k",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/slow-4m",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B4-four-streams/premium-750k",
+      "metrics": [
+        {
+          "name": "min_stream_mbps",
+          "unit": "MB/s",
+          "value": 204.55417701449997,
+          "higher_is_better": true,
+          "tolerance": 0.12
+        },
+        {
+          "name": "max_stream_mbps",
+          "unit": "MB/s",
+          "value": 204.70589874867952,
+          "higher_is_better": true
+        },
+        {
+          "name": "stall_p99",
+          "unit": "ms",
+          "value": 45.164875,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B5-two-handles/premium-750k",
+      "metrics": [
+        {
+          "name": "duplicate_bodies",
+          "unit": "count",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B6-contention/premium-750k",
+      "metrics": [
+        {
+          "name": "stream_mbps",
+          "unit": "MB/s",
+          "value": 227.1065910590974,
+          "higher_is_better": true,
+          "tolerance": 0.15
+        },
+        {
+          "name": "stream_startup_ms",
+          "unit": "ms",
+          "value": 239.878875,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "stream_p50",
+          "unit": "ms",
+          "value": 0.038709,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "stream_p99",
+          "unit": "ms",
+          "value": 72.765958,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "import_mbps",
+          "unit": "MB/s",
+          "value": 137.12463610017394,
+          "higher_is_better": true
+        }
+      ]
+    },
+    {
+      "name": "B7-failover/premium-750k",
+      "metrics": [
+        {
+          "name": "miss_ttfb_mean",
+          "unit": "ms",
+          "value": 164.884532,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "miss_ttfb_p50",
+          "unit": "ms",
+          "value": 158.877875,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "bodies_per_miss",
+          "unit": "count",
+          "value": 1.025,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B9-forward-skip/premium-750k",
+      "metrics": [
+        {
+          "name": "jump_read_ms",
+          "unit": "ms",
+          "value": 160.533833,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 66,
+          "higher_is_better": false
+        },
+        {
+          "name": "open_articles",
+          "unit": "count",
+          "value": 62,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B10-replay/premium-750k",
+      "metrics": [
+        {
+          "name": "replay_bytes_fetched_mb",
+          "unit": "MB",
+          "value": 32.73589324951172,
+          "higher_is_better": false
+        },
+        {
+          "name": "replay_read_ms",
+          "unit": "ms",
+          "value": 7.423875,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        }
+      ]
+    },
+    {
+      "name": "B11-seek-resume/premium-750k",
+      "metrics": [
+        {
+          "name": "seek_read_ms",
+          "unit": "ms",
+          "value": 641.415591,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "bytes_fetched_mb",
+          "unit": "MB",
+          "value": 325.8709373474121,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B11-seek-resume/slow-4m",
+      "metrics": [
+        {
+          "name": "seek_read_ms",
+          "unit": "ms",
+          "value": 4056.907166,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "bytes_fetched_mb",
+          "unit": "MB",
+          "value": 550.892749786377,
+          "higher_is_better": false
+        }
+      ]
+    }
+  ]
+}

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -299,6 +299,7 @@ providers:
     min_connections_alive: 2 # Warm connections kept open for fast first byte (default: 2, -1 = connect on demand only)
     inflight_requests: 10 # Concurrent bodies per connection (memory ceiling, default: 10); typical depth 3-4, raising does not improve throughput
     stat_inflight_requests: 100 # STAT pipeline depth per connection (determines idle health-sweep concurrency, default: 100)
+    stream_inflight_requests: 4 # Streaming bodies per connection; a playback read waits behind at most this many minus one (default: 4)
     tls: true
     insecure_tls: false
     enabled: true # Enable/disable this provider (default: true)

--- a/docs/superpowers/plans/2026-09-04-streaming-hole-ttl.md
+++ b/docs/superpowers/plans/2026-09-04-streaming-hole-ttl.md
@@ -1,0 +1,63 @@
+# Hole Records with TTL and Provider Fingerprint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A confirmed-missing article stays padded only for 24 hours and only under the provider set that confirmed it (spec phase 8, defect D7); backfills, reposts and newly added providers get a second look.
+
+**Architecture:** `HoleRun` gains `recorded_at` (unix seconds) and `FileMetadata` gains `hole_provider_fingerprint` (SHA-1 of the sorted enabled provider `host:port` list, 8 bytes hex). On open, runs older than `holes.TTL` (24 h) or stored under a different fingerprint are not loaded, so the first read through them re-probes once and re-records. `AddKnownHoles` takes the current fingerprint: a stored fingerprint that differs drops the stored runs first; merged runs are stamped now when they intersect a new run and keep the newest stored stamp otherwise. Legacy records (no stamp, no fingerprint) are treated as unknown, which is the safe direction. Transport failures never create holes today; a test pins that.
+
+**Spec:** `docs/superpowers/specs/2026-09-04-streaming-demand-shaping-design.md` (Phase 8)
+
+## Global Constraints
+
+- No competitor names in code, comments, commits, PRs.
+- Conventional Commits; branch `feat/streaming-hole-ttl` from `feat/streaming-body-depth`.
+- `make bench-compare BASE=baseline-main`: no regressions (this phase is off the hot path).
+
+---
+
+### Task 1: Proto and metadata
+
+**Files:** `internal/metadata/proto/metadata.proto` (+ regenerate with `make proto`), `internal/metadata/knownholes.go`, `internal/metadata/knownholes_test.go`.
+
+```go
+// LiveKnownHoles returns the stored runs still trusted now: stamped within
+// holes.TTL and recorded under fingerprint. Unstamped or foreign runs are
+// dropped so the next read re-probes them.
+func LiveKnownHoles(rows []*metapb.HoleRun, storedFP, fingerprint string, now time.Time) []holes.Run
+// AddKnownHoles merges runs into the file's hole map under fingerprint,
+// dropping stored runs that were recorded under a different one, and stamps
+// the result.
+func (ms *MetadataService) AddKnownHoles(virtualPath string, runs []holes.Run, fingerprint string) error
+```
+`holes.TTL = 24 * time.Hour` in `internal/holes/holes.go`.
+
+- [ ] Tests: fresh stamp under same fingerprint is live; stamp older than TTL is dropped; fingerprint mismatch drops all; unstamped legacy row dropped; `AddKnownHoles` replaces foreign runs, stamps new runs with now and keeps the stored stamp for untouched runs; merge of a new run into an old one takes the new stamp.
+- [ ] Commit `feat(metadata): hole runs carry a timestamp and provider fingerprint`.
+
+### Task 2: Provider fingerprint
+
+**Files:** `internal/config/accessors.go`, `internal/config/accessors_test.go`.
+
+```go
+// ProviderFingerprint names the set of enabled providers: SHA-1 over the
+// sorted "host:port" list, first 8 bytes hex. Hole records are trusted only
+// under the fingerprint that recorded them.
+func (c *Config) ProviderFingerprint() string
+```
+- [ ] Tests: order-independent; disabled providers excluded; changes when a provider is added.
+- [ ] Commit `feat(config): provider set fingerprint`.
+
+### Task 3: Wire into open and record paths
+
+**Files:** `internal/nzbfilesystem/holes.go` (`holeHooks` load, `holeMetaSnapshot.fingerprint`, `onHole` event), `internal/nzbfilesystem/pad_recorder.go` (`padMetadataStore.AddKnownHoles(path, runs, fingerprint)`, `padEvent.fingerprint`), test fakes implementing `padMetadataStore`, `internal/nzbfilesystem/hole_ttl_test.go`.
+
+`holeHooks()` computes `fp := ""; if mvf.configGetter != nil { fp = mvf.configGetter().ProviderFingerprint() }` and loads `metadata.LiveKnownHoles(mvf.meta.KnownHoles, mvf.meta.HoleProviderFingerprint, fp, time.Now())`.
+
+- [ ] Tests: a hole stamped an hour ago under the current fingerprint pads without a fetch (fetch count 0 for that segment); the same hole stamped 25 h ago is fetched once (430) and padded; a hole under another fingerprint is fetched once; the pad recorder passes the fingerprint through.
+- [ ] Reader-level test in `internal/usenet`: a transient error (not `ErrArticleNotFound`) never calls `OnHole`.
+- [ ] `go test -race ./internal/metadata/ ./internal/nzbfilesystem/ ./internal/usenet/ ./internal/config/`; commit `feat(nzbfilesystem): trust hole records for 24 h under the recording provider set`.
+
+### Task 4: Bench sanity, PR
+
+- [ ] `make bench-stream && make bench-compare BASE=baseline-main` (expect no change); push; `gh pr create --base feat/streaming-body-depth`.

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/javi11/gopar-turbo v0.2.1
-	github.com/javi11/nntppool/v4 v4.21.0
+	github.com/javi11/nntppool/v4 v4.22.0
 	github.com/javi11/nxg v0.1.0
 	github.com/javi11/nzbparser v0.5.5
 	github.com/javi11/rardecode/v2 v2.1.2-0.20260610075131-4664d7a7325a

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/javi11/gopar-turbo v0.2.1 h1:0xUZtofwBcjxle6QIl9EZAwxmLtWkECMM69tQhmc9iA=
 github.com/javi11/gopar-turbo v0.2.1/go.mod h1:fOQZIbPz+ADJ8vGAzVLXvQhsOsE08hvAcev8nQvBFfY=
-github.com/javi11/nntppool/v4 v4.21.0 h1:d7EIWNzK272kNK/3dDfIgsMebcQampa7fA66JBF31RM=
-github.com/javi11/nntppool/v4 v4.21.0/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
+github.com/javi11/nntppool/v4 v4.22.0 h1:zDRYcR9LoEQQbLrgSH43Iyv97rpydbTBXeFo9j7W4k4=
+github.com/javi11/nntppool/v4 v4.22.0/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
 github.com/javi11/nxg v0.1.0 h1:CTThldYlaVIPIhpkrMw0HcTD0NLrW1uYMoDILjjEOtM=
 github.com/javi11/nxg v0.1.0/go.mod h1:+GvYpp+y1oq+qBOWxFMvfTjtin/0zCeomWfjiPkiu8A=
 github.com/javi11/nzbparser v0.5.5 h1:kMKyX0xNO7bIeIlQvSPGzdWs71MG2Krf+yojOj+FuUc=

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -39,6 +39,9 @@ const (
 	// providerReconnectDelay lets a provider dropped after a 502 rejoin the
 	// pool instead of staying out until restart.
 	providerReconnectDelay = 30 * time.Second
+	// defaultStreamInflightRequests bounds streaming bodies per connection so
+	// a demand read waits behind at most three read-ahead bodies.
+	defaultStreamInflightRequests = 4
 )
 
 const (
@@ -713,6 +716,11 @@ type ProviderConfig struct {
 	// determines how much an idle-pool health sweep can widen: measured 24x sweep
 	// throughput improvement. While a stream is active the sweep is capped lower regardless.
 	StatInflightRequests     int        `yaml:"stat_inflight_requests" mapstructure:"stat_inflight_requests" json:"stat_inflight_requests"`
+	// StreamInflightRequests caps streaming (priority-lane) bodies in flight
+	// per connection, so a playback read never queues behind a connection's
+	// worth of read-ahead. 0 defaults to 4; values above inflight_requests
+	// are capped to it.
+	StreamInflightRequests int `yaml:"stream_inflight_requests" mapstructure:"stream_inflight_requests" json:"stream_inflight_requests,omitempty"`
 	TLS                      bool       `yaml:"tls" mapstructure:"tls" json:"tls"`
 	InsecureTLS              bool       `yaml:"insecure_tls" mapstructure:"insecure_tls" json:"insecure_tls"`
 	ProxyURL                 string     `yaml:"proxy_url" mapstructure:"proxy_url" json:"proxy_url,omitempty"`
@@ -1461,6 +1469,14 @@ func (p *ProviderConfig) ToNNTPProvider() nntppool.Provider {
 		statInflight = 100
 	}
 
+	streamInflight := p.StreamInflightRequests
+	if streamInflight <= 0 {
+		streamInflight = defaultStreamInflightRequests
+	}
+	if streamInflight > inflight {
+		streamInflight = inflight
+	}
+
 	return nntppool.Provider{
 		Host:              host,
 		TLSConfig:         tlsCfg,
@@ -1471,6 +1487,7 @@ func (p *ProviderConfig) ToNNTPProvider() nntppool.Provider {
 		StorageGroup:      p.StorageGroup,
 		Inflight:          inflight,
 		StatInflight:      statInflight,
+		StreamInflight:    streamInflight,
 		IdleTimeout:       providerIdleTimeout,
 		ReconnectDelay:    providerReconnectDelay,
 		SkipPing:          p.SkipPing,

--- a/internal/config/provider_nntp_test.go
+++ b/internal/config/provider_nntp_test.go
@@ -46,3 +46,18 @@ func TestToNNTPProviderSetsReconnectDelay(t *testing.T) {
 		t.Fatalf("ReconnectDelay = %v, want 30s so a provider removed on 502 comes back", got)
 	}
 }
+
+func TestToNNTPProviderStreamInflightDefaultsAndCaps(t *testing.T) {
+	p := tlsProvider()
+	if got := p.ToNNTPProvider().StreamInflight; got != 4 {
+		t.Fatalf("StreamInflight default = %d, want 4", got)
+	}
+	p.StreamInflightRequests = 6
+	if got := p.ToNNTPProvider().StreamInflight; got != 6 {
+		t.Fatalf("explicit StreamInflight = %d, want 6", got)
+	}
+	p.InflightRequests = 3
+	if got := p.ToNNTPProvider().StreamInflight; got != 3 {
+		t.Fatalf("StreamInflight must be capped at inflight_requests, got %d", got)
+	}
+}

--- a/internal/nzbfilesystem/stream_bench_test.go
+++ b/internal/nzbfilesystem/stream_bench_test.go
@@ -506,3 +506,45 @@ func BenchmarkStreamReplay(b *testing.B) {
 		}
 	})
 }
+
+// BenchmarkStreamSeekAndResume models a player jumping through a file: read
+// 8 MB, jump 500 MB forward, read 8 MB, five times. Each jump abandons the
+// previous reader's read-ahead; the bytes still fetched after that are the
+// cost of the abandoned window.
+func BenchmarkStreamSeekAndResume(b *testing.B) {
+	for _, p := range benchProfiles {
+		b.Run(p.Name, func(b *testing.B) {
+			h := newBenchHarness(b, p)
+			fileSegs := int(3<<30) / p.ArticleSize // ~3 GB so five 500 MB jumps fit
+			record(b, scenario("B11-seek-resume", p), func() []streambench.Metric {
+				before := h.bytesWritten()
+				mvf := h.openFile(b, fileSegs, benchPrefetch, -1)
+				buf := make([]byte, 1<<20)
+				readChunk := func(at int64) time.Duration {
+					start := time.Now()
+					for off := at; off < at+8<<20; {
+						n, err := mvf.ReadAt(buf, off)
+						if err != nil {
+							b.Fatalf("ReadAt(%d): %v", off, err)
+						}
+						off += int64(n)
+					}
+					return time.Since(start)
+				}
+				readChunk(0)
+				var seek streambench.Samples
+				pos := int64(0)
+				for i := 0; i < 5; i++ {
+					pos += 500 << 20
+					seek.Add(readChunk(pos))
+				}
+				_ = mvf.Close()
+				h.awaitQuietWire(500*time.Millisecond, 60*time.Second)
+				return []streambench.Metric{
+					{Name: "seek_read_ms", Unit: "ms", Value: ms(seek.Mean()), Tolerance: 0.10},
+					{Name: "bytes_fetched_mb", Unit: "MB", Value: float64(h.bytesWritten()-before) / (1 << 20)},
+				}
+			})
+		})
+	}
+}

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -140,6 +140,11 @@ const (
 	// not fanned a whole window out. Any consumption opens the window fully;
 	// a narrower ramp was measured to cost 16-25 % of a 16 MB startup.
 	openingSegments = 16
+	// readAheadBytesCap bounds the window in bytes as well as segments. A
+	// 60-segment window is 45 MB on 750 KB posts but 240 MB on 4 MiB posts,
+	// where it starves the reader's own demand article for the link and
+	// leaves a quarter of a gigabyte to abandon on every seek.
+	readAheadBytesCap = 96 << 20
 )
 
 // withFlightMap gives the reader its own in-flight article map. Tests use it
@@ -495,13 +500,17 @@ func IsArticleNotFound(err error) bool {
 // windowFor is how many segments may be scheduled ahead of the read position
 // given what the caller has read since the reader was created.
 func (b *UsenetReader) windowFor(bytesRead int64) int {
+	full := b.maxPrefetch
+	if b.priority && b.articleSize > 0 {
+		full = max(min(full, int(readAheadBytesCap/b.articleSize)), largeArticleHoldSegments)
+	}
 	if !b.priority || bytesRead > 0 {
-		return b.maxPrefetch
+		return full
 	}
 	if b.articleSize >= largeArticleBytes {
-		return min(b.maxPrefetch, largeArticleHoldSegments)
+		return min(full, largeArticleHoldSegments)
 	}
-	return min(b.maxPrefetch, openingSegments)
+	return min(full, openingSegments)
 }
 
 // BufferedAhead reports bytes scheduled for fetch beyond what the caller has

--- a/internal/usenet/usenet_reader_ramp_test.go
+++ b/internal/usenet/usenet_reader_ramp_test.go
@@ -112,3 +112,21 @@ func TestImportReaderDoesNotRamp(t *testing.T) {
 		t.Fatalf("import max in flight = %d, want %d", fp.MaxInFlight(), maxPrefetch)
 	}
 }
+
+// The window is bounded in bytes too: on large articles far fewer than
+// maxPrefetch segments are in flight.
+func TestWindowIsCappedInBytesOnLargeArticles(t *testing.T) {
+	ctx := context.Background()
+	const nSegs, segSize, maxPrefetch = 40, 4 << 20, 60
+	fp := rampPool(nSegs, segSize, 50*time.Millisecond)
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+	ur := newRampReader(t, ctx, fp, rg, maxPrefetch)
+	ur.Start()
+	if _, err := io.ReadAll(ur); err != nil {
+		t.Fatal(err)
+	}
+	want := int32(readAheadBytesCap / segSize)
+	if fp.MaxInFlight() > want {
+		t.Fatalf("max in flight %d exceeds the byte cap of %d segments", fp.MaxInFlight(), want)
+	}
+}


### PR DESCRIPTION
Stacked on #901 → #899 → #898 → #897 → #896 → #895 → #894. Needs nntppool v4.22.0 (released, pinned; no `replace`).

## Summary
- **nntppool `AbortDrainBytes` (default 1 MiB):** a body whose request was cancelled while its bytes were still arriving used to be drained to `io.Discard` in full to keep the connection in sync. When more than 1 MiB remains, the connection is now closed instead and its slot reconnects; pending neighbours go through the existing connection-death retry. Below the threshold (every 750 KB article) nothing changes, since a reconnect costs more than the drain. This is what stops a closed handle's read-ahead on 4 MiB posts from occupying the wire for seconds after every seek.
- **nntppool `StreamInflight` (default `min(Inflight, 4)`):** priority-lane bodies per connection are capped by a second semaphore alongside `bodySem`, so a demand read waits behind at most three stream bodies on its connection; import bodies keep `Inflight`. Exposed as `providers[].stream_inflight_requests` (default 4, capped at `inflight_requests`).
- **Read-ahead window capped in bytes (96 MiB):** 60 segments is 45 MB on 750 KB posts but 240 MB on 4 MiB posts, where it starved the reader's own demand article and left a quarter of a gigabyte to abandon on every seek. No effect on 750 KB posts.
- New scenario B11 (read 8 MB, jump 500 MB forward, read 8 MB, five times), pre-sampled on #901.

## Simulated benchmark (medians of 3)

| Scenario | Metric | #901 | this PR |
|---|---|---|---|
| B11 seek/resume, slow-4m | bytes fetched for 48 MB read (MB) | 1507 | 551 |
| B11 seek/resume, slow-4m | read after seek (ms) | 6273 | 4057 |
| B11 seek/resume, premium | bytes / read after seek | 326 MB / 643 ms | 326 MB / 641 ms (below abort threshold, by design) |
| B1 cold open, slow-4m | ttfb mean (ms) | 3745 | 117 (the next open no longer queues behind the previous handle's tail) |
| B2 sequential, slow-4m | steady MB/s / fetched-per-read | 46.8 / 1.48 | 59.5 / 1.12 |
| B2 sequential, premium | steady MB/s | 260 | 256 (A/B with the cap disabled: 259; machine spread) |
| B6 contention | stream / import MB/s | 226 / 139 | 227 / 137 |
| B1 cold open, premium | ttfb mean (ms) | 47 | 46 |

Against the committed baseline: no REGRESSION rows.

## Live (dev server, real providers, single samples; provider is slow this evening on every build)

| file | ttfb #901 | ttfb this PR | seek p50 #901 | seek p50 this PR | MB/s #901 | MB/s this PR |
|---|---|---|---|---|---|---|
| Supergirl S04E21 1080p | 105 | 118 | 70 | 69 | 52.0 | 52.0 |
| Avatar Fire and Ash 1080p | 67 | 65 | 76 | 144 | 90.7 | 96.1 |
| The Penguin S01E08 2160p remux | 62 | 74 | 78 | 111 | 89.4 | 97.0 |

Ten 1 MB reads 1 GB apart on the remux: 85-310 ms each.

## Test plan
- [x] nntppool: cancelled 4 MB body → connection closed within 2 s and the next request served on a fresh one; cancelled 256 KB body → drained, connection reused; `StreamInflight 2` lets only two priority bodies onto the wire while normal bodies are uncapped; full suite green
- [x] altmount: `stream_inflight_requests` default/explicit/capped; byte-capped window test; `go test -race` on `internal/usenet`, `internal/nzbfilesystem`, `internal/pool`, `internal/config`
- [x] benchmark and live above