### PR TITLE
feat(importer): recover headers past a dead first article, gate release rename, reuse parse work

### DIFF
--- a/frontend/src/components/config/WorkersConfigSection.tsx
+++ b/frontend/src/components/config/WorkersConfigSection.tsx
@@ -264,7 +264,9 @@ export function ImportConfigSection({
 								<div className="min-w-0">
 									<span className="block break-words font-bold text-xs">Rename to NZB Name</span>
 									<span className="mt-0.5 block break-words text-[11px] text-base-content/50 leading-snug">
-										Rename single-file imports to the NZB release name, not the obfuscated original.
+										Present an obfuscated payload under the NZB release name (SABnzbd rules): only
+										when its name says nothing and it clearly is the release; subtitles and samples
+										sharing its name follow it.
 									</span>
 								</div>
 							</label>

--- a/internal/importer/archive/payload_rename.go
+++ b/internal/importer/archive/payload_rename.go
@@ -1,0 +1,127 @@
+package archive
+
+import (
+	"path"
+	"strings"
+
+	"github.com/javi11/altmount/internal/importer/parser/fileinfo"
+)
+
+// payloadDominanceFactor is how much bigger than the runner-up the largest
+// entry must be before it can be called the release. A release is one large
+// file beside small ones; several files of a size are a set (a season pack in
+// one archive), and renaming one of them to the release name would be a guess.
+const payloadDominanceFactor = 3
+
+// excludedFromRename are extensions a payload is never renamed under: disc
+// structures and split containers, where a player finds the next piece by name.
+var excludedFromRename = map[string]bool{
+	".vob": true, ".rar": true, ".par2": true, ".mts": true, ".m2ts": true,
+	".cpi": true, ".clpi": true, ".mpl": true, ".mpls": true, ".bdm": true, ".bdmv": true,
+}
+
+// discStructureDirs name a ripped disc, where every filename is part of an
+// index the player reads.
+var discStructureDirs = map[string]bool{"video_ts": true, "audio_ts": true, "bdmv": true}
+
+// PayloadRenames decides which archive entries are presented under the release
+// name, following SABnzbd's final-filename deobfuscation: only the entry that
+// is clearly the release — largest by a wide margin, not part of a disc
+// structure, and carrying a name that says nothing — is renamed, and files
+// sharing its stem (subtitles, samples) follow it so they stay paired.
+//
+// Keys are the entries' InternalPath as given; values are the new leaf name.
+// A nil result means nothing should be renamed.
+func PayloadRenames(contents []Content, releaseName string) map[string]string {
+	release := strings.TrimSpace(path.Base(strings.ReplaceAll(releaseName, `\`, "/")))
+	if release == "" || release == "." || release == "/" || len(contents) == 0 {
+		return nil
+	}
+
+	var biggest *Content
+	var runnerUp int64
+	for i := range contents {
+		c := &contents[i]
+		if c.IsDirectory || c.Size == 0 {
+			continue
+		}
+		if hasDiscStructure(normalizePath(c.InternalPath)) {
+			return nil
+		}
+		switch {
+		case biggest == nil || c.Size > biggest.Size:
+			if biggest != nil {
+				runnerUp = biggest.Size
+			}
+			biggest = c
+		case c.Size > runnerUp:
+			runnerUp = c.Size
+		}
+	}
+	if biggest == nil {
+		return nil
+	}
+	if runnerUp > 0 && biggest.Size < runnerUp*payloadDominanceFactor {
+		return nil
+	}
+
+	payload := normalizePath(biggest.InternalPath)
+	ext := path.Ext(payload)
+	if excludedFromRename[strings.ToLower(ext)] {
+		return nil
+	}
+	leaf := path.Base(payload)
+	if !fileinfo.IsProbablyObfuscated(leaf) {
+		return nil
+	}
+
+	// "Movie.2019.mkv" must not become "Movie.2019.mkv.mkv".
+	target := release
+	if strings.EqualFold(path.Ext(target), ext) {
+		target = strings.TrimSuffix(target, path.Ext(target))
+	}
+
+	stem := strings.TrimSuffix(leaf, ext)
+	dir := path.Dir(payload)
+
+	taken := make(map[string]struct{}, len(contents))
+	for _, c := range contents {
+		taken[strings.ToLower(normalizePath(c.InternalPath))] = struct{}{}
+	}
+
+	renames := make(map[string]string)
+	for _, c := range contents {
+		if c.IsDirectory {
+			continue
+		}
+		current := normalizePath(c.InternalPath)
+		if path.Dir(current) != dir || !strings.HasPrefix(path.Base(current), stem) {
+			continue
+		}
+		newLeaf := target + strings.TrimPrefix(path.Base(current), stem)
+		renamed := newLeaf
+		if dir != "." && dir != "/" {
+			renamed = dir + "/" + newLeaf
+		}
+		// Renaming onto a name the archive already uses would hide one file
+		// behind another; the hash names are better than a lost entry.
+		if _, clash := taken[strings.ToLower(renamed)]; clash && !strings.EqualFold(renamed, current) {
+			return nil
+		}
+		renames[c.InternalPath] = newLeaf
+	}
+	return renames
+}
+
+func normalizePath(p string) string {
+	return path.Clean(strings.ReplaceAll(p, `\`, "/"))
+}
+
+func hasDiscStructure(p string) bool {
+	for _, part := range strings.Split(p, "/") {
+		if discStructureDirs[strings.ToLower(part)] {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/importer/archive/payload_rename_test.go
+++ b/internal/importer/archive/payload_rename_test.go
@@ -1,0 +1,114 @@
+package archive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPayloadRenames(t *testing.T) {
+	const release = "Some.Movie.2024.1080p.WEB-DL-GRP"
+
+	tests := []struct {
+		name     string
+		release  string // defaults to release
+		contents []Content
+		want     map[string]string
+	}{
+		{
+			name: "single obfuscated payload renamed to release",
+			contents: []Content{
+				{InternalPath: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Size: 5_000_000},
+			},
+			want: map[string]string{"a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv": release + ".mkv"},
+		},
+		{
+			name: "sidecars sharing the payload stem follow it",
+			contents: []Content{
+				{InternalPath: "x9y8z7w6v5u4t3s2r1q0p9o8n7m6l5k4.mkv", Size: 5_000_000},
+				{InternalPath: "x9y8z7w6v5u4t3s2r1q0p9o8n7m6l5k4.eng.srt", Size: 40_000},
+				{InternalPath: "x9y8z7w6v5u4t3s2r1q0p9o8n7m6l5k4-sample.mkv", Size: 200_000},
+				{InternalPath: "readme.nfo", Size: 1_000},
+			},
+			want: map[string]string{
+				"x9y8z7w6v5u4t3s2r1q0p9o8n7m6l5k4.mkv":        release + ".mkv",
+				"x9y8z7w6v5u4t3s2r1q0p9o8n7m6l5k4.eng.srt":    release + ".eng.srt",
+				"x9y8z7w6v5u4t3s2r1q0p9o8n7m6l5k4-sample.mkv": release + "-sample.mkv",
+			},
+		},
+		{
+			name: "payload in a subdirectory keeps only the leaf renamed",
+			contents: []Content{
+				{InternalPath: "Inner/a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Size: 5_000_000},
+			},
+			want: map[string]string{"Inner/a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv": release + ".mkv"},
+		},
+		{
+			name: "several files of a size are a set, nothing renamed",
+			contents: []Content{
+				{InternalPath: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Size: 1_000_000},
+				{InternalPath: "b3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Size: 1_100_000},
+				{InternalPath: "c3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Size: 900_000},
+			},
+			want: nil,
+		},
+		{
+			name: "clean payload name is left alone",
+			contents: []Content{
+				{InternalPath: "Some.Movie.2024.PROPER.1080p.mkv", Size: 5_000_000},
+			},
+			want: nil,
+		},
+		{
+			name: "disc structure is never renamed",
+			contents: []Content{
+				{InternalPath: "BDMV/STREAM/00001.m2ts", Size: 5_000_000},
+				{InternalPath: "BDMV/index.bdmv", Size: 100},
+			},
+			want: nil,
+		},
+		{
+			name: "split container extension is never renamed",
+			contents: []Content{
+				{InternalPath: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.vob", Size: 5_000_000},
+			},
+			want: nil,
+		},
+		{
+			name:    "release already carrying the extension is not doubled",
+			release: release + ".mkv",
+			contents: []Content{
+				{InternalPath: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Size: 5_000_000},
+			},
+			want: map[string]string{"a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv": release + ".mkv"},
+		},
+		{
+			name: "rename that would collide with an existing entry is abandoned",
+			contents: []Content{
+				{InternalPath: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Size: 5_000_000},
+				{InternalPath: release + ".mkv", Size: 10},
+			},
+			want: nil,
+		},
+		{
+			name: "directories and empty entries are ignored",
+			contents: []Content{
+				{InternalPath: "Extras", IsDirectory: true},
+				{InternalPath: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Size: 5_000_000},
+				{InternalPath: "empty.txt", Size: 0},
+			},
+			want: map[string]string{"a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv": release + ".mkv"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rel := tt.release
+			if rel == "" {
+				rel = release
+			}
+			got := PayloadRenames(tt.contents, rel)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/importer/archive/rar/aggregator.go
+++ b/internal/importer/archive/rar/aggregator.go
@@ -229,19 +229,15 @@ func ProcessArchive(ctx context.Context, opts ProcessArchiveOptions) error {
 	slog.InfoContext(ctx, "Starting RAR archive processing",
 		"total_files", len(rarContents))
 
-	// Determine if we should rename the file to match the NZB basename
-	// Only do this if there's exactly one media file in the archive
-	mediaFilesCount := 0
-	for _, content := range rarContents {
-		if !content.IsDirectory && (utils.IsAllowedFile(content.InternalPath, content.Size, allowedFileExtensions, filterSamples) ||
-			utils.IsAllowedFile(content.Filename, content.Size, allowedFileExtensions, filterSamples)) {
-			mediaFilesCount++
-		}
-	}
-
 	nzbName := filepath.Base(nzbPath)
 	releaseName := nzbtrim.TrimNzbExtension(nzbName)
-	shouldNormalizeName := renameToNzbName && mediaFilesCount == 1
+
+	// Present an obfuscated payload under the release name, SABnzbd-style:
+	// only the entry that is clearly the release, with its sidecars in tow.
+	var payloadRenames map[string]string
+	if renameToNzbName {
+		payloadRenames = archive.PayloadRenames(rarContents, releaseName)
+	}
 
 	// Count ISO-expanded files so single-file ISOs omit the index suffix.
 	isoExpandedCount := 0
@@ -299,12 +295,11 @@ func ProcessArchive(ctx context.Context, opts ProcessArchiveOptions) error {
 				"original", rarContent.Filename,
 				"renamed", baseFilename)
 			internalSubDir = "."
-		} else if shouldNormalizeName && (utils.IsAllowedFile(rarContent.InternalPath, rarContent.Size, allowedFileExtensions, filterSamples) ||
-			utils.IsAllowedFile(rarContent.Filename, rarContent.Size, allowedFileExtensions, filterSamples)) {
-			baseFilename = normalizeArchiveReleaseFilename(nzbName, baseFilename)
+		} else if renamed, ok := payloadRenames[rarContent.InternalPath]; ok {
 			slog.InfoContext(ctx, "Normalizing obfuscated filename in RAR archive",
 				"original", rarContent.Filename,
-				"normalized", baseFilename)
+				"normalized", renamed)
+			baseFilename = renamed
 			internalSubDir = "."
 		}
 
@@ -460,21 +455,4 @@ func GroupArchivesByBaseName(files []parser.ParsedFile) [][]parser.ParsedFile {
 	// recover a shared name) shatters into one single-file group per volume; fold it
 	// back into one ordered set using the volumes' own contiguous ordinals.
 	return reconcileObfuscatedVolumeSet(groups)
-}
-
-// normalizeArchiveReleaseFilename aligns the filename to the NZB basename while keeping the original extension.
-func normalizeArchiveReleaseFilename(nzbFilename, originalFilename string) string {
-	releaseName := nzbtrim.TrimNzbExtension(nzbFilename)
-	fileExt := filepath.Ext(originalFilename)
-
-	if fileExt == "" {
-		return releaseName
-	}
-
-	// If release name already contains the extension (e.g. Movie.mkv.nzb -> Movie.mkv), don't duplicate
-	if strings.HasSuffix(strings.ToLower(releaseName), strings.ToLower(fileExt)) {
-		return releaseName
-	}
-
-	return releaseName + fileExt
 }

--- a/internal/importer/archive/rar/aggregator_test.go
+++ b/internal/importer/archive/rar/aggregator_test.go
@@ -306,6 +306,53 @@ func TestProcessArchivePreservesInternalFolderStructure(t *testing.T) {
 			notWantMetaPaths: []string{"movies/MyMovie/SubFolder/obfuscated.mkv"},
 		},
 		{
+			name:            "season pack with rename: similar-size files are left alone",
+			virtualDir:      "tv/Show.S01",
+			nzbPath:         "tv/Show.S01.nzb",
+			renameToNzbName: true,
+			contents: []Content{
+				{InternalPath: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Filename: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Size: 2000,
+					Segments: []*metapb.SegmentData{{Id: "seg1", StartOffset: 0, EndOffset: 1999}}},
+				{InternalPath: "b3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Filename: "b3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Size: 2100,
+					Segments: []*metapb.SegmentData{{Id: "seg2", StartOffset: 0, EndOffset: 2099}}},
+			},
+			wantMetaPaths: []string{
+				"tv/Show.S01/a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv",
+				"tv/Show.S01/b3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv",
+			},
+			notWantMetaPaths: []string{"tv/Show.S01/Show.S01.mkv"},
+		},
+		{
+			name:            "rename: subtitle sharing the payload stem follows it",
+			virtualDir:      "movies/MyMovie",
+			nzbPath:         "movies/MyMovie.nzb",
+			renameToNzbName: true,
+			contents: []Content{
+				{InternalPath: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Filename: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Size: 20000,
+					Segments: []*metapb.SegmentData{{Id: "seg1", StartOffset: 0, EndOffset: 19999}}},
+				{InternalPath: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.eng.srt", Filename: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.eng.srt", Size: 100,
+					Segments: []*metapb.SegmentData{{Id: "seg2", StartOffset: 0, EndOffset: 99}}},
+			},
+			extractedFiles: []parser.ExtractedFileInfo{{Name: "MyMovie.mkv", Size: 20000}, {Name: "MyMovie.eng.srt", Size: 100}},
+			wantMetaPaths:  []string{"movies/MyMovie/MyMovie.mkv", "movies/MyMovie/MyMovie.eng.srt"},
+			notWantMetaPaths: []string{
+				"movies/MyMovie/a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv",
+				"movies/MyMovie/a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.eng.srt",
+			},
+		},
+		{
+			name:            "rename: clean payload name is kept",
+			virtualDir:      "movies/MyMovie",
+			nzbPath:         "movies/MyMovie.nzb",
+			renameToNzbName: true,
+			contents: []Content{
+				{InternalPath: "My.Movie.2024.PROPER.1080p.mkv", Filename: "My.Movie.2024.PROPER.1080p.mkv", Size: 2000,
+					Segments: []*metapb.SegmentData{{Id: "seg1", StartOffset: 0, EndOffset: 1999}}},
+			},
+			wantMetaPaths:    []string{"movies/MyMovie/My.Movie.2024.PROPER.1080p.mkv"},
+			notWantMetaPaths: []string{"movies/MyMovie/MyMovie.mkv"},
+		},
+		{
 			name:       "windows-style backslash paths normalized",
 			virtualDir: "movies/MyMovie",
 			nzbPath:    "movies/MyMovie.nzb",

--- a/internal/importer/archive/sevenzip/aggregator.go
+++ b/internal/importer/archive/sevenzip/aggregator.go
@@ -171,19 +171,15 @@ func ProcessArchive(ctx context.Context, opts ProcessArchiveOptions) error {
 	slog.InfoContext(ctx, "Starting 7zip archive processing",
 		"total_files", len(sevenZipContents))
 
-	// Determine if we should rename the file to match the NZB basename
-	// Only do this if there's exactly one media file in the archive
-	mediaFilesCount := 0
-	for _, content := range sevenZipContents {
-		if !content.IsDirectory && (utils.IsAllowedFile(content.InternalPath, content.Size, allowedFileExtensions, filterSamples) ||
-			utils.IsAllowedFile(content.Filename, content.Size, allowedFileExtensions, filterSamples)) {
-			mediaFilesCount++
-		}
-	}
-
 	nzbName := filepath.Base(nzbPath)
 	releaseName := nzbtrim.TrimNzbExtension(nzbName)
-	shouldNormalizeName := renameToNzbName && mediaFilesCount == 1
+
+	// Present an obfuscated payload under the release name, SABnzbd-style:
+	// only the entry that is clearly the release, with its sidecars in tow.
+	var payloadRenames map[string]string
+	if renameToNzbName {
+		payloadRenames = archive.PayloadRenames(sevenZipContents, releaseName)
+	}
 
 	// Count ISO-expanded files so single-file ISOs omit the index suffix.
 	isoExpandedCount := 0
@@ -230,12 +226,11 @@ func ProcessArchive(ctx context.Context, opts ProcessArchiveOptions) error {
 				"original", sevenZipContent.Filename,
 				"renamed", baseFilename)
 			internalSubDir = "."
-		} else if shouldNormalizeName && (utils.IsAllowedFile(sevenZipContent.InternalPath, sevenZipContent.Size, allowedFileExtensions, filterSamples) ||
-			utils.IsAllowedFile(sevenZipContent.Filename, sevenZipContent.Size, allowedFileExtensions, filterSamples)) {
-			baseFilename = normalizeArchiveReleaseFilename(nzbName, baseFilename)
+		} else if renamed, ok := payloadRenames[sevenZipContent.InternalPath]; ok {
 			slog.InfoContext(ctx, "Normalizing obfuscated filename in 7zip archive",
 				"original", sevenZipContent.Filename,
-				"normalized", baseFilename)
+				"normalized", renamed)
+			baseFilename = renamed
 			internalSubDir = "."
 		}
 
@@ -366,21 +361,4 @@ func ProcessArchive(ctx context.Context, opts ProcessArchiveOptions) error {
 		"files_processed", int(atomic.LoadInt32(&filesProcessed))+preProcessedCount)
 
 	return nil
-}
-
-// normalizeArchiveReleaseFilename aligns the filename to the NZB basename while keeping the original extension.
-func normalizeArchiveReleaseFilename(nzbFilename, originalFilename string) string {
-	releaseName := nzbtrim.TrimNzbExtension(nzbFilename)
-	fileExt := filepath.Ext(originalFilename)
-
-	if fileExt == "" {
-		return releaseName
-	}
-
-	// If release name already contains the extension (e.g. Movie.mkv.nzb -> Movie.mkv), don't duplicate
-	if strings.HasSuffix(strings.ToLower(releaseName), strings.ToLower(fileExt)) {
-		return releaseName
-	}
-
-	return releaseName + fileExt
 }

--- a/internal/importer/archive/sevenzip/aggregator_test.go
+++ b/internal/importer/archive/sevenzip/aggregator_test.go
@@ -108,6 +108,53 @@ func TestProcessArchivePreservesInternalFolderStructure(t *testing.T) {
 			notWantMetaPaths: []string{"movies/MyMovie/SubFolder/obfuscated.mkv"},
 		},
 		{
+			name:            "season pack with rename: similar-size files are left alone",
+			virtualDir:      "tv/Show.S01",
+			nzbPath:         "tv/Show.S01.nzb",
+			renameToNzbName: true,
+			contents: []Content{
+				{InternalPath: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Filename: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Size: 2000,
+					Segments: []*metapb.SegmentData{{Id: "seg1", StartOffset: 0, EndOffset: 1999}}},
+				{InternalPath: "b3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Filename: "b3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Size: 2100,
+					Segments: []*metapb.SegmentData{{Id: "seg2", StartOffset: 0, EndOffset: 2099}}},
+			},
+			wantMetaPaths: []string{
+				"tv/Show.S01/a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv",
+				"tv/Show.S01/b3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv",
+			},
+			notWantMetaPaths: []string{"tv/Show.S01/Show.S01.mkv"},
+		},
+		{
+			name:            "rename: subtitle sharing the payload stem follows it",
+			virtualDir:      "movies/MyMovie",
+			nzbPath:         "movies/MyMovie.nzb",
+			renameToNzbName: true,
+			contents: []Content{
+				{InternalPath: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Filename: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv", Size: 20000,
+					Segments: []*metapb.SegmentData{{Id: "seg1", StartOffset: 0, EndOffset: 19999}}},
+				{InternalPath: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.eng.srt", Filename: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.eng.srt", Size: 100,
+					Segments: []*metapb.SegmentData{{Id: "seg2", StartOffset: 0, EndOffset: 99}}},
+			},
+			extractedFiles: []parser.ExtractedFileInfo{{Name: "MyMovie.mkv", Size: 20000}, {Name: "MyMovie.eng.srt", Size: 100}},
+			wantMetaPaths:  []string{"movies/MyMovie/MyMovie.mkv", "movies/MyMovie/MyMovie.eng.srt"},
+			notWantMetaPaths: []string{
+				"movies/MyMovie/a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv",
+				"movies/MyMovie/a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.eng.srt",
+			},
+		},
+		{
+			name:            "rename: clean payload name is kept",
+			virtualDir:      "movies/MyMovie",
+			nzbPath:         "movies/MyMovie.nzb",
+			renameToNzbName: true,
+			contents: []Content{
+				{InternalPath: "My.Movie.2024.PROPER.1080p.mkv", Filename: "My.Movie.2024.PROPER.1080p.mkv", Size: 2000,
+					Segments: []*metapb.SegmentData{{Id: "seg1", StartOffset: 0, EndOffset: 1999}}},
+			},
+			wantMetaPaths:    []string{"movies/MyMovie/My.Movie.2024.PROPER.1080p.mkv"},
+			notWantMetaPaths: []string{"movies/MyMovie/MyMovie.mkv"},
+		},
+		{
 			name:       "windows-style backslash paths normalized",
 			virtualDir: "movies/MyMovie",
 			nzbPath:    "movies/MyMovie.nzb",

--- a/internal/importer/deferred_repair_test.go
+++ b/internal/importer/deferred_repair_test.go
@@ -151,3 +151,25 @@ func TestBailoutWhenNothingToRepairFrom(t *testing.T) {
 		t.Fatal("a fully damaged release with no PAR2 must still bail out")
 	}
 }
+
+// A header recovered from a later article marks the file degraded in the parser;
+// that must reach the repair queue alongside the fast-fail sweep's own findings.
+func TestMergeDegradedFilesCombinesSweepAndParserFindings(t *testing.T) {
+	sweep := map[string]string{"a.mkv": "seg-a"}
+	fromParser := map[string]string{"b.mkv": "seg-b", "a.mkv": "seg-a2"}
+
+	got := mergeDegradedFiles(sweep, fromParser)
+
+	if got["a.mkv"] != "seg-a" {
+		t.Errorf("sweep finding must win for a.mkv, got %q", got["a.mkv"])
+	}
+	if got["b.mkv"] != "seg-b" {
+		t.Errorf("parser finding missing for b.mkv, got %q", got["b.mkv"])
+	}
+	if nilMerge := mergeDegradedFiles(nil, map[string]string{"c.mkv": "seg-c"}); nilMerge["c.mkv"] != "seg-c" {
+		t.Errorf("merging into nil map lost c.mkv: %+v", nilMerge)
+	}
+	if empty := mergeDegradedFiles(nil, nil); empty != nil {
+		t.Errorf("merging two nil maps should stay nil, got %+v", empty)
+	}
+}

--- a/internal/importer/parser/fileinfo/fileinfo.go
+++ b/internal/importer/parser/fileinfo/fileinfo.go
@@ -83,7 +83,9 @@ func getFileInfo(
 	// RAR set whose first volume PAR2 named differently from its .rNN continuations.
 	if !fromPar2 && nzbFilenameStem != "" && (filename == "" || isProbablyObfuscated(filename)) {
 		ext := filepath.Ext(filename)
-		if ext != "" {
+		// An NZB named after its file ("The.Movie.mkv.nzb") already carries the
+		// extension in the stem; don't double it.
+		if ext != "" && !strings.EqualFold(filepath.Ext(nzbFilenameStem), ext) {
 			filename = nzbFilenameStem + ext
 		} else {
 			filename = nzbFilenameStem

--- a/internal/importer/parser/fileinfo/fileinfo_test.go
+++ b/internal/importer/parser/fileinfo/fileinfo_test.go
@@ -326,3 +326,17 @@ func TestGetFileInfo_Gap5StillFiresWithoutPar2(t *testing.T) {
 		t.Errorf("Filename = %q, want %q (Gap 5 should still substitute the NZB stem)", info.Filename, "My.Show.S01E01")
 	}
 }
+
+// An NZB named after the file it carries ("The.Movie.2024.mkv.nzb") yields a stem
+// that already ends in the extension; Gap 5 must not produce "The.Movie.2024.mkv.mkv".
+func TestGetFileInfo_Gap5DoesNotDoubleExtension(t *testing.T) {
+	file := &NzbFileWithFirstSegment{
+		NzbFile:   &nzbparser.NzbFile{Filename: "b082fa0beaa644d3aa01045d5b8d0b36.mkv"},
+		First16KB: make([]byte, 16),
+	}
+
+	info := getFileInfo(file, nil, "The.Movie.2024.mkv")
+	if info.Filename != "The.Movie.2024.mkv" {
+		t.Errorf("Filename = %q, want %q", info.Filename, "The.Movie.2024.mkv")
+	}
+}

--- a/internal/importer/parser/headcache.go
+++ b/internal/importer/parser/headcache.go
@@ -1,0 +1,175 @@
+package parser
+
+import (
+	"container/list"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/javi11/altmount/internal/importer/parser/par2"
+	"github.com/javi11/nntppool/v4"
+)
+
+// What a parse learns from the wire is immutable per message-id: an article's
+// yEnc header, its first 16 KiB, the descriptors in a PAR2 index. A retried or
+// repair-resumed import re-parses the same NZB, and without this it fetched
+// all of it again — for a deferred release that is every first segment plus
+// the PAR2 index, paid twice. The cache is process-local and bounded; a
+// restart simply starts cold.
+const (
+	defaultHeadCacheBytes = 64 << 20
+	defaultHeadCacheTTL   = 24 * time.Hour
+	maxDescriptorSets     = 256
+)
+
+// articleHead is what one article taught: its header, and up to 16 KiB of it.
+type articleHead struct {
+	meta  nntppool.YEncMeta
+	bytes []byte
+}
+
+type headEntry struct {
+	id   string
+	head articleHead
+	at   time.Time
+}
+
+// headCache is an LRU of article heads keyed by message-id, bounded by bytes
+// and age.
+type headCache struct {
+	mu       sync.Mutex
+	budget   int64
+	ttl      time.Duration
+	used     int64
+	order    *list.List
+	entries  map[string]*list.Element
+	now      func() time.Time
+	descMu   sync.Mutex
+	descSets map[string]descriptorSet
+}
+
+type descriptorSet struct {
+	descriptors map[[16]byte]*par2.FileDescriptor
+	at          time.Time
+}
+
+func newHeadCache(budget int64, ttl time.Duration) *headCache {
+	return &headCache{
+		budget:   budget,
+		ttl:      ttl,
+		order:    list.New(),
+		entries:  make(map[string]*list.Element),
+		now:      time.Now,
+		descSets: make(map[string]descriptorSet),
+	}
+}
+
+func entrySize(h articleHead) int64 { return int64(len(h.bytes)) + 64 }
+
+// get returns the cached head for a message-id, if present and fresh.
+func (c *headCache) get(id string) (articleHead, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.entries[id]
+	if !ok {
+		return articleHead{}, false
+	}
+	e := el.Value.(*headEntry)
+	if c.now().Sub(e.at) > c.ttl {
+		c.remove(el)
+		return articleHead{}, false
+	}
+	c.order.MoveToFront(el)
+	return e.head, true
+}
+
+// put stores a head. A header-only put never replaces an entry that already
+// carries bytes: the bytes are what a later phase (16 KiB completion, archive
+// header reads) comes back for.
+func (c *headCache) put(id string, head articleHead) {
+	size := entrySize(head)
+	if size > c.budget {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.entries[id]; ok {
+		e := el.Value.(*headEntry)
+		if len(head.bytes) == 0 && len(e.head.bytes) > 0 {
+			head.bytes = e.head.bytes
+			size = entrySize(head)
+		}
+		c.used -= entrySize(e.head)
+		e.head = head
+		e.at = c.now()
+		c.used += size
+		c.order.MoveToFront(el)
+	} else {
+		el := c.order.PushFront(&headEntry{id: id, head: head, at: c.now()})
+		c.entries[id] = el
+		c.used += size
+	}
+	for c.used > c.budget && c.order.Len() > 0 {
+		c.remove(c.order.Back())
+	}
+}
+
+func (c *headCache) remove(el *list.Element) {
+	e := el.Value.(*headEntry)
+	c.used -= entrySize(e.head)
+	delete(c.entries, e.id)
+	c.order.Remove(el)
+}
+
+// descriptorKey identifies a PAR2 index read by the articles it was read from.
+func descriptorKey(cache []*par2.FirstSegmentData) string {
+	ids := make([]string, 0, len(cache))
+	for _, d := range cache {
+		if d != nil && d.File != nil && len(d.File.Segments) > 0 && par2.HasMagicBytes(d.RawBytes) {
+			ids = append(ids, d.File.Segments[0].ID)
+		}
+	}
+	if len(ids) == 0 {
+		return ""
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, "\x00")
+}
+
+func (c *headCache) getDescriptors(key string) (map[[16]byte]*par2.FileDescriptor, bool) {
+	if key == "" {
+		return nil, false
+	}
+	c.descMu.Lock()
+	defer c.descMu.Unlock()
+	set, ok := c.descSets[key]
+	if !ok {
+		return nil, false
+	}
+	if c.now().Sub(set.at) > c.ttl {
+		delete(c.descSets, key)
+		return nil, false
+	}
+	return set.descriptors, true
+}
+
+func (c *headCache) putDescriptors(key string, descriptors map[[16]byte]*par2.FileDescriptor) {
+	if key == "" || len(descriptors) == 0 {
+		return
+	}
+	c.descMu.Lock()
+	defer c.descMu.Unlock()
+	if len(c.descSets) >= maxDescriptorSets {
+		// Drop the oldest set; a handful of releases at a time is the whole point.
+		var oldest string
+		var oldestAt time.Time
+		for k, s := range c.descSets {
+			if oldest == "" || s.at.Before(oldestAt) {
+				oldest, oldestAt = k, s.at
+			}
+		}
+		delete(c.descSets, oldest)
+	}
+	c.descSets[key] = descriptorSet{descriptors: descriptors, at: c.now()}
+}

--- a/internal/importer/parser/parser.go
+++ b/internal/importer/parser/parser.go
@@ -51,6 +51,12 @@ const (
 	firstSegmentRetryBackoff     = 300 * time.Millisecond
 )
 
+// headerProbeAttempts bounds how many leading articles are tried for a file's
+// yEnc header when the first one is gone. Every article of a multipart post
+// repeats =ybegin name/size and states its own =ypart offset, so a dead first
+// article need not drop the file; the layout is recoverable from the next one.
+const headerProbeAttempts = 4
+
 // FirstSegmentData holds cached data from the first segment of an NZB file
 // This avoids redundant fetching when both PAR2 extraction and file parsing need the same data
 type FirstSegmentData struct {
@@ -61,6 +67,11 @@ type FirstSegmentData struct {
 	IsArticleNotFound   bool               // True only when 430 Not Found (permanent); false for timeouts/transient
 	SkippedFirstSegment bool               // True when the fetch was intentionally skipped (clean-named multipart file); Headers/RawBytes are empty by design, not by failure
 	OriginalIndex       int                // Original position in the parsed NZB file list
+	// FirstArticleMissingID is set when the first article is gone but the yEnc
+	// header was recovered from a later one. Headers are valid (PartSize is the
+	// derived first-part size); RawBytes is empty, so magic-byte and PAR2
+	// Hash16k matching are unavailable for this file.
+	FirstArticleMissingID string
 }
 
 // Parser handles NZB file parsing
@@ -68,6 +79,7 @@ type Parser struct {
 	poolManager pool.Manager        // Pool manager for dynamic pool access
 	getConfig   config.ConfigGetter // Returns current config for connection limits
 	log         *slog.Logger        // Logger for debug/error messages
+	heads       *headCache          // what earlier parses learned from the wire
 }
 
 // Use conc pool for parallel processing with proper error handling
@@ -82,6 +94,7 @@ func NewParser(poolManager pool.Manager, getConfig config.ConfigGetter) *Parser 
 		poolManager: poolManager,
 		getConfig:   getConfig,
 		log:         slog.Default().With("component", "nzb-parser"),
+		heads:       newHeadCache(defaultHeadCacheBytes, defaultHeadCacheTTL),
 	}
 }
 
@@ -196,7 +209,7 @@ func (p *Parser) ParseNzb(ctx context.Context, n *nzbparser.Nzb, nzbPath string,
 	// Skip files with missing first segments as they cannot be matched
 	par2Cache := make([]*par2.FirstSegmentData, 0, len(firstSegmentCache))
 	for _, data := range firstSegmentCache {
-		if data == nil || data.File == nil || data.MissingFirstSegment {
+		if data == nil || data.File == nil || data.MissingFirstSegment || data.FirstArticleMissingID != "" {
 			continue
 		}
 		par2Cache = append(par2Cache, &par2.FirstSegmentData{
@@ -222,7 +235,15 @@ func (p *Parser) ParseNzb(ctx context.Context, n *nzbparser.Nzb, nzbPath string,
 	// (see par2MatchingUseful above). A nil descriptor map is handled downstream.
 	if par2MatchingUseful {
 		g.Go(func() error {
+			key := descriptorKey(par2Cache)
+			if cached, ok := p.heads.getDescriptors(key); ok {
+				par2Descriptors = cached
+				return nil
+			}
 			par2Descriptors, par2Err = par2.GetFileDescriptors(gctx, par2Cache, p.poolManager)
+			if par2Err == nil {
+				p.heads.putDescriptors(key, par2Descriptors)
+			}
 			return nil
 		})
 	}
@@ -257,10 +278,14 @@ func (p *Parser) ParseNzb(ctx context.Context, n *nzbparser.Nzb, nzbPath string,
 	if nzbStandardPartSize > 0 {
 		for _, data := range firstSegmentCache {
 			if data != nil && data.SkippedFirstSegment && data.File != nil && len(data.File.Segments) > 0 {
-				// FileSize stays 0: skipped files have no yEnc headers, so the
-				// last-part derivation is unavailable and normalization falls back
-				// to fetching the last segment (their only remaining transfer).
-				firstSegmentSizeCache[data.File.Segments[0].ID] = firstSegmentYencInfo{PartSize: nzbStandardPartSize}
+				// Skipped files have no yEnc headers. The poster's subject line
+				// often states the exact size, which lets normalization derive
+				// the last part instead of fetching it; when it doesn't, FileSize
+				// stays 0 and the last segment is fetched as before.
+				firstSegmentSizeCache[data.File.Segments[0].ID] = firstSegmentYencInfo{
+					PartSize: nzbStandardPartSize,
+					FileSize: declaredFileSize(data.File),
+				}
 			}
 		}
 	}
@@ -356,10 +381,22 @@ func (p *Parser) ParseNzb(ctx context.Context, n *nzbparser.Nzb, nzbPath string,
 
 	// Aggregate results in the original order
 	// Note: OriginalIndex is already set from the original n.Files order during parsing
+	deadFirstArticle := make(map[int]string)
+	for _, data := range firstSegmentCache {
+		if data != nil && data.FirstArticleMissingID != "" {
+			deadFirstArticle[data.OriginalIndex] = data.FirstArticleMissingID
+		}
+	}
 	for _, parsedFile := range parsedFiles {
 		parsed.Files = append(parsed.Files, *parsedFile)
 		parsed.TotalSize += parsedFile.Size
 		parsed.SegmentsCount += len(parsedFile.Segments)
+		if segID, ok := deadFirstArticle[parsedFile.OriginalIndex]; ok {
+			if parsed.DegradedFiles == nil {
+				parsed.DegradedFiles = make(map[string]string)
+			}
+			parsed.DegradedFiles[filepath.Base(parsedFile.Filename)] = segID
+		}
 	}
 
 	// Determine NZB type based on content analysis
@@ -709,6 +746,9 @@ func (p *Parser) fetchAllFirstSegments(ctx context.Context, files []nzbparser.Nz
 		isNotFound bool // true when 430 Not Found (permanent)
 		data       *FirstSegmentData
 		err        error
+		// missingIDs are articles found dead while probing past a missing first
+		// article; recorded even though the file itself survived.
+		missingIDs []string
 	}
 
 	// Goroutine bound only — the real fetch bound is the pool manager's global
@@ -782,68 +822,59 @@ func (p *Parser) fetchAllFirstSegments(ctx context.Context, files []nzbparser.Nz
 
 			firstSegment := fileToFetch.Segments[0]
 
-			// Fetch the first segment, retrying transient failures. A genuine
-			// article-not-found (430/423) is permanent, so we stop immediately.
-			// But transient errors — connection exhaustion ("all providers
-			// exhausted"), timeouts, resets — must NOT be treated like a missing
-			// article: dropping a volume over a transient hiccup shatters large
-			// multi-volume sets (one lost first segment → no PAR2 name → the
-			// volume is excluded → the archive looks incomplete). Retry those a
-			// few times before giving up.
 			var (
 				result   *nntppool.ArticleBody
 				fetchErr error
 			)
-			for attempt := 1; attempt <= maxFirstSegmentFetchAttempts; attempt++ {
-				// Take a token from the global import connection budget before the
-				// per-attempt timeout starts, so queue wait never burns the deadline.
-				releaseConn, acquireErr := p.poolManager.AcquireImportConnection(ctx)
-				if acquireErr != nil {
-					// Budget acquisition only fails when the context is done — fatal.
-					return fetchResult{}, acquireErr
-				}
+			if _, known := opts.KnownMissingSegmentIDs[firstSegment.ID]; known {
+				fetchErr = nntppool.ErrArticleNotFound
+			} else {
+				result, fetchErr = p.fetchBodyWithRetry(ctx, cp, firstSegment.ID)
+			}
 
-				// Create context with timeout
-				c, cancel := context.WithTimeout(ctx, time.Second*30)
-				// Get body for the first segment (v4 returns decoded bytes + YEnc metadata)
-				result, fetchErr = cp.Body(c, firstSegment.ID)
-				cancel()
-				releaseConn()
-
-				// Success or permanent miss: stop retrying.
-				if fetchErr == nil || stderrors.Is(fetchErr, nntppool.ErrArticleNotFound) {
-					break
+			if fetchErr != nil && stderrors.Is(fetchErr, nntppool.ErrArticleNotFound) {
+				// The first article is gone; the header lives in every article
+				// of a multipart post, so ask the next few before giving up.
+				p.log.DebugContext(ctx, "missing segment",
+					"segment_id", firstSegment.ID,
+					"error", fetchErr,
+				)
+				data, missing := p.probeHeaderFromLaterArticle(ctx, cp, fileToFetch, originalIndex, opts.KnownMissingSegmentIDs)
+				if data != nil {
+					return fetchResult{
+						segmentID:  firstSegment.ID,
+						isNotFound: true,
+						data:       data,
+						missingIDs: missing,
+					}, nil
 				}
-				// Transient failure: brief backoff (unless the context is done) then retry.
-				if attempt < maxFirstSegmentFetchAttempts {
-					select {
-					case <-ctx.Done():
-					case <-time.After(time.Duration(attempt) * firstSegmentRetryBackoff):
-					}
-				}
+				return fetchResult{
+					segmentID:  firstSegment.ID,
+					isNotFound: true,
+					missingIDs: missing,
+					data: &FirstSegmentData{
+						File:                fileToFetch,
+						MissingFirstSegment: true,
+						IsArticleNotFound:   true,
+						OriginalIndex:       originalIndex,
+					},
+					err: fmt.Errorf("failed to get body: %w", fetchErr),
+				}, nil
 			}
 			if fetchErr != nil {
 				p.log.DebugContext(ctx, "missing segment",
 					"segment_id", firstSegment.ID,
 					"error", fetchErr,
 				)
-				notFound := stderrors.Is(fetchErr, nntppool.ErrArticleNotFound)
 				return fetchResult{
-					segmentID:  firstSegment.ID,
-					isNotFound: notFound,
+					segmentID: firstSegment.ID,
 					data: &FirstSegmentData{
 						File:                fileToFetch,
 						MissingFirstSegment: true,
-						IsArticleNotFound:   notFound,
 						OriginalIndex:       originalIndex,
 					},
 					err: fmt.Errorf("failed to get body: %w", fetchErr),
 				}, nil
-			}
-
-			if p.poolManager != nil {
-				p.poolManager.IncArticlesDownloaded()
-				p.poolManager.UpdateDownloadProgress("", int64(len(result.Bytes)))
 			}
 
 			headers := result.YEnc
@@ -883,6 +914,13 @@ func (p *Parser) fetchAllFirstSegments(ctx context.Context, files []nzbparser.Nz
 	// Build cache from all fetches (successful and failed)
 	// Also collect permanently-missing segment IDs to skip redundant calls later
 	for _, result := range results {
+		for _, id := range result.missingIDs {
+			notFoundIDs[id] = struct{}{}
+		}
+		if result.err == nil && result.isNotFound && result.segmentID != "" {
+			// First article dead, header recovered from a later one.
+			notFoundIDs[result.segmentID] = struct{}{}
+		}
 		if result.err != nil {
 			if result.isNotFound && result.segmentID != "" {
 				notFoundIDs[result.segmentID] = struct{}{}
@@ -909,6 +947,114 @@ func (p *Parser) fetchAllFirstSegments(ctx context.Context, files []nzbparser.Nz
 	}
 
 	return cache, notFoundIDs, nil
+}
+
+// fetchBodyWithRetry fetches one article, retrying transient failures. A
+// genuine article-not-found (430/423) is permanent and returned at once:
+// transient errors — connection exhaustion, timeouts, resets — must not be
+// mistaken for a missing article, or one hiccup shatters a multi-volume set.
+func (p *Parser) fetchBodyWithRetry(ctx context.Context, cp pool.NntpClient, segmentID string) (*nntppool.ArticleBody, error) {
+	if head, ok := p.heads.get(segmentID); ok && len(head.bytes) > 0 {
+		return &nntppool.ArticleBody{MessageID: segmentID, Bytes: head.bytes, YEnc: head.meta}, nil
+	}
+	var (
+		result   *nntppool.ArticleBody
+		fetchErr error
+	)
+	for attempt := 1; attempt <= maxFirstSegmentFetchAttempts; attempt++ {
+		// Take a token from the global import connection budget before the
+		// per-attempt timeout starts, so queue wait never burns the deadline.
+		releaseConn, acquireErr := p.poolManager.AcquireImportConnection(ctx)
+		if acquireErr != nil {
+			return nil, acquireErr
+		}
+		c, cancel := context.WithTimeout(ctx, time.Second*30)
+		result, fetchErr = cp.Body(c, segmentID)
+		cancel()
+		releaseConn()
+
+		if fetchErr == nil {
+			if p.poolManager != nil {
+				p.poolManager.IncArticlesDownloaded()
+				p.poolManager.UpdateDownloadProgress("", int64(len(result.Bytes)))
+			}
+			p.heads.put(segmentID, articleHead{meta: result.YEnc, bytes: clipHead(result.Bytes)})
+			return result, nil
+		}
+		if stderrors.Is(fetchErr, nntppool.ErrArticleNotFound) {
+			return nil, fetchErr
+		}
+		if attempt < maxFirstSegmentFetchAttempts {
+			select {
+			case <-ctx.Done():
+			case <-time.After(time.Duration(attempt) * firstSegmentRetryBackoff):
+			}
+		}
+	}
+	return nil, fetchErr
+}
+
+// probeHeaderFromLaterArticle recovers a file's yEnc header from articles
+// 1..headerProbeAttempts-1 after the first one was found missing. It returns
+// the recovered data (nil when every probe failed) and the ids of the articles
+// found dead on the way. Only 430s are walked past: a transient failure ends
+// the probe, since the file would be dropped on a guess otherwise.
+func (p *Parser) probeHeaderFromLaterArticle(ctx context.Context, cp pool.NntpClient, file *nzbparser.NzbFile, originalIndex int, knownMissing map[string]struct{}) (*FirstSegmentData, []string) {
+	var missing []string
+	for i := 1; i < len(file.Segments) && i < headerProbeAttempts; i++ {
+		if ctx.Err() != nil {
+			break
+		}
+		seg := file.Segments[i]
+		if _, known := knownMissing[seg.ID]; known {
+			continue
+		}
+		result, err := p.fetchBodyWithRetry(ctx, cp, seg.ID)
+		if err != nil {
+			if stderrors.Is(err, nntppool.ErrArticleNotFound) {
+				missing = append(missing, seg.ID)
+				continue
+			}
+			break
+		}
+		headers := result.YEnc
+		headers.PartSize = firstPartSizeFromLaterArticle(headers, i)
+		p.log.InfoContext(ctx, "Recovered yEnc header from a later article; first article is missing",
+			"file", file.Filename, "first_segment", file.Segments[0].ID, "header_segment", seg.ID)
+		return &FirstSegmentData{
+			File:                  file,
+			Headers:               headers,
+			OriginalIndex:         originalIndex,
+			FirstArticleMissingID: file.Segments[0].ID,
+		}, missing
+	}
+	return nil, missing
+}
+
+// clipHead copies at most the leading 16 KiB of an article for the cache: that
+// is all any later phase reads from a first segment (PAR2 Hash16k, magic
+// bytes, archive headers).
+func clipHead(b []byte) []byte {
+	const maxHead = 16 * 1024
+	if len(b) > maxHead {
+		b = b[:maxHead]
+	}
+	return append([]byte(nil), b...)
+}
+
+// firstPartSizeFromLaterArticle derives the first part's decoded size from an
+// article at index>0: its =ypart begin sits exactly index whole parts into the
+// file, so begin/index is the uniform part size. nntppool reports PartBegin
+// already converted to a 0-based offset. This also holds when the probed
+// article is the last, shorter one, where its own PartSize would be wrong for
+// the first part.
+func firstPartSizeFromLaterArticle(meta nntppool.YEncMeta, index int) int64 {
+	if index > 0 && meta.PartBegin > 0 {
+		if step := meta.PartBegin / int64(index); step > 0 {
+			return step
+		}
+	}
+	return meta.PartSize
 }
 
 // pickRepresentativeMiddleSegment picks one "middle" segment (the second
@@ -966,7 +1112,7 @@ func isPar2SidecarExtension(filename string) bool {
 // philosophy as shouldSkipFirstSegmentFetch. Skipped/missing files have no first-16KB
 // bytes to hash and can never be matched; PAR2 files describe others, not themselves.
 func needsPar2Matching(d *FirstSegmentData) bool {
-	if d == nil || d.File == nil || d.MissingFirstSegment || d.SkippedFirstSegment {
+	if d == nil || d.File == nil || d.MissingFirstSegment || d.SkippedFirstSegment || d.FirstArticleMissingID != "" {
 		return false
 	}
 	if par2.HasMagicBytes(d.RawBytes) {
@@ -1126,6 +1272,7 @@ func (p *Parser) complete16KBReads(ctx context.Context, cache []*FirstSegmentDat
 				bytesRead += n
 			}
 			d.RawBytes = buffer[:bytesRead]
+			p.heads.put(d.File.Segments[0].ID, articleHead{meta: d.Headers, bytes: clipHead(d.RawBytes)})
 			return nil
 		})
 	}
@@ -1138,6 +1285,10 @@ func (p *Parser) complete16KBReads(ctx context.Context, cache []*FirstSegmentDat
 func (p *Parser) fetchYencHeaders(ctx context.Context, segment nzbparser.NzbSegment, groups []string) (nntppool.YEncMeta, error) {
 	if p.poolManager == nil {
 		return nntppool.YEncMeta{}, errors.NewNonRetryableError("no pool manager available", nil)
+	}
+
+	if head, ok := p.heads.get(segment.ID); ok && head.meta.PartSize > 0 {
+		return head.meta, nil
 	}
 
 	cp, err := p.poolManager.GetPool()
@@ -1163,6 +1314,7 @@ func (p *Parser) fetchYencHeaders(ctx context.Context, segment nzbparser.NzbSegm
 			p.poolManager.IncArticlesDownloaded()
 			p.poolManager.UpdateDownloadProgress("", int64(headers.PartSize))
 		}
+		p.heads.put(segment.ID, articleHead{meta: headers})
 
 		return headers, nil
 	case result := <-resultCh:
@@ -1181,6 +1333,7 @@ func (p *Parser) fetchYencHeaders(ctx context.Context, segment nzbparser.NzbSegm
 		if headers.PartSize <= 0 {
 			return nntppool.YEncMeta{}, errors.NewNonRetryableError("invalid part size from yenc header", nil)
 		}
+		p.heads.put(segment.ID, articleHead{meta: headers})
 		return headers, nil
 	case <-ctx.Done():
 		return nntppool.YEncMeta{}, errors.NewNonRetryableError("context canceled", ctx.Err())

--- a/internal/importer/parser/parser_headcache_test.go
+++ b/internal/importer/parser/parser_headcache_test.go
@@ -1,0 +1,127 @@
+package parser
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/altmount/internal/testsupport/par2gen"
+	"github.com/javi11/nntppool/v4"
+	"github.com/javi11/nzbparser"
+)
+
+// A retried or repair-resumed import re-parses the same NZB. Everything the
+// first pass learned from the wire — first-segment heads, yEnc headers, the
+// PAR2 index — is immutable per message-id, so the second pass must not fetch
+// any of it again.
+func TestParseNzbReusesFetchedHeadsAcrossParses(t *testing.T) {
+	content := bytes.Repeat([]byte("F"), 32768)
+	par2Bytes := par2gen.Build(par2gen.FileEntry{Name: "Real.Movie.2024.mkv", Content: content})
+
+	fp := fakepool.New()
+	fp.SetBehavior("vid-0", fakepool.SegmentBehavior{
+		Bytes: content[:16384],
+		YEnc:  nntppool.YEncMeta{FileName: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5", FileSize: 32768, Part: 1, PartBegin: 0, PartSize: 16384},
+	})
+	fp.SetBehavior("vid-1", fakepool.SegmentBehavior{
+		Bytes: content[16384:],
+		YEnc:  nntppool.YEncMeta{FileSize: 32768, Part: 2, PartBegin: 16384, PartSize: 16384},
+	})
+	fp.SetBehavior("p2-0", fakepool.SegmentBehavior{
+		Bytes: par2Bytes,
+		YEnc:  nntppool.YEncMeta{FileName: "release.par2", FileSize: int64(len(par2Bytes)), PartSize: int64(len(par2Bytes))},
+	})
+
+	newNzb := func() *nzbparser.Nzb {
+		return &nzbparser.Nzb{Files: nzbparser.NzbFiles{
+			{Filename: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5", Segments: nzbparser.NzbSegments{
+				{Bytes: 16800, Number: 1, ID: "vid-0"},
+				{Bytes: 16800, Number: 2, ID: "vid-1"},
+			}},
+			{Filename: "release.par2", Segments: nzbparser.NzbSegments{
+				{Bytes: len(par2Bytes) + 100, Number: 1, ID: "p2-0"},
+			}},
+		}}
+	}
+
+	p := NewParser(newFakeFullPoolManager(fp), stormConfigGetter(4))
+
+	videoOf := func(parsed *ParsedNzb) ParsedFile {
+		for _, f := range parsed.Files {
+			if !f.IsPar2Archive {
+				return f
+			}
+		}
+		t.Fatalf("no video file in %+v", parsed.Files)
+		return ParsedFile{}
+	}
+
+	first, err := p.ParseNzb(context.Background(), newNzb(), "release.nzb", nil, ParseOptions{})
+	if err != nil {
+		t.Fatalf("first ParseNzb error = %v", err)
+	}
+	if got := videoOf(first).Filename; got != "Real.Movie.2024.mkv" {
+		t.Fatalf("first parse Filename = %q, want PAR2 name", got)
+	}
+	calls := map[string]int64{}
+	for _, id := range []string{"vid-0", "vid-1", "p2-0"} {
+		calls[id] = fp.PerMessageCalls(id)
+	}
+	if calls["p2-0"] == 0 || calls["vid-0"] == 0 {
+		t.Fatalf("first parse issued no fetches: %+v", calls)
+	}
+
+	second, err := p.ParseNzb(context.Background(), newNzb(), "release.nzb", nil, ParseOptions{})
+	if err != nil {
+		t.Fatalf("second ParseNzb error = %v", err)
+	}
+	if videoOf(second).Filename != videoOf(first).Filename || videoOf(second).Size != videoOf(first).Size {
+		t.Errorf("second parse differs: %+v vs %+v", videoOf(second), videoOf(first))
+	}
+	for id, n := range calls {
+		if got := fp.PerMessageCalls(id); got != n {
+			t.Errorf("%s fetched %d times after second parse, want %d (served from cache)", id, got, n)
+		}
+	}
+}
+
+func TestHeadCacheEvictsOldestWhenOverBudget(t *testing.T) {
+	c := newHeadCache(200, time.Hour)
+	c.put("a", articleHead{bytes: make([]byte, 60)})
+	c.put("b", articleHead{bytes: make([]byte, 60)})
+	if _, ok := c.get("a"); ok {
+		t.Error("a should have been evicted to make room for b")
+	}
+	if _, ok := c.get("b"); !ok {
+		t.Error("b should be present")
+	}
+	// An entry larger than the whole budget is not cached at all.
+	c.put("huge", articleHead{bytes: make([]byte, 400)})
+	if _, ok := c.get("huge"); ok {
+		t.Error("oversized entry must not be cached")
+	}
+}
+
+func TestHeadCacheExpiresEntries(t *testing.T) {
+	now := time.Now()
+	c := newHeadCache(1<<20, time.Minute)
+	c.now = func() time.Time { return now }
+	c.put("a", articleHead{meta: nntppool.YEncMeta{PartSize: 1}})
+	now = now.Add(2 * time.Minute)
+	if _, ok := c.get("a"); ok {
+		t.Error("expired entry must not be returned")
+	}
+}
+
+// A header-only entry must not overwrite one that already carries bytes.
+func TestHeadCacheKeepsBytesOverHeaderOnly(t *testing.T) {
+	c := newHeadCache(1<<20, time.Hour)
+	c.put("a", articleHead{meta: nntppool.YEncMeta{PartSize: 5}, bytes: []byte("hello")})
+	c.put("a", articleHead{meta: nntppool.YEncMeta{PartSize: 5}})
+	got, _ := c.get("a")
+	if string(got.bytes) != "hello" {
+		t.Errorf("bytes = %q, want hello", got.bytes)
+	}
+}

--- a/internal/importer/parser/parser_headerprobe_test.go
+++ b/internal/importer/parser/parser_headerprobe_test.go
@@ -1,0 +1,155 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/nntppool/v4"
+	"github.com/javi11/nzbparser"
+)
+
+// obfuscated name so the first-segment fetch is not skipped by the clean-name gate.
+const probeObfuscatedName = "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5"
+
+func fourSegmentFile(name string) nzbparser.NzbFile {
+	return nzbparser.NzbFile{
+		Filename: name,
+		Segments: nzbparser.NzbSegments{
+			{Bytes: 1030000, Number: 1, ID: "seg-0"},
+			{Bytes: 1030000, Number: 2, ID: "seg-1"},
+			{Bytes: 1030000, Number: 3, ID: "seg-2"},
+			{Bytes: 515000, Number: 4, ID: "seg-3"},
+		},
+	}
+}
+
+// A dead first article must not drop a file whose remaining articles still
+// carry the yEnc header: the name, exact size and part size are recoverable
+// from any later article of a multipart post.
+func TestParseNzbRecoversHeaderFromLaterArticleWhenFirstIsMissing(t *testing.T) {
+	const realName = "Movie.2020.1080p.BluRay.mkv"
+	const partSize = int64(1000000)
+	const fileSize = int64(3500000)
+
+	fp := fakepool.New()
+	fp.SetBehavior("seg-0", fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+	fp.SetBehavior("seg-1", fakepool.SegmentBehavior{
+		Bytes: make([]byte, 64),
+		YEnc: nntppool.YEncMeta{
+			FileName:  realName,
+			FileSize:  fileSize,
+			Part:      2,
+			PartBegin: partSize, // nntppool reports =ypart begin 0-based
+			PartSize:  partSize,
+			Total:     4,
+		},
+	})
+
+	p := NewParser(newFakeFullPoolManager(fp), stormConfigGetter(2))
+	n := &nzbparser.Nzb{Files: nzbparser.NzbFiles{fourSegmentFile(probeObfuscatedName)}}
+
+	parsed, err := p.ParseNzb(context.Background(), n, "test.nzb", nil, ParseOptions{})
+	if err != nil {
+		t.Fatalf("ParseNzb error = %v", err)
+	}
+	if len(parsed.Files) != 1 {
+		t.Fatalf("len(parsed.Files) = %d, want 1 (file recovered from later article)", len(parsed.Files))
+	}
+	f := parsed.Files[0]
+	if f.Filename != realName {
+		t.Errorf("Filename = %q, want %q (from yEnc header)", f.Filename, realName)
+	}
+	if f.Size != fileSize {
+		t.Errorf("Size = %d, want %d (from =ybegin size)", f.Size, fileSize)
+	}
+	if got := f.Segments[0].SegmentSize; got != partSize {
+		t.Errorf("first segment size = %d, want %d (derived from =ypart begin)", got, partSize)
+	}
+	if got := f.Segments[3].SegmentSize; got != fileSize-3*partSize {
+		t.Errorf("last segment size = %d, want %d (derived arithmetically)", got, fileSize-3*partSize)
+	}
+	if segID, ok := parsed.DegradedFiles[realName]; !ok || segID != "seg-0" {
+		t.Errorf("DegradedFiles[%q] = %q, %v; want \"seg-0\", true", realName, segID, ok)
+	}
+	// seg-0 (430) + seg-1 (header) and nothing else: no last-segment fetch.
+	if calls := fp.BodyCalls(); calls != 2 {
+		t.Errorf("BodyCalls = %d, want 2", calls)
+	}
+}
+
+// When the leading articles are all gone the file is still dropped, after a
+// bounded number of probes.
+func TestParseNzbDropsFileWhenAllProbeArticlesMissing(t *testing.T) {
+	fp := fakepool.New()
+	for _, id := range []string{"seg-0", "seg-1", "seg-2", "seg-3"} {
+		fp.SetBehavior(id, fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+	}
+	fp.SetBehavior("good-0", fakepool.SegmentBehavior{Bytes: make([]byte, 16)})
+
+	p := NewParser(newFakeFullPoolManager(fp), stormConfigGetter(2))
+	n := &nzbparser.Nzb{Files: nzbparser.NzbFiles{
+		fourSegmentFile(probeObfuscatedName),
+		{Filename: "Good.2020.1080p.BluRay.mkv", Segments: nzbparser.NzbSegments{{Bytes: 12345, Number: 1, ID: "good-0"}}},
+	}}
+
+	parsed, err := p.ParseNzb(context.Background(), n, "test.nzb", nil, ParseOptions{})
+	if err != nil {
+		t.Fatalf("ParseNzb error = %v", err)
+	}
+	if len(parsed.Files) != 1 || parsed.Files[0].Filename != "Good.2020.1080p.BluRay.mkv" {
+		t.Fatalf("parsed.Files = %+v, want only the healthy file", parsed.Files)
+	}
+	// 4 probes on the dead file + 1 for the healthy one.
+	if calls := fp.BodyCalls(); calls != 5 {
+		t.Errorf("BodyCalls = %d, want 5", calls)
+	}
+}
+
+// A first segment already known missing from the pre-parse Stat sweep goes
+// straight to the fallback article without spending a Body call on it.
+func TestParseNzbSkipsKnownMissingFirstSegmentBeforeProbing(t *testing.T) {
+	fp := fakepool.New()
+	fp.SetBehavior("seg-1", fakepool.SegmentBehavior{
+		Bytes: make([]byte, 64),
+		YEnc:  nntppool.YEncMeta{FileName: "Movie.mkv", FileSize: 3500000, Part: 2, PartBegin: 1000000, PartSize: 1000000},
+	})
+
+	p := NewParser(newFakeFullPoolManager(fp), stormConfigGetter(2))
+	n := &nzbparser.Nzb{Files: nzbparser.NzbFiles{fourSegmentFile(probeObfuscatedName)}}
+
+	parsed, err := p.ParseNzb(context.Background(), n, "test.nzb", nil, ParseOptions{
+		KnownMissingSegmentIDs: map[string]struct{}{"seg-0": {}},
+	})
+	if err != nil {
+		t.Fatalf("ParseNzb error = %v", err)
+	}
+	if len(parsed.Files) != 1 || parsed.Files[0].Filename != "Movie.mkv" {
+		t.Fatalf("parsed.Files = %+v, want the recovered file", parsed.Files)
+	}
+	if calls := fp.BodyCalls(); calls != 1 {
+		t.Errorf("BodyCalls = %d, want 1 (seg-0 skipped, seg-1 probed)", calls)
+	}
+}
+
+func TestFirstPartSizeFromLaterArticle(t *testing.T) {
+	tests := []struct {
+		name  string
+		meta  nntppool.YEncMeta
+		index int
+		want  int64
+	}{
+		{"second article of uniform post", nntppool.YEncMeta{PartBegin: 1000000, PartSize: 1000000}, 1, 1000000},
+		{"fourth article of uniform post", nntppool.YEncMeta{PartBegin: 3000000, PartSize: 1000000}, 3, 1000000},
+		{"shorter last article still yields the uniform size", nntppool.YEncMeta{PartBegin: 3000000, PartSize: 500000}, 3, 1000000},
+		{"index zero falls back to own part size", nntppool.YEncMeta{PartBegin: 0, PartSize: 1000000}, 0, 1000000},
+		{"missing =ypart falls back to own part size", nntppool.YEncMeta{PartSize: 777}, 2, 777},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := firstPartSizeFromLaterArticle(tt.meta, tt.index); got != tt.want {
+				t.Errorf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/importer/parser/parser_subjectsize_test.go
+++ b/internal/importer/parser/parser_subjectsize_test.go
@@ -1,0 +1,78 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/nntppool/v4"
+	"github.com/javi11/nzbparser"
+)
+
+// Posting tools write the exact decoded file size at the end of the subject
+// line. For a clean-named file whose first segment is skipped, that number
+// replaces the last-segment header fetch: the last part's size follows from it.
+func TestParseNzbDerivesLastPartFromSubjectSize(t *testing.T) {
+	const (
+		fullEncoded = 720000
+		lastEncoded = 51000
+		partDecoded = 700000
+		fileSize    = 2*partDecoded + 50000
+		name        = "Inception.2010.1080p.BluRay.mkv"
+	)
+
+	fp := fakepool.New()
+	fp.SetBehavior("seg-1", fakepool.SegmentBehavior{
+		YEnc: nntppool.YEncMeta{FileName: name, PartSize: partDecoded},
+	})
+	// seg-2 deliberately has no behaviour: fetching it is the failure this test guards.
+
+	p := NewParser(newFakeFullPoolManager(fp), stormConfigGetter(4))
+	n := &nzbparser.Nzb{Files: nzbparser.NzbFiles{{
+		Filename: name,
+		Subject:  `[1/1] - "` + name + `" yEnc (1/3) 1450000`,
+		Segments: nzbparser.NzbSegments{
+			{Bytes: fullEncoded, Number: 1, ID: "seg-0"},
+			{Bytes: fullEncoded, Number: 2, ID: "seg-1"},
+			{Bytes: lastEncoded, Number: 3, ID: "seg-2"},
+		},
+	}}}
+
+	parsed, err := p.ParseNzb(context.Background(), n, "test.nzb", nil, ParseOptions{})
+	if err != nil {
+		t.Fatalf("ParseNzb error = %v", err)
+	}
+	f := parsed.Files[0]
+	if f.Size != fileSize {
+		t.Errorf("Size = %d, want %d (from subject)", f.Size, fileSize)
+	}
+	if got := f.Segments[2].SegmentSize; got != 50000 {
+		t.Errorf("last segment size = %d, want 50000 (derived)", got)
+	}
+	if got := fp.PerMessageCalls("seg-2"); got != 0 {
+		t.Errorf("last segment fetched %d times, want 0", got)
+	}
+}
+
+func TestSizeFromSubject(t *testing.T) {
+	tests := []struct {
+		name    string
+		subject string
+		encoded int64
+		want    int64
+	}{
+		{"trailing size after part counter", `[1/5] - "movie.mkv" yEnc (1/170) 710427259`, 730000000, 710427259},
+		{"size right after yEnc", `"movie.mkv" yEnc 710427259`, 730000000, 710427259},
+		{"no size", `[1/5] - "movie.mkv" yEnc (1/170)`, 730000000, 0},
+		{"number larger than the encoded bytes is not a size", `"x.mkv" yEnc (1/2) 999999999`, 730000000, 0},
+		{"number below half the encoded bytes is not a size", `"x.mkv" yEnc (1/2) 1234`, 730000000, 0},
+		{"unknown encoded total", `"x.mkv" yEnc (1/2) 710427259`, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sizeFromSubject(tt.subject, tt.encoded); got != tt.want {
+				t.Errorf("sizeFromSubject(%q, %d) = %d, want %d", tt.subject, tt.encoded, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/importer/parser/subjectsize.go
+++ b/internal/importer/parser/subjectsize.go
@@ -1,0 +1,51 @@
+package parser
+
+import (
+	"regexp"
+	"strconv"
+
+	"github.com/javi11/nzbparser"
+)
+
+// subjectSizePatterns pull the byte count posting tools write at the end of a
+// subject line: `[1/5] - "movie.mkv" yEnc (1/170) 710427259`. It is the file's
+// exact decoded length, which the NZB's own segment sizes cannot give.
+var subjectSizePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\(\d+/\d+\)\s+(\d+)\s*$`),
+	regexp.MustCompile(`(?i)\byEnc\s+(\d+)\s*$`),
+}
+
+// sizeFromSubject reads the poster's declared file size out of a subject line,
+// returning zero when there is none or when it does not stand up against the
+// encoded total. A decoded file never outweighs the articles carrying it and
+// yEnc never doubles what it encodes, so a trailing number outside that band
+// is a date, a part count or a password, not a size.
+func sizeFromSubject(subject string, encoded int64) int64 {
+	if encoded <= 0 {
+		return 0
+	}
+	for _, pattern := range subjectSizePatterns {
+		match := pattern.FindStringSubmatch(subject)
+		if len(match) < 2 {
+			continue
+		}
+		size, err := strconv.ParseInt(match[1], 10, 64)
+		if err != nil || size <= 0 || size > encoded || size < encoded/2 {
+			continue
+		}
+		return size
+	}
+	return 0
+}
+
+// declaredFileSize is sizeFromSubject over an NZB file's own segments.
+func declaredFileSize(file *nzbparser.NzbFile) int64 {
+	if file == nil {
+		return 0
+	}
+	var encoded int64
+	for _, seg := range file.Segments {
+		encoded += int64(seg.Bytes)
+	}
+	return sizeFromSubject(file.Subject, encoded)
+}

--- a/internal/importer/parser/types.go
+++ b/internal/importer/parser/types.go
@@ -47,6 +47,10 @@ type ParsedNzb struct {
 	ExtractedFiles []ExtractedFileInfo
 	Store          *metapb.NzbStore // NzbStore for this release (built at parse time)
 	SegmentIndex   map[string]int64 // message-id → flat store index
+	// DegradedFiles maps a parsed filename to the message-id of its dead first
+	// article, for files whose header was recovered from a later article. The
+	// processor merges it into the repair queue so the hole gets patched.
+	DegradedFiles map[string]string
 }
 
 // GetPassword returns the password for this NZB

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/javi11/altmount/internal/importer/filesystem"
 	"github.com/javi11/altmount/internal/importer/multifile"
 	"github.com/javi11/altmount/internal/importer/parser"
+	"github.com/javi11/altmount/internal/importer/parser/fileinfo"
 	"github.com/javi11/altmount/internal/importer/singlefile"
 	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
 	"github.com/javi11/altmount/internal/importer/validation"
@@ -51,8 +52,8 @@ type Processor struct {
 	log               *slog.Logger
 	broadcaster       *progress.ProgressBroadcaster // WebSocket progress broadcaster
 	recorder          HistoryRecorder
-	par2Repair        RepairEnqueuer         // optional; queues PAR2 repairs at import time
-	patchIndex        validation.PatchIndex  // optional; locally repaired articles count as available
+	par2Repair        RepairEnqueuer        // optional; queues PAR2 repairs at import time
+	patchIndex        validation.PatchIndex // optional; locally repaired articles count as available
 
 	// Pre-compiled regex patterns for RAR file sorting
 	rarPartPattern  *regexp.Regexp // pattern.part###.rar
@@ -174,6 +175,23 @@ func (proc *Processor) queueImportRepairs(ctx context.Context, enabled bool, wri
 		}
 		proc.par2Repair.Enqueue(ctx, vp, segID)
 	}
+}
+
+// mergeDegradedFiles folds the parser's degraded files (dead first article,
+// header recovered from a later one) into the fast-fail sweep's findings. The
+// sweep's segment id wins on a clash: it is the one that proved the damage.
+func mergeDegradedFiles(sweep, fromParser map[string]string) map[string]string {
+	if len(fromParser) == 0 {
+		return sweep
+	}
+	merged := make(map[string]string, len(sweep)+len(fromParser))
+	for k, v := range fromParser {
+		merged[k] = v
+	}
+	for k, v := range sweep {
+		merged[k] = v
+	}
+	return merged
 }
 
 // NewProcessor creates a new NZB processor using metadata storage
@@ -454,7 +472,7 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 							"sampled", result.SampledCount)
 					}
 					if len(result.MissingSegmentIDs) > 0 {
-						degradedFiles[f.Filename] = result.MissingSegmentIDs[0]
+						degradedFiles[filepath.Base(f.Filename)] = result.MissingSegmentIDs[0]
 					}
 					continue // not broken: let it import
 				}
@@ -647,6 +665,7 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 		if err := proc.parser.ValidateNzb(parsed); err != nil {
 			return "", nil, NewNonRetryableError("NZB validation failed", err)
 		}
+		degradedFiles = mergeDegradedFiles(degradedFiles, parsed.DegradedFiles)
 	}
 
 	// Attach extracted files metadata if available (optimization)
@@ -1384,14 +1403,20 @@ func (proc *Processor) processSevenZipArchive(
 	return nzbFolder, writtenPaths, nil
 }
 
-// applyNzbRename renames the first file in files to match nzbName when renameToNzbName is true.
-// Returns the slice unchanged when renameToNzbName is false or files is empty.
+// applyNzbRename renames the first file in files to match nzbName when
+// renameToNzbName is true and its name says nothing (SABnzbd's rule): a clean
+// filename is kept, since the release name is not a better one. Returns the
+// slice unchanged otherwise.
 func applyNzbRename(renameToNzbName bool, nzbName string, files []parser.ParsedFile) []parser.ParsedFile {
 	if !renameToNzbName || len(files) == 0 {
 		return files
 	}
+	leaf := filepath.Base(files[0].Filename)
+	if !fileinfo.IsProbablyObfuscated(leaf) {
+		return files
+	}
 	originalDir := filepath.Dir(files[0].Filename)
-	normalizedBase := normalizeReleaseFilename(nzbName, filepath.Base(files[0].Filename))
+	normalizedBase := normalizeReleaseFilename(nzbName, leaf)
 	if originalDir != "." && originalDir != "" {
 		files[0].Filename = filepath.Join(originalDir, normalizedBase)
 	} else {

--- a/internal/importer/processor_test.go
+++ b/internal/importer/processor_test.go
@@ -353,6 +353,20 @@ func TestApplyNzbRename(t *testing.T) {
 			expected:         "sub/file.mkv",
 		},
 		{
+			name:             "true: clean filename is kept",
+			renameToNzbName:  true,
+			nzbName:          "release.nzb",
+			originalFilename: "My.Movie.2024.PROPER.1080p.mkv",
+			expected:         "My.Movie.2024.PROPER.1080p.mkv",
+		},
+		{
+			name:             "true: hash filename renamed",
+			renameToNzbName:  true,
+			nzbName:          "release.nzb",
+			originalFilename: "a3f9c1d2e4b5a6f7c8d9e0f1a2b3c4d5.mkv",
+			expected:         "release.mkv",
+		},
+		{
 			name:             "true: renames leaf only, preserves subdirectory",
 			renameToNzbName:  true,
 			nzbName:          "movie.nzb",


### PR DESCRIPTION
## Summary

- **Header probe fallback**: when a file's first article is 430, probe articles 1–3 for the yEnc header, derive the first-part size from the article's 0-based `=ypart begin`, and import the file as degraded with the dead article queued for PAR2 repair. Previously one expired article dropped the whole file (and failed single-file releases). A first segment already known missing from the fast-fail sweep skips straight to the fallback.
- **Gated release rename** (`rename_to_nzb_name`): follows SABnzbd's final-filename rules. Only an obfuscated payload that is at least 3× the runner-up and not a disc-structure/split-container extension is renamed; subtitles and samples sharing its stem follow it. Replaces the old "exactly one allowed media file" rule in the RAR/7z aggregators and the unconditional single-file rename. Behaviour change: a clean-named file is no longer renamed even with the option on.
- **Parse cache across attempts**: a process-wide bounded LRU (64 MiB, 24 h) keyed by message-id keeps first-segment heads, yEnc headers and PAR2 descriptor sets, so retried or repair-resumed imports do not refetch what the first pass read.
- **Subject-line size**: for clean-named files whose first segment is skipped, the poster's trailing size in the subject (bounds-checked against the encoded total) lets the last part be derived instead of fetched.
- **Fix**: the NZB-stem filename fallback doubled the extension (`The.Movie.mkv.nzb` → `The.Movie.mkv.mkv`); previously masked by the unconditional rename.

## Test plan

- [x] `go test ./...` green
- [x] `go vet ./...` clean, `bun run check` green
- [x] New tests: header recovery from later article / all probes missing / known-missing skip; `firstPartSizeFromLaterArticle` table; head-cache LRU/TTL/reuse across parses; `PayloadRenames` table + aggregator cases (season pack untouched, sidecar follows, clean name kept); subject-size derivation; Gap 5 double-extension
- [ ] Manual: import a release whose first article is expired and confirm it lands degraded with a repair queued