### PR TITLE
feat(rclonecli): make the rcd restart tolerance configurable

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -104,6 +104,13 @@ rclone:
   vfs_read_ahead: '128M' # VFS read-ahead size (--vfs-read-ahead=128M)
   dir_cache_time: '10m' # Directory cache time (--dir-cache-time=10m)
 
+  # How long the rcd may stay unresponsive to liveness probes before it is killed
+  # and restarted. Restarting re-establishes the mount, which unmounts it out from
+  # under every process currently reading it, so raise this if your rcd goes
+  # briefly slow under load (large library scans, bursts of VFS refreshes) and you
+  # would rather ride the stall out than drop the mount.
+  rcd_restart_after: '90s'
+
   # Additional VFS settings (advanced configuration)
   vfs_cache_min_free_space: '1G' # Minimum free space for VFS cache
   vfs_disk_space_total: '1G' # Total disk space for VFS operations

--- a/frontend/src/components/config/MountConfigSection.tsx
+++ b/frontend/src/components/config/MountConfigSection.tsx
@@ -744,6 +744,23 @@ function RCloneMountSubSection({ config, onFormDataChange }: RCloneSubSectionPro
 				</div>
 				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
 					<fieldset className="fieldset">
+						<legend className="fieldset-legend">RCD Restart Tolerance</legend>
+						<input
+							type="text"
+							className="input input-bordered w-full bg-base-100 text-sm"
+							value={mountFormData.rcd_restart_after}
+							onChange={(e) => handleMountInputChange("rcd_restart_after", e.target.value)}
+							placeholder="90s"
+						/>
+						<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/70 text-xs">
+							How long the rcd may stay unresponsive before it's killed and restarted. Restarting
+							unmounts the drive out from under every reader, so raise this if your rcd goes
+							briefly slow under load (e.g., 5m).
+						</p>
+					</fieldset>
+				</div>
+				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+					<fieldset className="fieldset">
 						<legend className="fieldset-legend">User ID (UID)</legend>
 						<input
 							type="number"
@@ -1404,6 +1421,7 @@ function buildRCloneMountFormData(config: ConfigResponse): RCloneMountFormData {
 		read_only: config.rclone.read_only || false,
 		timeout: config.rclone.timeout || "10m",
 		syslog: config.rclone.syslog ?? true,
+		rcd_restart_after: config.rclone.rcd_restart_after || "90s",
 		log_level: config.rclone.log_level || "INFO",
 		uid: config.rclone.uid || 1000,
 		gid: config.rclone.gid || 1000,

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -198,6 +198,10 @@ export interface RCloneConfig {
 	timeout: string;
 	syslog: boolean;
 
+	// How long the rcd may stay unresponsive to liveness probes before it is
+	// killed and restarted. Empty means the built-in default (90s).
+	rcd_restart_after: string;
+
 	// System and filesystem options
 	log_level: string;
 	uid: number;
@@ -461,6 +465,7 @@ export interface RCloneUpdateRequest {
 	read_only?: boolean;
 	timeout?: string;
 	syslog?: boolean;
+	rcd_restart_after?: string;
 
 	// System and filesystem options
 	log_level?: string;
@@ -586,6 +591,7 @@ export interface RCloneMountFormData {
 	read_only: boolean;
 	timeout: string;
 	syslog: boolean;
+	rcd_restart_after: string;
 
 	// System and filesystem options
 	log_level: string;

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -82,6 +82,10 @@ type RCloneAPIResponse struct {
 	Timeout       string `json:"timeout"`
 	Syslog        bool   `json:"syslog"`
 
+	// RcdRestartAfter is how long the rcd may stay unresponsive to liveness
+	// probes before it is killed and restarted. Empty means the built-in default.
+	RcdRestartAfter string `json:"rcd_restart_after"`
+
 	// System and filesystem options
 	LogLevel    string `json:"log_level"`
 	UID         int    `json:"uid"`
@@ -352,6 +356,8 @@ func ToConfigAPIResponse(cfg *config.Config, apiKey string) *ConfigAPIResponse {
 		ReadOnly:      cfg.RClone.ReadOnly,
 		Timeout:       cfg.RClone.Timeout,
 		Syslog:        cfg.RClone.Syslog,
+
+		RcdRestartAfter: cfg.RClone.RcdRestartAfter,
 
 		// System and filesystem options
 		LogLevel:    cfg.RClone.LogLevel,

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -577,6 +577,13 @@ type RCloneConfig struct {
 	Timeout       string `yaml:"timeout" mapstructure:"timeout" json:"timeout"`
 	Syslog        bool   `yaml:"syslog" mapstructure:"syslog" json:"syslog"`
 
+	// RcdRestartAfter is how long the rcd subprocess must stay unresponsive to
+	// liveness probes before it is killed and restarted. Empty means the built-in
+	// default. Restarting is disruptive, because re-establishing the mount
+	// unmounts it out from under every process reading it, so an install whose
+	// rcd goes briefly slow under load can raise this to ride the stall out.
+	RcdRestartAfter string `yaml:"rcd_restart_after" mapstructure:"rcd_restart_after" json:"rcd_restart_after"`
+
 	// Advanced Settings
 	NoModTime          bool `yaml:"no_mod_time" mapstructure:"no_mod_time" json:"no_mod_time"`
 	NoChecksum         bool `yaml:"no_checksum" mapstructure:"no_checksum" json:"no_checksum"`
@@ -2071,6 +2078,10 @@ func DefaultConfig(configDir ...string) *Config {
 			VFSReadChunkSizeLimit: "2G",      // --vfs-read-chunk-size-limit=2G
 			VFSReadAhead:          "128M",    // --vfs-read-ahead=128M (changed from 128k)
 			DirCacheTime:          "10m",     // --dir-cache-time=10m (changed from 5m)
+
+			// Matches the previous hard-coded behaviour: probes run every 30s and
+			// three consecutive failures triggered a restart.
+			RcdRestartAfter: "90s",
 
 			// Additional VFS Settings (not specified in your command, using sensible defaults)
 			VFSCacheMinFreeSpace: "1G",

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -2068,6 +2068,10 @@ func DefaultConfig(configDir ...string) *Config {
 			ReadOnly:      false, // Not specified in your command, so false
 			Syslog:        true,  // --syslog
 
+			// Matches the previous hard-coded behaviour: probes run every 30s and
+			// three consecutive failures triggered a restart.
+			RcdRestartAfter: "90s",
+
 			// VFS Cache Settings - matching your command
 			CacheDir:              cachePath, // VFS cache directory (defaults to <rclone_path>/cache)
 			VFSCacheMode:          "full",    // --vfs-cache-mode=full
@@ -2078,10 +2082,6 @@ func DefaultConfig(configDir ...string) *Config {
 			VFSReadChunkSizeLimit: "2G",      // --vfs-read-chunk-size-limit=2G
 			VFSReadAhead:          "128M",    // --vfs-read-ahead=128M (changed from 128k)
 			DirCacheTime:          "10m",     // --dir-cache-time=10m (changed from 5m)
-
-			// Matches the previous hard-coded behaviour: probes run every 30s and
-			// three consecutive failures triggered a restart.
-			RcdRestartAfter: "90s",
 
 			// Additional VFS Settings (not specified in your command, using sensible defaults)
 			VFSCacheMinFreeSpace: "1G",

--- a/pkg/rclonecli/health.go
+++ b/pkg/rclonecli/health.go
@@ -53,9 +53,18 @@ func (m *Manager) restartAfterProbeFailures() int {
 		return maxConsecutiveProbeFailures
 	}
 
-	// Round up: a value shorter than one interval still means "restart on the
-	// first sustained failure" rather than "restart immediately, every tick".
-	threshold := int((after + healthCheckInterval - 1) / healthCheckInterval)
+	// Round up by dividing first and adjusting, rather than the usual
+	// (after + interval - 1) / interval. That form overflows for a duration near
+	// the maximum time.Duration, wrapping negative, and the clamp below would
+	// then turn the longest tolerance anyone can express into a threshold of 1:
+	// a restart on every failed probe, the exact opposite of what was asked for.
+	threshold := int(after / healthCheckInterval)
+	if after%healthCheckInterval != 0 {
+		threshold++
+	}
+
+	// A value shorter than one interval still means "restart on the first
+	// sustained failure" rather than "restart immediately, every tick".
 	if threshold < 1 {
 		threshold = 1
 	}

--- a/pkg/rclonecli/health.go
+++ b/pkg/rclonecli/health.go
@@ -20,8 +20,48 @@ const (
 	// maxConsecutiveProbeFailures is how many back-to-back failed liveness
 	// probes are required before the rcd subprocess is considered wedged and
 	// restarted. Prevents a single transient miss from nuking a healthy rcd.
+	//
+	// This is the fallback for rclone.rcd_restart_after; see
+	// restartAfterProbeFailures, which derives the count from that setting.
 	maxConsecutiveProbeFailures = 3
+
+	// probeTimeout bounds a single liveness probe.
+	probeTimeout = 5 * time.Second
 )
+
+// restartAfterProbeFailures returns how many consecutive failed probes must
+// accumulate before the rcd is restarted.
+//
+// The knob is expressed as a duration rather than a probe count because a count
+// is meaningless without healthCheckInterval, and exposing both invites
+// combinations that mean nothing. One duration, divided by the interval, keeps
+// the two in step.
+func (m *Manager) restartAfterProbeFailures() int {
+	if m.cfg == nil {
+		return maxConsecutiveProbeFailures
+	}
+
+	configured := m.cfg.GetConfig().RClone.RcdRestartAfter
+	if configured == "" {
+		return maxConsecutiveProbeFailures
+	}
+
+	after, err := time.ParseDuration(configured)
+	if err != nil || after <= 0 {
+		m.logger.WarnContext(m.ctx, "Ignoring unusable rclone.rcd_restart_after",
+			"value", configured, "using_probe_threshold", maxConsecutiveProbeFailures)
+		return maxConsecutiveProbeFailures
+	}
+
+	// Round up: a value shorter than one interval still means "restart on the
+	// first sustained failure" rather than "restart immediately, every tick".
+	threshold := int((after + healthCheckInterval - 1) / healthCheckInterval)
+	if threshold < 1 {
+		threshold = 1
+	}
+
+	return threshold
+}
 
 // checkMountHealth checks if a specific mount is healthy
 func (m *Manager) checkMountHealth(provider string) bool {
@@ -131,11 +171,12 @@ func (m *Manager) performMountHealthCheck() {
 	// IsReady() only reflects startup state. Probe the rcd subprocess with a
 	// bounded timeout so a wedged rcd is detected even when no individual
 	// mount has failed yet.
-	if m.probe(m.ctx, 5*time.Second) {
+	if m.probe(m.ctx, probeTimeout) {
 		// Healthy probe: clear the failure streak and continue to per-mount checks.
 		m.consecutiveProbeFailures = 0
 	} else {
 		m.consecutiveProbeFailures++
+		restartAfter := m.restartAfterProbeFailures()
 
 		// Never kill the rcd during the startup grace period: right after
 		// startup it is busy initializing FUSE mounts, so a slow probe is
@@ -147,10 +188,10 @@ func (m *Manager) performMountHealthCheck() {
 		m.mu.RUnlock()
 		withinGrace := !readyAt.IsZero() && time.Since(readyAt) < startupGracePeriod
 
-		if withinGrace || m.consecutiveProbeFailures < maxConsecutiveProbeFailures {
+		if withinGrace || m.consecutiveProbeFailures < restartAfter {
 			m.logger.WarnContext(m.ctx, "rcd liveness probe failed; not restarting yet",
 				"consecutive_failures", m.consecutiveProbeFailures,
-				"threshold", maxConsecutiveProbeFailures,
+				"threshold", restartAfter,
 				"within_startup_grace", withinGrace)
 			// Skip per-mount recovery this tick: if rcd is slow, operations/list
 			// would fail too and could trigger a restart that bypasses this guard.

--- a/pkg/rclonecli/health.go
+++ b/pkg/rclonecli/health.go
@@ -122,7 +122,7 @@ func (m *Manager) RecoverMount(ctx context.Context, provider string) error {
 	// every subsequent RPC (mount/unmount, config/create, mount/mount) will
 	// hang on context deadline exceeded. Kill+respawn rcd before issuing
 	// recovery RPCs to break out of that wedge.
-	if !m.probe(ctx, 5*time.Second) {
+	if !m.probe(ctx, probeTimeout) {
 		m.logger.WarnContext(ctx, "rcd unresponsive during recovery, restarting subprocess", "provider", provider)
 		if err := m.restart(ctx); err != nil {
 			return fmt.Errorf("failed to restart wedged rcd: %w", err)

--- a/pkg/rclonecli/health_test.go
+++ b/pkg/rclonecli/health_test.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/javi11/altmount/internal/config"
 )
 
 // newHealthTestManager builds a minimal Manager wired only with the fields
@@ -146,4 +148,69 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+// withRcdRestartAfter wires a config into the test manager so the derived
+// threshold can be asserted.
+func withRcdRestartAfter(t *testing.T, m *Manager, value string) {
+	t.Helper()
+
+	cfg := &config.Config{}
+	cfg.RClone.RcdRestartAfter = value
+	m.cfg = config.NewManager(cfg, "")
+}
+
+func TestRestartAfterProbeFailures_DerivesCountFromDuration(t *testing.T) {
+	for _, tc := range []struct {
+		configured string
+		want       int
+		why        string
+	}{
+		{"90s", 3, "the default, and the previous hard-coded behaviour"},
+		{"30s", 1, "exactly one interval"},
+		{"5m", 10, "a tolerant install riding out a long stall"},
+		{"45s", 2, "rounds up rather than truncating to one interval"},
+		{"1s", 1, "shorter than an interval still means one sustained failure"},
+		{"", 3, "unset falls back to the built-in default"},
+		{"nonsense", 3, "unparseable falls back rather than disabling the guard"},
+		{"-30s", 3, "negative falls back rather than restarting every tick"},
+	} {
+		m, _ := newHealthTestManager(t, false, time.Time{})
+		withRcdRestartAfter(t, m, tc.configured)
+
+		if got := m.restartAfterProbeFailures(); got != tc.want {
+			t.Errorf("rcd_restart_after=%q gave threshold %d, want %d (%s)",
+				tc.configured, got, tc.want, tc.why)
+		}
+	}
+}
+
+func TestRestartAfterProbeFailures_NoConfigUsesDefault(t *testing.T) {
+	m, _ := newHealthTestManager(t, false, time.Time{})
+	if got := m.restartAfterProbeFailures(); got != maxConsecutiveProbeFailures {
+		t.Errorf("with no config wired, threshold = %d, want %d", got, maxConsecutiveProbeFailures)
+	}
+}
+
+// TestPerformMountHealthCheck_HonoursConfiguredTolerance is the point of the
+// change: an install that configures more tolerance rides out a stall that the
+// default would have restarted the rcd for, tearing the mount out from under
+// every reader.
+func TestPerformMountHealthCheck_HonoursConfiguredTolerance(t *testing.T) {
+	m, restarts := newHealthTestManager(t, false, time.Now().Add(-time.Hour))
+	withRcdRestartAfter(t, m, "5m") // 10 probes
+
+	for range maxConsecutiveProbeFailures + 2 {
+		m.performMountHealthCheck()
+	}
+	if got := atomic.LoadInt32(restarts); got != 0 {
+		t.Fatalf("restarted %d times past the default threshold; the configured tolerance was ignored", got)
+	}
+
+	for range 5 {
+		m.performMountHealthCheck()
+	}
+	if got := atomic.LoadInt32(restarts); got != 1 {
+		t.Fatalf("restarts = %d after reaching the configured threshold, want 1", got)
+	}
 }

--- a/pkg/rclonecli/health_test.go
+++ b/pkg/rclonecli/health_test.go
@@ -174,6 +174,10 @@ func TestRestartAfterProbeFailures_DerivesCountFromDuration(t *testing.T) {
 		{"", 3, "unset falls back to the built-in default"},
 		{"nonsense", 3, "unparseable falls back rather than disabling the guard"},
 		{"-30s", 3, "negative falls back rather than restarting every tick"},
+		// Near time.Duration's maximum. The obvious (x+interval-1)/interval form
+		// overflows here and collapses to 1, turning the longest tolerance
+		// expressible into a restart on every failed probe.
+		{"2562047h47m16.854775807s", 307445735, "an absurd but valid duration must not invert into no tolerance"},
 	} {
 		m, _ := newHealthTestManager(t, false, time.Time{})
 		withRcdRestartAfter(t, m, tc.configured)


### PR DESCRIPTION
Fixes #882.

Restarting the rcd isn't cheap: the re-establish path runs `fusermount -uz`, so every
process reading the mount loses it. How long we wait before calling it wedged should be
something an install can set, and right now it's a constant.

So this adds one duration, `rclone.rcd_restart_after`, instead of exposing the four values
that actually decide the timing (`healthCheckInterval`, the probe deadline,
`maxConsecutiveProbeFailures`, `startupGracePeriod`). Those are coupled, and separate
knobs mostly let you build combinations that don't mean anything. The probe count is just
the duration divided by the interval, rounded up.

Default `90s` is what happens today: 30s probes, 3 strikes. Empty, unparseable and
negative fall back to it.

I also pulled the 5s probe deadline out of two inline literals into a constant while I was
in there.

Left the other half of the issue alone, the part about separating "RC is slow" from "the
mount has to go". That's a design change and I didn't want to assume. Say the word if
you'd rather have it that way round.
