### PR TITLE
chore(streaming): cancellable FUSE reads, counter-based buffered offset, housekeeping

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -4,11 +4,14 @@
 the in-process provider simulator (`internal/testsupport/nntpserver`) and writes
 `bench/results/<short-sha>.json`. `make bench-compare BASE=<name>` diffs the
 current results against `bench/results/<name>.json` and exits non-zero when any
-metric regresses by more than 5 % in its bad direction.
+gated metric regresses by more than 5 % (or its own wider tolerance) in its bad
+direction. Each scenario is run three times and the median is recorded.
 
-Scenarios: B1 cold open TTFB, B2 sequential throughput and waste, B3 seek
-storm, B4 four concurrent streams, B5 two handles on one file, B6 stream under
-import contention, B7 provider failover, B8 bytes fetched while paused.
+Scenarios: B1 cold open TTFB, B2 sequential startup and steady throughput, B3
+seek storm, B4 four concurrent streams, B5 two handles on one file, B6 stream
+under import contention, B7 provider failover, B8 bytes fetched while paused,
+B9 forward skip, B10 close-and-reopen replay, B11 seek and resume.
 
-Results are committed per phase so a PR description can cite its delta table.
-Run on an idle machine; the simulator is CPU-bound at high aggregate bandwidth.
+Results are committed per landed change so a PR description can cite its delta
+table; per-SHA files are scratch output. Run on an idle machine; the simulator
+is CPU-bound at high aggregate bandwidth. Full guide: `docs/docs/6. Development/setup.md`.

--- a/bench/results/phase10-soft-memlimit.json
+++ b/bench/results/phase10-soft-memlimit.json
@@ -1,0 +1,384 @@
+{
+  "git_sha": "6f64c127",
+  "timestamp": "2026-09-04T19:33:31.229725Z",
+  "scenarios": [
+    {
+      "name": "B1-cold-open/premium-750k",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 48.25307,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 50.294791,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 57.185625,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 60,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B1-cold-open/slow-4m",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 118.993977,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 118.689,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 129.0535,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 26,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/premium-750k",
+      "metrics": [
+        {
+          "name": "startup_ms",
+          "unit": "ms",
+          "value": 213.154542,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 266.1532127603831,
+          "higher_is_better": true
+        },
+        {
+          "name": "throughput_total",
+          "unit": "MB/s",
+          "value": 220.97249997237844,
+          "higher_is_better": true,
+          "informational": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 1.235035972595215,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/slow-4m",
+      "metrics": [
+        {
+          "name": "startup_ms",
+          "unit": "ms",
+          "value": 1601.335625,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 57.10922747459282,
+          "higher_is_better": true
+        },
+        {
+          "name": "throughput_total",
+          "unit": "MB/s",
+          "value": 50.72435113145843,
+          "higher_is_better": true,
+          "informational": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 1.04654403368632,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/premium-750k",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 145.807625,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 155.372167,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1.05,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/slow-4m",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 1571.397958,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 1583.415792,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/premium-750k",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/slow-4m",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B4-four-streams/premium-750k",
+      "metrics": [
+        {
+          "name": "min_stream_mbps",
+          "unit": "MB/s",
+          "value": 203.16731092578576,
+          "higher_is_better": true,
+          "tolerance": 0.12
+        },
+        {
+          "name": "max_stream_mbps",
+          "unit": "MB/s",
+          "value": 203.6691336592865,
+          "higher_is_better": true
+        },
+        {
+          "name": "stall_p99",
+          "unit": "ms",
+          "value": 43.843083,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B5-two-handles/premium-750k",
+      "metrics": [
+        {
+          "name": "duplicate_bodies",
+          "unit": "count",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B6-contention/premium-750k",
+      "metrics": [
+        {
+          "name": "stream_mbps",
+          "unit": "MB/s",
+          "value": 240.00488581374694,
+          "higher_is_better": true,
+          "tolerance": 0.15
+        },
+        {
+          "name": "stream_startup_ms",
+          "unit": "ms",
+          "value": 252.740292,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "stream_p50",
+          "unit": "ms",
+          "value": 0.035583,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "stream_p99",
+          "unit": "ms",
+          "value": 61.1285,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "import_mbps",
+          "unit": "MB/s",
+          "value": 138.7730708666649,
+          "higher_is_better": true
+        }
+      ]
+    },
+    {
+      "name": "B7-failover/premium-750k",
+      "metrics": [
+        {
+          "name": "miss_ttfb_mean",
+          "unit": "ms",
+          "value": 157.307869,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "miss_ttfb_p50",
+          "unit": "ms",
+          "value": 151.399125,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "bodies_per_miss",
+          "unit": "count",
+          "value": 1.025,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B9-forward-skip/premium-750k",
+      "metrics": [
+        {
+          "name": "jump_read_ms",
+          "unit": "ms",
+          "value": 145.077625,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 66,
+          "higher_is_better": false
+        },
+        {
+          "name": "open_articles",
+          "unit": "count",
+          "value": 62,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B10-replay/premium-750k",
+      "metrics": [
+        {
+          "name": "replay_bytes_fetched_mb",
+          "unit": "MB",
+          "value": 33.47989082336426,
+          "higher_is_better": false
+        },
+        {
+          "name": "replay_read_ms",
+          "unit": "ms",
+          "value": 6.926375,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        }
+      ]
+    },
+    {
+      "name": "B11-seek-resume/premium-750k",
+      "metrics": [
+        {
+          "name": "seek_read_ms",
+          "unit": "ms",
+          "value": 647.574783,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "bytes_fetched_mb",
+          "unit": "MB",
+          "value": 325.8709373474121,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B11-seek-resume/slow-4m",
+      "metrics": [
+        {
+          "name": "seek_read_ms",
+          "unit": "ms",
+          "value": 4077.658425,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "bytes_fetched_mb",
+          "unit": "MB",
+          "value": 551.048999786377,
+          "higher_is_better": false
+        }
+      ]
+    }
+  ]
+}

--- a/bench/results/phase11-depth.json
+++ b/bench/results/phase11-depth.json
@@ -1,0 +1,384 @@
+{
+  "git_sha": "54860c39",
+  "timestamp": "2026-09-04T22:01:39.377802Z",
+  "scenarios": [
+    {
+      "name": "B1-cold-open/premium-750k",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 46.820368,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 46.860958,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 53.751042,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 60.05,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B1-cold-open/slow-4m",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 117.736131,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 117.534667,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 130.117542,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 25.95,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/premium-750k",
+      "metrics": [
+        {
+          "name": "startup_ms",
+          "unit": "ms",
+          "value": 221.67075,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 269.8747867672008,
+          "higher_is_better": true
+        },
+        {
+          "name": "throughput_total",
+          "unit": "MB/s",
+          "value": 221.62471804238498,
+          "higher_is_better": true,
+          "informational": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 1.235035972595215,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/slow-4m",
+      "metrics": [
+        {
+          "name": "startup_ms",
+          "unit": "ms",
+          "value": 1604.848,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 57.81942455969557,
+          "higher_is_better": true
+        },
+        {
+          "name": "throughput_total",
+          "unit": "MB/s",
+          "value": 51.259007365940974,
+          "higher_is_better": true,
+          "informational": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 1.0714412117004395,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/premium-750k",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 154.491542,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 166.68975,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1.05,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/slow-4m",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 1646.300667,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 1666.895292,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/premium-750k",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/slow-4m",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B4-four-streams/premium-750k",
+      "metrics": [
+        {
+          "name": "min_stream_mbps",
+          "unit": "MB/s",
+          "value": 207.49616196942907,
+          "higher_is_better": true,
+          "tolerance": 0.12
+        },
+        {
+          "name": "max_stream_mbps",
+          "unit": "MB/s",
+          "value": 207.8453298193616,
+          "higher_is_better": true
+        },
+        {
+          "name": "stall_p99",
+          "unit": "ms",
+          "value": 35.7025,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B5-two-handles/premium-750k",
+      "metrics": [
+        {
+          "name": "duplicate_bodies",
+          "unit": "count",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B6-contention/premium-750k",
+      "metrics": [
+        {
+          "name": "stream_mbps",
+          "unit": "MB/s",
+          "value": 251.6067072657053,
+          "higher_is_better": true,
+          "tolerance": 0.15
+        },
+        {
+          "name": "stream_startup_ms",
+          "unit": "ms",
+          "value": 241.596792,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "stream_p50",
+          "unit": "ms",
+          "value": 0.040708,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "stream_p99",
+          "unit": "ms",
+          "value": 59.079416,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "import_mbps",
+          "unit": "MB/s",
+          "value": 145.60019431961192,
+          "higher_is_better": true
+        }
+      ]
+    },
+    {
+      "name": "B7-failover/premium-750k",
+      "metrics": [
+        {
+          "name": "miss_ttfb_mean",
+          "unit": "ms",
+          "value": 165.762938,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "miss_ttfb_p50",
+          "unit": "ms",
+          "value": 158.588708,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "bodies_per_miss",
+          "unit": "count",
+          "value": 1.025,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B9-forward-skip/premium-750k",
+      "metrics": [
+        {
+          "name": "jump_read_ms",
+          "unit": "ms",
+          "value": 151.203459,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 66,
+          "higher_is_better": false
+        },
+        {
+          "name": "open_articles",
+          "unit": "count",
+          "value": 62,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B10-replay/premium-750k",
+      "metrics": [
+        {
+          "name": "replay_bytes_fetched_mb",
+          "unit": "MB",
+          "value": 31.99189567565918,
+          "higher_is_better": false
+        },
+        {
+          "name": "replay_read_ms",
+          "unit": "ms",
+          "value": 6.610541,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        }
+      ]
+    },
+    {
+      "name": "B11-seek-resume/premium-750k",
+      "metrics": [
+        {
+          "name": "seek_read_ms",
+          "unit": "ms",
+          "value": 639.578733,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "bytes_fetched_mb",
+          "unit": "MB",
+          "value": 325.8709373474121,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B11-seek-resume/slow-4m",
+      "metrics": [
+        {
+          "name": "seek_read_ms",
+          "unit": "ms",
+          "value": 4068.779383,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "bytes_fetched_mb",
+          "unit": "MB",
+          "value": 550.923999786377,
+          "higher_is_better": false
+        }
+      ]
+    }
+  ]
+}

--- a/bench/results/phase9-housekeeping.json
+++ b/bench/results/phase9-housekeeping.json
@@ -1,0 +1,384 @@
+{
+  "git_sha": "8707bfb2",
+  "timestamp": "2026-09-04T16:54:07.977694Z",
+  "scenarios": [
+    {
+      "name": "B1-cold-open/premium-750k",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 48.217845,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 47.714667,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 57.509084,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 60,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B1-cold-open/slow-4m",
+      "metrics": [
+        {
+          "name": "ttfb_mean",
+          "unit": "ms",
+          "value": 118.183875,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "ttfb_p50",
+          "unit": "ms",
+          "value": 117.632,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "ttfb_p99",
+          "unit": "ms",
+          "value": 131.049208,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 25.9,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/premium-750k",
+      "metrics": [
+        {
+          "name": "startup_ms",
+          "unit": "ms",
+          "value": 231.978708,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 266.76654290047406,
+          "higher_is_better": true
+        },
+        {
+          "name": "throughput_total",
+          "unit": "MB/s",
+          "value": 216.98554727077612,
+          "higher_is_better": true,
+          "informational": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 1.231315984725952,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B2-sequential/slow-4m",
+      "metrics": [
+        {
+          "name": "startup_ms",
+          "unit": "ms",
+          "value": 1610.057083,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "throughput",
+          "unit": "MB/s",
+          "value": 56.405362323311785,
+          "higher_is_better": true
+        },
+        {
+          "name": "throughput_total",
+          "unit": "MB/s",
+          "value": 46.51898063935864,
+          "higher_is_better": true,
+          "informational": true
+        },
+        {
+          "name": "waste_ratio",
+          "unit": "ratio",
+          "value": 1.1240469471613566,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/premium-750k",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 151.516791,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 164.705833,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1.05,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B3-seek-storm/slow-4m",
+      "metrics": [
+        {
+          "name": "read_p50",
+          "unit": "ms",
+          "value": 1647.065,
+          "higher_is_better": false
+        },
+        {
+          "name": "read_p99",
+          "unit": "ms",
+          "value": 1670.439875,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "articles_per_read",
+          "unit": "count",
+          "value": 1,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/premium-750k",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B8-pause-resume/slow-4m",
+      "metrics": [
+        {
+          "name": "bytes_during_pause",
+          "unit": "MB",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B4-four-streams/premium-750k",
+      "metrics": [
+        {
+          "name": "min_stream_mbps",
+          "unit": "MB/s",
+          "value": 203.22024507394227,
+          "higher_is_better": true,
+          "tolerance": 0.12
+        },
+        {
+          "name": "max_stream_mbps",
+          "unit": "MB/s",
+          "value": 203.42282624254622,
+          "higher_is_better": true
+        },
+        {
+          "name": "stall_p99",
+          "unit": "ms",
+          "value": 34.881959,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B5-two-handles/premium-750k",
+      "metrics": [
+        {
+          "name": "duplicate_bodies",
+          "unit": "count",
+          "value": 0,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B6-contention/premium-750k",
+      "metrics": [
+        {
+          "name": "stream_mbps",
+          "unit": "MB/s",
+          "value": 226.72783819729776,
+          "higher_is_better": true,
+          "tolerance": 0.15
+        },
+        {
+          "name": "stream_startup_ms",
+          "unit": "ms",
+          "value": 241.027791,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "stream_p50",
+          "unit": "ms",
+          "value": 0.035875,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "stream_p99",
+          "unit": "ms",
+          "value": 53.909042,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "import_mbps",
+          "unit": "MB/s",
+          "value": 138.63981077638897,
+          "higher_is_better": true
+        }
+      ]
+    },
+    {
+      "name": "B7-failover/premium-750k",
+      "metrics": [
+        {
+          "name": "miss_ttfb_mean",
+          "unit": "ms",
+          "value": 164.430408,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "miss_ttfb_p50",
+          "unit": "ms",
+          "value": 158.19375,
+          "higher_is_better": false,
+          "informational": true
+        },
+        {
+          "name": "bodies_per_miss",
+          "unit": "count",
+          "value": 1.025,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B9-forward-skip/premium-750k",
+      "metrics": [
+        {
+          "name": "jump_read_ms",
+          "unit": "ms",
+          "value": 157.787292,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "articles",
+          "unit": "count",
+          "value": 66,
+          "higher_is_better": false
+        },
+        {
+          "name": "open_articles",
+          "unit": "count",
+          "value": 62,
+          "higher_is_better": false,
+          "informational": true
+        }
+      ]
+    },
+    {
+      "name": "B10-replay/premium-750k",
+      "metrics": [
+        {
+          "name": "replay_bytes_fetched_mb",
+          "unit": "MB",
+          "value": 31.99189567565918,
+          "higher_is_better": false
+        },
+        {
+          "name": "replay_read_ms",
+          "unit": "ms",
+          "value": 7.06375,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        }
+      ]
+    },
+    {
+      "name": "B11-seek-resume/premium-750k",
+      "metrics": [
+        {
+          "name": "seek_read_ms",
+          "unit": "ms",
+          "value": 649.093366,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "bytes_fetched_mb",
+          "unit": "MB",
+          "value": 325.8709373474121,
+          "higher_is_better": false
+        }
+      ]
+    },
+    {
+      "name": "B11-seek-resume/slow-4m",
+      "metrics": [
+        {
+          "name": "seek_read_ms",
+          "unit": "ms",
+          "value": 4061.909125,
+          "higher_is_better": false,
+          "tolerance": 0.1
+        },
+        {
+          "name": "bytes_fetched_mb",
+          "unit": "MB",
+          "value": 551.142749786377,
+          "higher_is_better": false
+        }
+      ]
+    }
+  ]
+}

--- a/cmd/altmount/cmd/memlimit.go
+++ b/cmd/altmount/cmd/memlimit.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"os"
+	"runtime/debug"
+
+	"github.com/javi11/altmount/internal/config"
+)
+
+// applySoftMemoryLimit sets the Go soft memory limit derived from the segment
+// cache budget and returns it; 0 means the runtime was left as it was.
+func applySoftMemoryLimit(ctx context.Context, cfg *config.Config) int64 {
+	gomemlimit := os.Getenv("GOMEMLIMIT")
+	if gomemlimit != "" {
+		return 0
+	}
+	limit := cfg.SegmentCache.SoftMemoryLimit(gomemlimit)
+	if limit == 0 {
+		debug.SetMemoryLimit(math.MaxInt64)
+		return 0
+	}
+	debug.SetMemoryLimit(limit)
+	slog.InfoContext(ctx, "Soft memory limit set from segment cache budget",
+		"limit_mb", limit>>20, "cache_mb", cfg.SegmentCache.MemoryBytes()>>20)
+	return limit
+}

--- a/cmd/altmount/cmd/memlimit.go
+++ b/cmd/altmount/cmd/memlimit.go
@@ -10,20 +10,21 @@ import (
 	"github.com/javi11/altmount/internal/config"
 )
 
-// applySoftMemoryLimit sets the Go soft memory limit derived from the segment
-// cache budget and returns it; 0 means the runtime was left as it was.
+// applySoftMemoryLimit sets the configured Go soft memory limit and returns
+// it; 0 means the runtime was left as it was.
 func applySoftMemoryLimit(ctx context.Context, cfg *config.Config) int64 {
 	gomemlimit := os.Getenv("GOMEMLIMIT")
 	if gomemlimit != "" {
 		return 0
 	}
-	limit := cfg.SegmentCache.SoftMemoryLimit(gomemlimit)
+	limit := cfg.SoftMemoryLimit(gomemlimit)
 	if limit == 0 {
 		debug.SetMemoryLimit(math.MaxInt64)
 		return 0
 	}
 	debug.SetMemoryLimit(limit)
-	slog.InfoContext(ctx, "Soft memory limit set from segment cache budget",
-		"limit_mb", limit>>20, "cache_mb", cfg.SegmentCache.MemoryBytes()>>20)
+	slog.InfoContext(ctx, "Soft memory limit set",
+		"limit_mb", limit>>20, "segment_cache_memory_mb", cfg.SegmentCache.MemoryBytes()>>20,
+		"pinned", cfg.MemoryLimitMB != nil && *cfg.MemoryLimitMB > 0)
 	return limit
 }

--- a/cmd/altmount/cmd/memlimit_test.go
+++ b/cmd/altmount/cmd/memlimit_test.go
@@ -18,7 +18,7 @@ func TestApplySoftMemoryLimitSetsRuntimeLimit(t *testing.T) {
 	cfg := &config.Config{SegmentCache: config.SegmentCacheConfig{MemoryMB: &mb}}
 	got := applySoftMemoryLimit(context.Background(), cfg)
 
-	want := cfg.SegmentCache.SoftMemoryLimit("")
+	want := cfg.SoftMemoryLimit("")
 	if got != want || debug.SetMemoryLimit(-1) != want {
 		t.Fatalf("applied %d, runtime %d, want %d", got, debug.SetMemoryLimit(-1), want)
 	}

--- a/cmd/altmount/cmd/memlimit_test.go
+++ b/cmd/altmount/cmd/memlimit_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"context"
+	"math"
+	"runtime/debug"
+	"testing"
+
+	"github.com/javi11/altmount/internal/config"
+)
+
+func TestApplySoftMemoryLimitSetsRuntimeLimit(t *testing.T) {
+	prev := debug.SetMemoryLimit(-1)
+	t.Cleanup(func() { debug.SetMemoryLimit(prev) })
+	t.Setenv("GOMEMLIMIT", "")
+
+	mb := 128
+	cfg := &config.Config{SegmentCache: config.SegmentCacheConfig{MemoryMB: &mb}}
+	got := applySoftMemoryLimit(context.Background(), cfg)
+
+	want := cfg.SegmentCache.SoftMemoryLimit("")
+	if got != want || debug.SetMemoryLimit(-1) != want {
+		t.Fatalf("applied %d, runtime %d, want %d", got, debug.SetMemoryLimit(-1), want)
+	}
+}
+
+func TestApplySoftMemoryLimitLeavesRuntimeWhenDisabled(t *testing.T) {
+	prev := debug.SetMemoryLimit(-1)
+	t.Cleanup(func() { debug.SetMemoryLimit(prev) })
+	t.Setenv("GOMEMLIMIT", "1GiB")
+	operator := int64(1) << 30
+	debug.SetMemoryLimit(operator)
+
+	mb := 128
+	cfg := &config.Config{SegmentCache: config.SegmentCacheConfig{MemoryMB: &mb}}
+	if got := applySoftMemoryLimit(context.Background(), cfg); got != 0 {
+		t.Fatalf("applied %d, want 0", got)
+	}
+	if debug.SetMemoryLimit(-1) != operator {
+		t.Fatalf("runtime limit changed to %d", debug.SetMemoryLimit(-1))
+	}
+}
+
+func TestApplySoftMemoryLimitClearsLimitWhenMemoryTierOff(t *testing.T) {
+	prev := debug.SetMemoryLimit(-1)
+	t.Cleanup(func() { debug.SetMemoryLimit(prev) })
+	t.Setenv("GOMEMLIMIT", "")
+	debug.SetMemoryLimit(512 << 20)
+
+	zero := 0
+	cfg := &config.Config{SegmentCache: config.SegmentCacheConfig{MemoryMB: &zero}}
+	if got := applySoftMemoryLimit(context.Background(), cfg); got != 0 {
+		t.Fatalf("applied %d, want 0", got)
+	}
+	if debug.SetMemoryLimit(-1) != math.MaxInt64 {
+		t.Fatalf("runtime limit %d, want cleared", debug.SetMemoryLimit(-1))
+	}
+}

--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -138,6 +138,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if initialCache := initializeSegmentCache(ctx, cfg, cacheSource); initialCache != nil {
 		defer initialCache.Stop()
 	}
+	applySoftMemoryLimit(ctx, cfg)
 
 	// Background PAR2 repair: repairs missing articles and serves the patched
 	// payloads on the read path's hole branch.
@@ -201,6 +202,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// Register segment cache config change handler for dynamic path/size/expiry changes.
 	// Enable/disable toggles take effect automatically via cacheSource.Store() at file-open time.
 	configManager.OnConfigChange(func(oldConfig, newConfig *config.Config) {
+		if oldConfig.SegmentCache.MemoryBytes() != newConfig.SegmentCache.MemoryBytes() {
+			applySoftMemoryLimit(ctx, newConfig)
+		}
 		structuralChange := oldConfig.SegmentCache.CachePath != newConfig.SegmentCache.CachePath ||
 			oldConfig.SegmentCache.MaxSizeGB != newConfig.SegmentCache.MaxSizeGB ||
 			intPtrValue(oldConfig.SegmentCache.ExpiryHours) != intPtrValue(newConfig.SegmentCache.ExpiryHours)

--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -202,7 +202,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// Register segment cache config change handler for dynamic path/size/expiry changes.
 	// Enable/disable toggles take effect automatically via cacheSource.Store() at file-open time.
 	configManager.OnConfigChange(func(oldConfig, newConfig *config.Config) {
-		if oldConfig.SegmentCache.MemoryBytes() != newConfig.SegmentCache.MemoryBytes() {
+		if oldConfig.SoftMemoryLimit("") != newConfig.SoftMemoryLimit("") {
 			applySoftMemoryLimit(ctx, newConfig)
 		}
 		structuralChange := oldConfig.SegmentCache.CachePath != newConfig.SegmentCache.CachePath ||

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -40,7 +40,9 @@ streaming:
 
 # Segment cache: decoded articles kept for reuse across handles and re-opens.
 segment_cache:
-  memory_mb: 256 # In-memory tier in front of the disk cache; on even when the disk cache is off (0 disables)
+  memory_mb: 256 # In-memory tier in front of the disk cache; on even when the disk cache is off (0 disables).
+  # The Go soft memory limit is set to memory_mb + 256 MB so evicted articles are collected promptly;
+  # set GOMEMLIMIT in the environment to take over that limit yourself.
   enabled: false # Disk tier
   cache_path: /tmp/altmount-segcache
   max_size_gb: 10

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -33,7 +33,7 @@ metadata:
 
 # Streaming and download configuration
 streaming:
-  max_prefetch: 30 # Number of segments to prefetch ahead of current read position
+  max_prefetch: 60 # Segments to prefetch ahead of the read position (default: 60; also capped at 96 MB)
   failure_masking:
     enabled: true # Automatically hide files from mounts after repeated failures
     threshold: 3 # Number of streaming failures before masking a file

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -41,8 +41,6 @@ streaming:
 # Segment cache: decoded articles kept for reuse across handles and re-opens.
 segment_cache:
   memory_mb: 256 # In-memory tier in front of the disk cache; on even when the disk cache is off (0 disables).
-  # The Go soft memory limit is set to memory_mb + 256 MB so evicted articles are collected promptly;
-  # set GOMEMLIMIT in the environment to take over that limit yourself.
   enabled: false # Disk tier
   cache_path: /tmp/altmount-segcache
   max_size_gb: 10
@@ -200,6 +198,10 @@ health:
   resolve_repair_on_import: false # Automatically resolve pending repairs in the same directory when a new file is imported (default: false)
 
 # WebDAV mount path configuration
+# Go soft memory limit in MB. Unset or 0: derived from segment_cache.memory_mb plus the PAR2 solver
+# budget plus 256 MB headroom (about 770 MB with defaults). Positive: use exactly this value.
+# -1: leave the Go runtime default. GOMEMLIMIT in the environment always wins.
+memory_limit_mb: 0
 mount_path: '' # WebDAV mount path, Example: '/mnt/remotes/altmount' or '/mnt/unionfs'. Must be an absolute path.
                # Windows examples: 'Z:' (drive letter via WinFsp) or 'C:\altmount' (directory mount)
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -303,7 +303,7 @@ providers:
     min_connections_alive: 2 # Warm connections kept open for fast first byte (default: 2, -1 = connect on demand only)
     inflight_requests: 10 # Concurrent bodies per connection (memory ceiling, default: 10); typical depth 3-4, raising does not improve throughput
     stat_inflight_requests: 100 # STAT pipeline depth per connection (determines idle health-sweep concurrency, default: 100)
-    stream_inflight_requests: 4 # Streaming bodies per connection; a playback read waits behind at most this many minus one (default: 4)
+    # stream_inflight_requests: 4 # Optional cap on streaming bodies per connection so a seek waits behind fewer read-ahead bodies; costs sequential throughput on providers that reward deep pipelines (default: same as inflight_requests)
     tls: true
     insecure_tls: false
     enabled: true # Enable/disable this provider (default: true)

--- a/docs/docs/3. Configuration/streaming.md
+++ b/docs/docs/3. Configuration/streaming.md
@@ -83,6 +83,7 @@ fuse:
   max_read_ahead_mb: 128
 
 segment_cache:
+  memory_mb: 256
   enabled: true
   cache_path: /mnt/cache/altmount-segcache
   max_size_gb: 150
@@ -106,27 +107,31 @@ segment_cache:
 
 #### Segment Cache Options
 
-The segment cache provides a persistent on-disk caching layer shared by both FUSE and WebDAV. Each cached entry corresponds to one decoded Usenet article (~750 KB). Enabling it is **strongly recommended** for media playback.
+The segment cache keeps decoded Usenet articles (~750 KB each) for reuse, shared by FUSE and WebDAV. It has two tiers: an in-memory tier that is on by default, and an optional on-disk tier behind it. Enabling the disk tier is **strongly recommended** for media playback.
 
-| Parameter      | Default                    | Description                                                      |
-| -------------- | -------------------------- | ---------------------------------------------------------------- |
-| `enabled`      | `false`                    | Enables the segment cache — **set to `true` for streaming**      |
-| `cache_path`   | `/tmp/altmount-segcache`   | Directory for cached data (use a fast disk for best results)     |
-| `max_size_gb`  | `10`                       | Maximum disk space for the cache (adjust to your available disk) |
-| `expiry_hours` | `24`                       | How long cached segments are kept before eviction                |
+| Parameter      | Default                    | Description                                                                                  |
+| -------------- | -------------------------- | -------------------------------------------------------------------------------------------- |
+| `memory_mb`    | `256`                      | Size of the in-memory tier; `0` disables it. Also settable from the Streaming settings page  |
+| `enabled`      | `false`                    | Enables the disk tier — **set to `true` for streaming**                                      |
+| `cache_path`   | `/tmp/altmount-segcache`   | Directory for cached data (use a fast disk for best results)                                 |
+| `max_size_gb`  | `10`                       | Maximum disk space for the cache (adjust to your available disk)                             |
+| `expiry_hours` | `24`                       | How long cached segments are kept on disk before eviction                                    |
 
 ### How the Segment Cache Works
 
-When `enabled` is `true`, reads flow through a two-tier caching system:
+Reads check memory first, then disk, then fetch from the provider:
 
-1. **Cache hit** — Data is served directly from the local disk cache with no network round-trip.
-2. **Cache miss** — The requested segment is fetched from the backend, written to the disk cache, and returned to the reader.
+1. **Memory hit** — Recently played articles are served from RAM. This is what makes a rewind, a replay of the same file, or a second viewer of the same title instant.
+2. **Disk hit** — Data is served from the local disk cache with no network round-trip and promoted back into memory.
+3. **Miss** — The article is fetched from the provider, kept in memory, and written to the disk cache in the background.
 
-Cache eviction runs automatically every 5 minutes, removing expired entries and enforcing the size limit via LRU (least recently used). Files that are currently open are never evicted.
+Disk eviction runs automatically every 5 minutes, removing expired entries and enforcing the size limit via LRU (least recently used). Files that are currently open are never evicted. The memory tier evicts the least recently used articles as soon as it reaches `memory_mb`.
+
+**RAM usage:** while streaming, AltMount uses roughly `memory_mb` plus 300 MB. The extra is read-ahead buffers, connections and the Go runtime; AltMount sets a soft memory limit of `memory_mb` + 256 MB so evicted articles are collected promptly. With the default of 256 MB expect around 500–550 MB. Lower `memory_mb` on small boxes (128 MB is a good balance), or set `GOMEMLIMIT` in the environment to take over the limit yourself.
 
 ### Tips
 
-- **Enable segment cache** for media playback. Without it, every read goes directly to the backend with no local caching, which will cause buffering.
+- **Enable the disk tier** for media playback. The memory tier alone only covers the last few minutes of video.
 - **Use a fast disk** for `cache_path`. An SSD or NVMe drive significantly improves cache read performance. Avoid placing the cache on the same slow storage you're mounting.
 - Increase `max_size_gb` based on your available disk space. For large libraries, `50`–`150` GB prevents frequent cache evictions during heavy usage.
 - Increase `expiry_hours` to `72` if you re-watch content frequently — this keeps popular segments cached longer.

--- a/docs/docs/3. Configuration/streaming.md
+++ b/docs/docs/3. Configuration/streaming.md
@@ -127,7 +127,9 @@ Reads check memory first, then disk, then fetch from the provider:
 
 Disk eviction runs automatically every 5 minutes, removing expired entries and enforcing the size limit via LRU (least recently used). Files that are currently open are never evicted. The memory tier evicts the least recently used articles as soon as it reaches `memory_mb`.
 
-**RAM usage:** while streaming, AltMount uses roughly `memory_mb` plus 300 MB. The extra is read-ahead buffers, connections and the Go runtime; AltMount sets a soft memory limit of `memory_mb` + 256 MB so evicted articles are collected promptly. With the default of 256 MB expect around 500–550 MB. Lower `memory_mb` on small boxes (128 MB is a good balance), or set `GOMEMLIMIT` in the environment to take over the limit yourself.
+**RAM usage:** while streaming, AltMount uses roughly `memory_mb` plus 300 MB. The extra is read-ahead buffers, connections and the Go runtime. Lower `memory_mb` on small boxes (128 MB is a good balance).
+
+**Go memory limit:** AltMount sets a Go soft memory limit so evicted articles are collected promptly instead of letting the heap double before each collection. The top-level `memory_limit_mb` controls it: unset or `0` derives the limit from `segment_cache.memory_mb` plus the PAR2 solver budget (`par2_repair.max_memory_mb` × `max_concurrent_jobs`) plus 256 MB headroom, about 770 MB with defaults; a positive value pins the limit (for example `512` on a box where only one stream and no repairs run); `-1` leaves the Go default. `GOMEMLIMIT` in the environment always takes precedence, so Docker users can also set it there. Keep the limit above what the process actually holds live: if live memory exceeds a soft limit the collector runs continuously and costs CPU without freeing anything.
 
 ### Tips
 

--- a/docs/docs/5. Troubleshooting/performance.md
+++ b/docs/docs/5. Troubleshooting/performance.md
@@ -149,7 +149,8 @@ If media playback freezes or buffers frequently:
 1. **Shrink the memory cache**: Lower `segment_cache.memory_mb` (default 256). Streaming RAM is roughly this value plus 300 MB, so 128 MB lands near 400 MB total
 2. **Reduce Prefetch**: Lower `streaming.max_prefetch` to use less memory
 3. **Limit Import Workers**: Reduce `import.max_processor_workers`
-4. **Check for Leaks**: Monitor for gradual memory increase over time. A steady figure just under `memory_mb` + 300 MB is the cache doing its job, not a leak
+4. **Pin the Go memory limit**: Set the top-level `memory_limit_mb` (for example `512`) if the automatic limit is too generous for your box; see the streaming configuration page for how it is derived
+5. **Check for Leaks**: Monitor for gradual memory increase over time. A steady figure just under `memory_mb` + 300 MB is the cache doing its job, not a leak
 
 ### Poor Streaming Performance
 

--- a/docs/docs/5. Troubleshooting/performance.md
+++ b/docs/docs/5. Troubleshooting/performance.md
@@ -146,9 +146,10 @@ If media playback freezes or buffers frequently:
 
 **Solutions**:
 
-1. **Reduce Prefetch**: Lower `streaming.max_prefetch` to use less memory
-2. **Limit Import Workers**: Reduce `import.max_processor_workers`
-3. **Check for Leaks**: Monitor for gradual memory increase over time
+1. **Shrink the memory cache**: Lower `segment_cache.memory_mb` (default 256). Streaming RAM is roughly this value plus 300 MB, so 128 MB lands near 400 MB total
+2. **Reduce Prefetch**: Lower `streaming.max_prefetch` to use less memory
+3. **Limit Import Workers**: Reduce `import.max_processor_workers`
+4. **Check for Leaks**: Monitor for gradual memory increase over time. A steady figure just under `memory_mb` + 300 MB is the cache doing its job, not a leak
 
 ### Poor Streaming Performance
 

--- a/docs/docs/6. Development/setup.md
+++ b/docs/docs/6. Development/setup.md
@@ -218,6 +218,64 @@ cd frontend
 bun test
 ```
 
+### Streaming Benchmarks
+
+Changes to the read path (`internal/usenet`, `internal/nzbfilesystem`, `internal/pool`) are gated by a reproducible streaming benchmark. It runs the real reader stack against an in-process Usenet provider simulator (`internal/testsupport/nntpserver`) that models round-trip time, per-connection bandwidth and aggregate bandwidth, so results do not depend on your provider or network.
+
+```bash
+# Run every scenario (about 7-10 minutes) and write bench/results/<short-sha>.json
+make bench-stream
+
+# Fail if any gated metric regressed against a stored result
+make bench-compare BASE=baseline-main
+```
+
+Run it on an idle machine: the simulator is CPU-bound at high aggregate bandwidth and a busy laptop shifts throughput figures by several percent.
+
+#### Provider profiles
+
+| Profile        | RTT    | Per connection | Aggregate | Connections | Models                        |
+| -------------- | ------ | -------------- | --------- | ----------- | ----------------------------- |
+| `premium-750k` | 40 ms  | 8 MB/s         | 400 MB/s  | 50          | Fast provider, 750 KB articles |
+| `slow-4m`      | 100 ms | 3 MB/s         | 60 MB/s   | 20          | Slow provider, 4 MiB articles  |
+
+#### Scenarios
+
+| ID  | Benchmark                        | What it measures                                                                   |
+| --- | -------------------------------- | ---------------------------------------------------------------------------------- |
+| B1  | `BenchmarkStreamColdOpen`        | Time to first byte on a fresh open, and articles fetched to get there              |
+| B2  | `BenchmarkStreamSequential`      | Startup time, steady-state throughput after 16 MB, and bytes fetched vs. delivered |
+| B3  | `BenchmarkStreamSeekStorm`       | Random 64 KB reads across a file: latency and articles per read                    |
+| B4  | `BenchmarkStreamFourConcurrent`  | Four players at once: slowest and fastest stream, stall p99                        |
+| B5  | `BenchmarkStreamTwoHandles`      | Two handles on one file: duplicate article downloads                               |
+| B6  | `BenchmarkStreamUnderContention` | One stream while an import saturates the pool: stream and import throughput        |
+| B7  | `BenchmarkStreamFailover`        | Reads that hit a missing article on the first provider: TTFB and bodies per miss   |
+| B8  | `BenchmarkStreamPauseResume`     | Bytes fetched while the player is paused                                           |
+| B9  | `BenchmarkStreamForwardSkip`     | Jump 100 MB ahead: read latency and articles fetched                               |
+| B10 | `BenchmarkStreamReplay`          | Close and reopen the same file: bytes refetched and replay read time               |
+| B11 | `BenchmarkStreamSeekAndResume`   | Five 500 MB jumps: seek read time and total bytes fetched                          |
+
+#### How the gate works
+
+- Each scenario runs three times (`ALTMOUNT_BENCH_REPS`) and records the median, which removes most run-to-run noise.
+- A metric fails when it moves more than 5 % in its bad direction. Noisy metrics carry a wider per-metric tolerance (for example 15 % on stream throughput under contention).
+- Tail metrics (p99, per-scenario article counts) are informational: they print in the table but never fail the gate.
+- `bench/results/` holds one committed result per landed change (`baseline-main.json`, `phase1-...json`, ...). Per-commit files named by short SHA are scratch output and are not committed.
+
+#### Runtime A/B without code changes
+
+The benchmark binary is a normal Go test, so runtime knobs apply to it. To measure a GC or memory setting, run with the environment variable and compare against the last committed result:
+
+```bash
+GOMEMLIMIT=512MiB ALTMOUNT_BENCH_OUT=$PWD/bench/results/memlimit.json \
+  go test ./internal/nzbfilesystem/ -run '^$' -bench 'BenchmarkStream' -benchtime 1x -timeout 60m
+make bench-compare BASE=phase9-housekeeping BENCH_OUT=bench/results/memlimit.json
+```
+
+#### Adding a scenario
+
+Scenarios live in `internal/nzbfilesystem/stream_bench_test.go` and share the harness in `stream_bench_harness_test.go`. Sample the new scenario on the base branch first and commit that result, so the PR that changes behaviour has a before number. Mark tails and counts with `info(...)` and give inherently noisy metrics a `Tolerance`.
+
 ## Linting and Code Quality
 
 ### Backend Linting

--- a/frontend/src/components/config/StreamingConfigSection.tsx
+++ b/frontend/src/components/config/StreamingConfigSection.tsx
@@ -247,7 +247,8 @@ export function StreamingConfigSection({
 			<div className="border-base-200 border-t pt-10">
 				<h3 className="font-bold text-base-content text-lg">Segment Cache</h3>
 				<p className="text-base-content/50 text-sm">
-					Cache decoded Usenet segments on disk so repeated reads avoid network round-trips.
+					Keep decoded Usenet segments in memory, and optionally on disk, so repeated reads avoid
+					network round-trips.
 				</p>
 				<p className="mt-1 text-base-content/60 text-sm">
 					The segment cache applies regardless of the mount option chosen. It is recommended to
@@ -256,12 +257,61 @@ export function StreamingConfigSection({
 			</div>
 
 			<div className="space-y-8">
+				{/* Memory tier slider */}
+				<div className="space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
+					<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+						<div className="min-w-0">
+							<h4 className="overflow-visible whitespace-normal font-bold text-base-content text-sm">
+								Memory Cache
+							</h4>
+							<p className="mt-1 break-words text-[11px] text-base-content/50 leading-relaxed">
+								Recently played articles kept in RAM so rewinds, replays and a second viewer of the
+								same file are served without downloading again. AltMount uses roughly this amount
+								plus 300 MB of RAM while streaming. Set to 0 to disable.
+							</p>
+						</div>
+						<div className="mt-1 flex shrink-0 items-center justify-start gap-3 sm:mt-0 sm:justify-end">
+							{cacheData.memory_mb === 0 ? (
+								<span className="font-black font-mono text-primary text-xl">Off</span>
+							) : (
+								<>
+									<span className="font-black font-mono text-primary text-xl">
+										{cacheData.memory_mb}
+									</span>
+									<span className="font-bold text-base-content/60 text-xs uppercase">MB</span>
+								</>
+							)}
+						</div>
+					</div>
+
+					<div className="space-y-4">
+						<input
+							type="range"
+							min="0"
+							max="1024"
+							value={cacheData.memory_mb}
+							step="64"
+							className="range range-primary range-sm w-full [&::-webkit-slider-runnable-track]:rounded-full"
+							disabled={isReadOnly}
+							onChange={(e) => handleCacheChange("memory_mb", Number.parseInt(e.target.value, 10))}
+						/>
+						<div className="flex justify-between px-2 font-black text-base-content/50 text-xs">
+							<span>Off</span>
+							<span>256 MB</span>
+							<span>512 MB</span>
+							<span>768 MB</span>
+							<span>1 GB</span>
+						</div>
+					</div>
+				</div>
+
 				{/* Enabled toggle */}
 				<div className="flex items-center justify-between rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
 					<div className="min-w-0">
-						<h4 className="font-bold text-base-content text-sm">Enable Segment Cache</h4>
+						<h4 className="font-bold text-base-content text-sm">Enable Disk Cache</h4>
 						<p className="mt-1 break-words text-[11px] text-base-content/50 leading-relaxed">
-							When enabled, decoded segments are stored on disk and shared by FUSE and WebDAV.
+							When enabled, decoded segments are also stored on disk behind the memory cache and
+							shared by FUSE and WebDAV.
 						</p>
 					</div>
 					<input

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -26,6 +26,7 @@ export interface ConfigResponse {
 	par2_repair: Par2RepairConfig;
 	mount_path: string;
 	mount_type: MountType;
+	memory_limit_mb?: number | null; // Go soft memory limit; 0/unset auto, -1 off
 	api_key?: string;
 	download_key?: string;
 	profiler_enabled: boolean;

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -119,6 +119,7 @@ export interface SegmentCacheConfig {
 	cache_path: string;
 	max_size_gb: number;
 	expiry_hours: number;
+	memory_mb: number; // in-memory tier of decoded articles; 0 disables
 }
 
 // Health configuration

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/javi11/gopar-turbo v0.2.1
-	github.com/javi11/nntppool/v4 v4.22.0
+	github.com/javi11/nntppool/v4 v4.22.2
 	github.com/javi11/nxg v0.1.0
 	github.com/javi11/nzbparser v0.5.5
 	github.com/javi11/rardecode/v2 v2.1.2-0.20260610075131-4664d7a7325a

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/javi11/gopar-turbo v0.2.1 h1:0xUZtofwBcjxle6QIl9EZAwxmLtWkECMM69tQhmc9iA=
 github.com/javi11/gopar-turbo v0.2.1/go.mod h1:fOQZIbPz+ADJ8vGAzVLXvQhsOsE08hvAcev8nQvBFfY=
-github.com/javi11/nntppool/v4 v4.22.0 h1:zDRYcR9LoEQQbLrgSH43Iyv97rpydbTBXeFo9j7W4k4=
-github.com/javi11/nntppool/v4 v4.22.0/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
+github.com/javi11/nntppool/v4 v4.22.2 h1:JHE+78M3yqJp1AGbJQhFKglB0l4cm45XwwetskJQS+A=
+github.com/javi11/nntppool/v4 v4.22.2/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
 github.com/javi11/nxg v0.1.0 h1:CTThldYlaVIPIhpkrMw0HcTD0NLrW1uYMoDILjjEOtM=
 github.com/javi11/nxg v0.1.0/go.mod h1:+GvYpp+y1oq+qBOWxFMvfTjtin/0zCeomWfjiPkiu8A=
 github.com/javi11/nzbparser v0.5.5 h1:kMKyX0xNO7bIeIlQvSPGzdWs71MG2Krf+yojOj+FuUc=

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -39,9 +39,6 @@ const (
 	// providerReconnectDelay lets a provider dropped after a 502 rejoin the
 	// pool instead of staying out until restart.
 	providerReconnectDelay = 30 * time.Second
-	// defaultStreamInflightRequests bounds streaming bodies per connection so
-	// a demand read waits behind at most three read-ahead bodies.
-	defaultStreamInflightRequests = 4
 )
 
 const (
@@ -1505,11 +1502,14 @@ func (p *ProviderConfig) ToNNTPProvider() nntppool.Provider {
 		statInflight = 100
 	}
 
+	// Streaming bodies per connection default to the full pipeline depth.
+	// A tighter cap shortens how long a seek waits behind read-ahead on its
+	// connection, but providers that reward deep pipelines lose sequential
+	// throughput to it: capped at 4 a 15-connection account measured about
+	// 20% below the uncapped pipeline. Users who want the bounded wait set
+	// stream_inflight_requests explicitly.
 	streamInflight := p.StreamInflightRequests
-	if streamInflight <= 0 {
-		streamInflight = defaultStreamInflightRequests
-	}
-	if streamInflight > inflight {
+	if streamInflight <= 0 || streamInflight > inflight {
 		streamInflight = inflight
 	}
 

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -81,6 +81,11 @@ type Config struct {
 	MountPath       string           `yaml:"mount_path" mapstructure:"mount_path" json:"mount_path"`
 	MountType       MountType        `yaml:"mount_type" mapstructure:"mount_type" json:"mount_type"`
 	ProfilerEnabled bool             `yaml:"profiler_enabled" mapstructure:"profiler_enabled" json:"profiler_enabled" default:"false"`
+	// MemoryLimitMB is the Go soft memory limit. Unset or 0 derives it from
+	// the budgets that allocate (see SoftMemoryLimit); a positive value pins
+	// it; a negative value leaves the runtime default. GOMEMLIMIT in the
+	// environment always takes precedence.
+	MemoryLimitMB *int `yaml:"memory_limit_mb" mapstructure:"memory_limit_mb" json:"memory_limit_mb"`
 }
 
 // Par2RepairConfig configures background PAR2 repair of missing usenet
@@ -233,22 +238,33 @@ func (c SegmentCacheConfig) MemoryBytes() int64 {
 	return int64(max(*c.MemoryMB, 0)) << 20
 }
 
-// softMemoryHeadroomMB is what the process needs above the memory tier:
-// read-ahead windows, connection buffers, metadata, and the runtime itself.
+// softMemoryHeadroomMB is what the process needs above the configured
+// budgets: read-ahead windows, connection buffers, metadata, and the runtime.
 const softMemoryHeadroomMB = 256
 
-// SoftMemoryLimit is the Go soft memory limit to apply for this cache budget.
-// Without a limit the collector lets the heap reach twice the live set, so a
-// 256 MB tier costs 600+ MB of RSS. The limit makes the runtime collect the
-// evicted articles as soon as the heap nears budget plus headroom. It is 0
-// (leave the runtime alone) when the memory tier is off or the operator set
-// GOMEMLIMIT themselves.
-func (c SegmentCacheConfig) SoftMemoryLimit(gomemlimit string) int64 {
-	cache := c.MemoryBytes()
-	if cache == 0 || gomemlimit != "" {
+// SoftMemoryLimit is the Go soft memory limit to apply, or 0 to leave the
+// runtime alone. Without a limit the collector lets the heap reach twice the
+// live set, so a 256 MB memory tier costs 600+ MB of RSS. The automatic value
+// adds every budget that holds live heap (memory tier, PAR2 solver per
+// concurrent job) plus headroom, so the limit stays above the live set and the
+// collector never has to run back to back. A soft limit is only useful while
+// the memory tier is on: with it off the heap is small and bursty.
+func (c *Config) SoftMemoryLimit(gomemlimit string) int64 {
+	if gomemlimit != "" {
 		return 0
 	}
-	return cache + int64(softMemoryHeadroomMB)<<20
+	if c.MemoryLimitMB != nil && *c.MemoryLimitMB != 0 {
+		if *c.MemoryLimitMB < 0 {
+			return 0
+		}
+		return int64(*c.MemoryLimitMB) << 20
+	}
+	cache := c.SegmentCache.MemoryBytes()
+	if cache == 0 {
+		return 0
+	}
+	par2 := int64(max(c.Par2Repair.MaxMemoryMB, 0)) * int64(max(c.Par2Repair.MaxConcurrentJobs, 1))
+	return cache + (par2+softMemoryHeadroomMB)<<20
 }
 
 // WebDAVConfig represents WebDAV server configuration

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -1056,6 +1056,8 @@ func (c *Config) Validate() error {
 	if c.SegmentCache.MemoryMB == nil {
 		memoryMB := defaultSegmentCacheMemoryMB
 		c.SegmentCache.MemoryMB = &memoryMB
+	} else if *c.SegmentCache.MemoryMB < 0 {
+		return fmt.Errorf("segment_cache memory_mb must be 0 or greater")
 	}
 
 	if c.Import.MaxProcessorWorkers <= 0 {

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -233,6 +233,24 @@ func (c SegmentCacheConfig) MemoryBytes() int64 {
 	return int64(max(*c.MemoryMB, 0)) << 20
 }
 
+// softMemoryHeadroomMB is what the process needs above the memory tier:
+// read-ahead windows, connection buffers, metadata, and the runtime itself.
+const softMemoryHeadroomMB = 256
+
+// SoftMemoryLimit is the Go soft memory limit to apply for this cache budget.
+// Without a limit the collector lets the heap reach twice the live set, so a
+// 256 MB tier costs 600+ MB of RSS. The limit makes the runtime collect the
+// evicted articles as soon as the heap nears budget plus headroom. It is 0
+// (leave the runtime alone) when the memory tier is off or the operator set
+// GOMEMLIMIT themselves.
+func (c SegmentCacheConfig) SoftMemoryLimit(gomemlimit string) int64 {
+	cache := c.MemoryBytes()
+	if cache == 0 || gomemlimit != "" {
+		return 0
+	}
+	return cache + int64(softMemoryHeadroomMB)<<20
+}
+
 // WebDAVConfig represents WebDAV server configuration
 type WebDAVConfig struct {
 	Port     int    `yaml:"port" mapstructure:"port" json:"port"`

--- a/internal/config/provider_nntp_test.go
+++ b/internal/config/provider_nntp_test.go
@@ -49,8 +49,13 @@ func TestToNNTPProviderSetsReconnectDelay(t *testing.T) {
 
 func TestToNNTPProviderStreamInflightDefaultsAndCaps(t *testing.T) {
 	p := tlsProvider()
-	if got := p.ToNNTPProvider().StreamInflight; got != 4 {
-		t.Fatalf("StreamInflight default = %d, want 4", got)
+	p.InflightRequests = 12
+	if got := p.ToNNTPProvider().StreamInflight; got != 12 {
+		t.Fatalf("StreamInflight default = %d, want inflight_requests (12)", got)
+	}
+	p.InflightRequests = 0
+	if got := p.ToNNTPProvider().StreamInflight; got != 10 {
+		t.Fatalf("StreamInflight default with inflight unset = %d, want 10", got)
 	}
 	p.StreamInflightRequests = 6
 	if got := p.ToNNTPProvider().StreamInflight; got != 6 {

--- a/internal/config/soft_memory_limit_test.go
+++ b/internal/config/soft_memory_limit_test.go
@@ -2,36 +2,71 @@ package config
 
 import "testing"
 
-func TestSoftMemoryLimitDerivesFromCacheBudget(t *testing.T) {
-	mb := 256
-	c := SegmentCacheConfig{MemoryMB: &mb}
-	want := int64(256+softMemoryHeadroomMB) << 20
+func memLimitConfig(cacheMB int, par2MB, par2Jobs int) *Config {
+	c := DefaultConfig()
+	c.SegmentCache.MemoryMB = &cacheMB
+	c.Par2Repair.MaxMemoryMB = par2MB
+	c.Par2Repair.MaxConcurrentJobs = par2Jobs
+	return c
+}
+
+func TestSoftMemoryLimitAutoAddsCachePar2AndHeadroom(t *testing.T) {
+	c := memLimitConfig(256, 256, 1)
+	want := int64(256+256+softMemoryHeadroomMB) << 20
 	if got := c.SoftMemoryLimit(""); got != want {
 		t.Fatalf("SoftMemoryLimit = %d, want %d", got, want)
 	}
 }
 
-func TestSoftMemoryLimitUsesDefaultBudgetWhenUnset(t *testing.T) {
-	c := SegmentCacheConfig{}
-	want := int64(defaultSegmentCacheMemoryMB+softMemoryHeadroomMB) << 20
+func TestSoftMemoryLimitAutoScalesPar2ByConcurrentJobs(t *testing.T) {
+	c := memLimitConfig(128, 100, 3)
+	want := int64(128+300+softMemoryHeadroomMB) << 20
 	if got := c.SoftMemoryLimit(""); got != want {
 		t.Fatalf("SoftMemoryLimit = %d, want %d", got, want)
+	}
+}
+
+func TestSoftMemoryLimitAutoOffWhenMemoryTierDisabled(t *testing.T) {
+	c := memLimitConfig(0, 256, 1)
+	if got := c.SoftMemoryLimit(""); got != 0 {
+		t.Fatalf("SoftMemoryLimit with memory tier off = %d, want 0", got)
+	}
+}
+
+func TestSoftMemoryLimitExplicitValuePins(t *testing.T) {
+	c := memLimitConfig(256, 256, 1)
+	pinned := 1024
+	c.MemoryLimitMB = &pinned
+	if got := c.SoftMemoryLimit(""); got != int64(1024)<<20 {
+		t.Fatalf("SoftMemoryLimit = %d, want 1 GiB", got)
+	}
+}
+
+func TestSoftMemoryLimitNegativeDisables(t *testing.T) {
+	c := memLimitConfig(256, 256, 1)
+	off := -1
+	c.MemoryLimitMB = &off
+	if got := c.SoftMemoryLimit(""); got != 0 {
+		t.Fatalf("SoftMemoryLimit = %d, want 0", got)
+	}
+}
+
+func TestSoftMemoryLimitZeroMeansAuto(t *testing.T) {
+	c := memLimitConfig(256, 256, 1)
+	want := c.SoftMemoryLimit("")
+	auto := 0
+	c.MemoryLimitMB = &auto
+	if got := c.SoftMemoryLimit(""); got != want {
+		t.Fatalf("SoftMemoryLimit = %d, want auto-derived %d", got, want)
 	}
 }
 
 func TestSoftMemoryLimitDefersToOperatorGOMEMLIMIT(t *testing.T) {
-	mb := 256
-	c := SegmentCacheConfig{MemoryMB: &mb}
+	c := memLimitConfig(256, 256, 1)
+	pinned := 1024
+	c.MemoryLimitMB = &pinned
 	if got := c.SoftMemoryLimit("2GiB"); got != 0 {
 		t.Fatalf("SoftMemoryLimit with GOMEMLIMIT set = %d, want 0", got)
-	}
-}
-
-func TestSoftMemoryLimitOffWhenMemoryTierDisabled(t *testing.T) {
-	zero := 0
-	c := SegmentCacheConfig{MemoryMB: &zero}
-	if got := c.SoftMemoryLimit(""); got != 0 {
-		t.Fatalf("SoftMemoryLimit with memory tier off = %d, want 0", got)
 	}
 }
 

--- a/internal/config/soft_memory_limit_test.go
+++ b/internal/config/soft_memory_limit_test.go
@@ -1,0 +1,36 @@
+package config
+
+import "testing"
+
+func TestSoftMemoryLimitDerivesFromCacheBudget(t *testing.T) {
+	mb := 256
+	c := SegmentCacheConfig{MemoryMB: &mb}
+	want := int64(256+softMemoryHeadroomMB) << 20
+	if got := c.SoftMemoryLimit(""); got != want {
+		t.Fatalf("SoftMemoryLimit = %d, want %d", got, want)
+	}
+}
+
+func TestSoftMemoryLimitUsesDefaultBudgetWhenUnset(t *testing.T) {
+	c := SegmentCacheConfig{}
+	want := int64(defaultSegmentCacheMemoryMB+softMemoryHeadroomMB) << 20
+	if got := c.SoftMemoryLimit(""); got != want {
+		t.Fatalf("SoftMemoryLimit = %d, want %d", got, want)
+	}
+}
+
+func TestSoftMemoryLimitDefersToOperatorGOMEMLIMIT(t *testing.T) {
+	mb := 256
+	c := SegmentCacheConfig{MemoryMB: &mb}
+	if got := c.SoftMemoryLimit("2GiB"); got != 0 {
+		t.Fatalf("SoftMemoryLimit with GOMEMLIMIT set = %d, want 0", got)
+	}
+}
+
+func TestSoftMemoryLimitOffWhenMemoryTierDisabled(t *testing.T) {
+	zero := 0
+	c := SegmentCacheConfig{MemoryMB: &zero}
+	if got := c.SoftMemoryLimit(""); got != 0 {
+		t.Fatalf("SoftMemoryLimit with memory tier off = %d, want 0", got)
+	}
+}

--- a/internal/config/soft_memory_limit_test.go
+++ b/internal/config/soft_memory_limit_test.go
@@ -34,3 +34,28 @@ func TestSoftMemoryLimitOffWhenMemoryTierDisabled(t *testing.T) {
 		t.Fatalf("SoftMemoryLimit with memory tier off = %d, want 0", got)
 	}
 }
+
+func TestValidate_SegmentCacheMemoryMB(t *testing.T) {
+	zero, negative, big := 0, -1, 4096
+	tests := []struct {
+		name    string
+		mb      *int
+		wantErr bool
+	}{
+		{"nil defaults", nil, false},
+		{"zero disables", &zero, false},
+		{"large is valid", &big, false},
+		{"negative is invalid", &negative, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := DefaultConfig()
+			c.Health.Enabled = nil
+			c.SegmentCache.MemoryMB = tt.mb
+			err := c.Validate()
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("wantErr=%v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}

--- a/internal/fuse/backend/cgofuse/fs.go
+++ b/internal/fuse/backend/cgofuse/fs.go
@@ -42,6 +42,10 @@ type openHandle struct {
 	path     string
 	closed   atomic.Bool
 	asyncBuf *backend.AsyncReadBuffer // nil when async read-ahead is disabled
+	// ctx lives as long as the handle; Release cancels it so a read parked on
+	// a stalled segment unblocks instead of waiting out the read timeout.
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // FS implements cgofuse.FileSystemInterface using NzbFilesystem.
@@ -131,6 +135,9 @@ func (f *FS) Destroy() {
 func (f *FS) closeHandle(h *openHandle) {
 	if !h.closed.CompareAndSwap(false, true) {
 		return
+	}
+	if h.cancel != nil {
+		h.cancel()
 	}
 	if h.stream != nil && f.cfg.StreamTracker != nil {
 		f.cfg.StreamTracker.Remove(h.stream.ID)
@@ -291,10 +298,13 @@ func (f *FS) OpenEx(path string, fi *cgofuse.FileInfo_t) int {
 		return -cgofuse.EIO
 	}
 
+	hctx, hcancel := context.WithCancel(context.Background())
 	h := &openHandle{
 		file:   file,
 		stream: stream,
 		path:   clean,
+		ctx:    hctx,
+		cancel: hcancel,
 	}
 
 	// Attach a read-ahead buffer for sufficiently large files. The buffer
@@ -336,7 +346,7 @@ func (f *FS) Read(path string, buff []byte, ofst int64, fh uint64) int {
 
 	var n int
 	var err error
-	ctx := context.Background()
+	ctx := h.ctx
 
 	if h.asyncBuf != nil {
 		n, err = h.asyncBuf.ReadAtContext(ctx, buff, ofst)

--- a/internal/nzbfilesystem/stream_bench_harness_test.go
+++ b/internal/nzbfilesystem/stream_bench_harness_test.go
@@ -126,6 +126,7 @@ func newBenchHarness(tb testing.TB, p benchProfile, cfgs ...nntpserver.Config) *
 			MinConnections: p.Conns,
 			Inflight:       p.Inflight,
 			StatInflight:   p.StatInflight,
+			StreamInflight: p.Inflight,
 			SkipPing:       true,
 			IdleTimeout:    time.Hour,
 		})

--- a/internal/pool/specbudget.go
+++ b/internal/pool/specbudget.go
@@ -15,12 +15,16 @@ type SpeculativeBudget struct {
 }
 
 // speculativeBodiesPerConn is how many speculative bodies a connection is
-// worth: the depth at which pipelining stops paying off.
-const speculativeBodiesPerConn = 3
+// worth: one below the default per-connection stream cap, so read-ahead can
+// fill every connection's pipeline while each still has a slot left for a
+// demand read. Providers that serve articles slowly are depth-bound, so a
+// smaller figure costs throughput directly: three per connection measured
+// about 15% below the full pipeline at a 15-connection budget.
+const speculativeBodiesPerConn = 4
 
 func NewSpeculativeBudget() *SpeculativeBudget { return &SpeculativeBudget{} }
 
-// SetCapacity derives the slot count from total provider connections: three
+// SetCapacity derives the slot count from total provider connections: four
 // bodies per connection, minus one so a demand read never finds every slot
 // taken by read-ahead. Zero or negative disables the budget (unlimited).
 func (b *SpeculativeBudget) SetCapacity(totalConns int) {

--- a/internal/pool/specbudget_test.go
+++ b/internal/pool/specbudget_test.go
@@ -5,8 +5,12 @@ import "testing"
 func TestSpeculativeBudgetCapacityFormula(t *testing.T) {
 	b := NewSpeculativeBudget()
 	b.SetCapacity(50)
-	if got := b.Capacity(); got != 149 {
-		t.Fatalf("Capacity(50 conns) = %d, want 149", got)
+	if got := b.Capacity(); got != 199 {
+		t.Fatalf("Capacity(50 conns) = %d, want 199", got)
+	}
+	b.SetCapacity(15)
+	if got := b.Capacity(); got != 59 {
+		t.Fatalf("Capacity(15 conns) = %d, want 59", got)
 	}
 	b.SetCapacity(0)
 	if got := b.Capacity(); got != 0 {
@@ -24,15 +28,17 @@ func TestSpeculativeBudgetCapacityFormula(t *testing.T) {
 
 func TestSpeculativeBudgetBoundsAndReleases(t *testing.T) {
 	b := NewSpeculativeBudget()
-	b.SetCapacity(1) // 1*3-1 = 2 slots
+	b.SetCapacity(1) // 1*4-1 = 3 slots
 	r1, ok1 := b.TryAcquire()
 	r2, ok2 := b.TryAcquire()
-	if !ok1 || !ok2 {
-		t.Fatal("two slots expected")
+	r3, ok3 := b.TryAcquire()
+	if !ok1 || !ok2 || !ok3 {
+		t.Fatal("three slots expected")
 	}
 	if _, ok := b.TryAcquire(); ok {
-		t.Fatal("third acquire must be refused")
+		t.Fatal("fourth acquire must be refused")
 	}
+	r3()
 	r1()
 	r1() // idempotent
 	if b.InFlight() != 1 {

--- a/internal/usenet/buffered_offset_test.go
+++ b/internal/usenet/buffered_offset_test.go
@@ -1,0 +1,52 @@
+package usenet
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/altmount/internal/testsupport/segments"
+)
+
+// GetBufferedOffset reports scheduled bytes from counters and never
+// re-materialises a released segment slot.
+func TestBufferedOffsetDoesNotResurrectReleasedSegments(t *testing.T) {
+	ctx := context.Background()
+	const n, segSize = 6, 128
+	fp := fakepool.New()
+	for i := 0; i < n; i++ {
+		fp.SetBehavior(segments.MessageID(i), fakepool.SegmentBehavior{Bytes: segments.Payload(i, segSize)})
+	}
+	loader := eagerLoader{n: n, size: segSize}
+	rg := NewLazySegmentRange(ctx, 0, int64(n*segSize-1), loader, 0, 0, n-1, int64((n-1)*segSize))
+	ur := newReaderForTest(t, ctx, fp, rg, 2)
+	ur.Start()
+	buf := make([]byte, 3*segSize)
+	if _, err := io.ReadFull(ur, buf); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	off := ur.GetBufferedOffset()
+	if off < 3*segSize || off > int64(n*segSize) {
+		t.Fatalf("buffered offset %d out of range", off)
+	}
+	rg.mu.RLock()
+	defer rg.mu.RUnlock()
+	// Segments 0 and 1 are consumed and released; 2 is still current.
+	for i := 0; i < 2; i++ {
+		if rg.segments[i] != nil {
+			t.Fatalf("consumed slot %d was re-materialised", i)
+		}
+	}
+}
+
+type eagerLoader struct{ n, size int }
+
+func (l eagerLoader) GetSegment(i int) (Segment, []string, bool) {
+	if i < 0 || i >= l.n {
+		return Segment{}, nil, false
+	}
+	return Segment{Id: segments.MessageID(i), Start: 0, End: int64(l.size - 1), Size: int64(l.size)}, nil, true
+}

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -521,24 +521,17 @@ func (b *UsenetReader) BufferedAhead() int64 {
 	return max(b.scheduledBytes-b.totalBytesRead, 0)
 }
 
+// GetBufferedOffset reports the file offset up to which this reader has
+// scheduled fetches: the range start plus every scheduled segment's usable
+// bytes. It reads counters only, so it never re-materialises a segment slot
+// the reader has already consumed and released.
 func (b *UsenetReader) GetBufferedOffset() int64 {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-
 	if b.rg == nil {
 		return 0
 	}
-
-	if b.nextToDownload == 0 {
-		return 0
-	}
-
-	idx := b.nextToDownload - 1
-	s, err := b.rg.GetSegment(idx)
-	if err != nil || s == nil {
-		return 0
-	}
-	return s.Start + int64(s.SegmentSize)
+	return b.rg.start + b.scheduledBytes
 }
 
 // downloadSegmentWithRetry attempts to download a segment with retry logic for pool unavailability


### PR DESCRIPTION
Top of the stack: #903 → #902 → #901 → #899 → #898 → #897 → #896 → #895 → #894. **Pull this branch to test the whole series.**

## Summary
- cgofuse (macOS / FUSE-T) reads now run under a per-handle context that `Release` cancels, so a read parked on a stalled segment unblocks instead of waiting out the 120 s read timeout. Previously `context.Background()` made those reads uncancellable.
- `UsenetReader.GetBufferedOffset` is computed from the range start plus scheduled bytes. It used to re-materialise the consumed lazy segment slot it was asked about, leaving a segment with a never-completing buffer behind on every read.
- `config.sample.yaml` `streaming.max_prefetch` documented at the real default (60) and mentions the 96 MB byte cap.

## Audit notes (spec phase 9)
- Error ranking: nntppool delivers a 430 when any provider returned one even if another provider timed out, after its escalation pass has re-asked the slow provider with a wider window. Kept as is: the alternative (a flaky provider turning every genuinely missing article into a hard read failure) is worse, and padding is now bounded by the run/total/ratio caps plus the 24 h TTL and provider fingerprint from #903. The reader side is pinned by `TestTransportFailureNeverBecomesAHole`.
- `internal/pool/headroom.go` is not dead: the pool contention benchmark's adaptive scenarios drive it. Kept.
- `ReconnectDelay` for providers dropped on 502 landed in #895.

## Whole-stack result (medians of 3, simulated provider, vs the baseline committed in #894)

| Scenario | Metric | main | stack |
|---|---|---|---|
| B1 cold open, 750 KB articles | first byte (ms) | 146 | 48 |
| B1 cold open, 4 MiB articles | first byte (ms) | 3907 | 118 |
| B2 sequential, 750 KB | steady MB/s | 219 | 267 |
| B2 sequential, 4 MiB | steady MB/s / fetched per byte read | 35 / 2.21 | 56 / 1.12 |
| B4 four players, one title | per-player MB/s | 78-91 | 203 |
| B5 two handles, one file | duplicate downloads | 127 | 0 |
| B6 playback during import | stream / import MB/s | (162) / 136 | 227 / 139 |
| B10 reopen after probe | replay read of 32 MB head (ms) | 242 | 7 |
| B11 seek storm, 4 MiB | bytes for 48 MB read / read after seek | 1507 MB / 6.3 s | 551 MB / 4.1 s |

No REGRESSION rows at any phase; every PR carries its own table and a live A/B against the dev providers.

## Test plan
- [x] `go test -race` on `internal/usenet`, `internal/nzbfilesystem`, `internal/fuse/backend/cgofuse`
- [x] `TestBufferedOffsetDoesNotResurrectReleasedSegments`
- [x] `make bench-compare BASE=baseline-main` no regressions
- [ ] manual: play, seek, and re-open files through WebDAV and FUSE from this branch