### PR TITLE
perf(streaming): cut import and warm-open latency; add nzb-streaming-benchmarks results

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -15,3 +15,12 @@ B9 forward skip, B10 close-and-reopen replay, B11 seek and resume.
 Results are committed per landed change so a PR description can cite its delta
 table; per-SHA files are scratch output. Run on an idle machine; the simulator
 is CPU-bound at high aggregate bandwidth. Full guide: `docs/docs/6. Development/setup.md`.
+
+## External comparison
+
+`bench/nzb-streaming-benchmarks/` holds a rerun of Viren070's public
+[nzb-streaming-benchmarks](https://github.com/Viren070/nzb-streaming-benchmarks)
+harness against AltMount and the other NZB streaming applications it covers.
+`RESULTS.md` is the generated report with a provenance preamble, `results.json` the
+raw run, `CORPUS.md` the local corpus. Numbers are comparable within that report
+only; the corpus differs from the published one.

--- a/bench/nzb-streaming-benchmarks/CORPUS.md
+++ b/bench/nzb-streaming-benchmarks/CORPUS.md
@@ -1,0 +1,219 @@
+# NZB corpus
+
+14 NZBs selected from a pool of 14, chosen for **characteristic
+coverage** rather than title. Every classification below was verified against live NNTP by
+`src/corpus/probe.mjs` (archive headers actually fetched and parsed), not inferred from
+filenames, which are frequently obfuscated and carry stale inline comments.
+
+The NZBs themselves are gitignored. Regenerate with:
+
+```
+node src/corpus/analyze.mjs     # static structure     -> corpus/analysis.json
+node src/corpus/probe.mjs       # live archive probing -> corpus/probe.json
+node src/corpus/select.mjs      # curate + manifest    -> corpus/corpus.json + this file
+```
+
+Disc collections (BDMV/ISO packs) were deliberately excluded: they are not streaming
+scenarios.
+
+## Coverage
+
+| Axis | Entries |
+|---|---|
+| `password-in-nzb` | 7 |
+| `direct-video` | 5 |
+| `partNN` | 4 |
+| `rar` | 3 |
+| `7z` | 2 |
+| `encrypted-headers` | 2 |
+| `no-archive` | 2 |
+| `rar4` | 2 |
+| `rar5` | 2 |
+| `split-7z.NNN` | 2 |
+| `stored` | 2 |
+| `extensionless` | 1 |
+| `file-selection` | 1 |
+| `letter-rollover` | 1 |
+| `missing-articles` | 1 |
+| `named-volumes` | 1 |
+| `obfuscated-names` | 1 |
+| `per-file-unique-stems` | 1 |
+| `rar+rNN` | 1 |
+| `season-pack` | 1 |
+
+## smoke
+
+Small and healthy. A full pass is cheap, so use these while iterating.
+
+### `rar4-small`
+
+Small stored RAR4 partNN set; cheap archive control.
+
+- **Axes**: `rar4`, `stored`, `named-volumes`, `partNN`
+- **Verified**: rar4 · stored
+- **Size**: 0.4 GiB posted · 17 files · 1,010 segments · NZB 0.1 MB
+- **Health**: 16/16 sampled articles present
+- **Source**: `FatherBrown.nzb`
+- **sha256**: `55ed581204b3d83b…`
+
+### `plain-medium`
+
+Direct MKV at movie size, no archive layer.
+
+- **Axes**: `direct-video`, `no-archive`, `per-file-unique-stems`
+- **Verified**: matroska
+- **Size**: 6.7 GiB posted · 7 files · 1,662 segments · NZB 0.2 MB
+- **Health**: 16/16 sampled articles present
+- **Obfuscation**: `per-file-unique-stems`
+- **Source**: `ToyStory5.nzb`
+- **sha256**: `9add0ee889f54187…`
+
+
+## core
+
+The main capability and performance matrix.
+
+### `obfuscated-direct`
+
+Same post fully obfuscated: extensionless names, opaque subjects.
+
+- **Axes**: `direct-video`, `obfuscated-names`, `extensionless`
+- **Verified**: unknown
+- **Size**: 6.7 GiB posted · 7 files · 1,662 segments · NZB 0.2 MB
+- **Health**: 16/16 sampled articles present
+- **Obfuscation**: `extensionless-names`, `unquoted-subjects`, `opaque-subjects`, `per-file-unique-stems`
+- **Source**: `Obfuscated.nzb`
+- **sha256**: `6794d1464e7cb28c…`
+
+### `plain-large`
+
+Large direct MKV with hex stems.
+
+- **Axes**: `direct-video`, `no-archive`
+- **Verified**: matroska
+- **Size**: 15.9 GiB posted · 10 files · 7,915 segments · NZB 0.7 MB
+- **Health**: 16/16 sampled articles present
+- **Obfuscation**: `per-file-unique-stems`
+- **Source**: `El.Rio.De.La.Muerte.2024.SPANiSH.MULTi.1080p.BluRay.x264-USENETHD.nzb`
+- **sha256**: `97df5ff5d59a3ff1…`
+
+### `plain-season-pack`
+
+Ten direct MKVs in one NZB.
+
+- **Axes**: `direct-video`, `season-pack`, `file-selection`
+- **Verified**: matroska · password in NZB
+- **Size**: 22.6 GiB posted · 20 files · 32,850 segments · NZB 2.8 MB
+- **Health**: 16/16 sampled articles present
+- **Source**: `Bosch.S01.nzb`
+- **sha256**: `c9b60371473825b0…`
+
+### `rar4-rNN`
+
+RAR4 .rar/.rNN volumes with letter rollover past .r99.
+
+- **Axes**: `rar4`, `stored`, `rar+rNN`, `letter-rollover`
+- **Verified**: rar4 · stored
+- **Size**: 6.2 GiB posted · 125 files · 8,404 segments · NZB 0.8 MB
+- **Health**: 16/16 sampled articles present
+- **Source**: `It (1).nzb`
+- **sha256**: `f89633155ab56480…`
+
+### `rar-hdrenc-small`
+
+Header-encrypted RAR5 with password meta.
+
+- **Axes**: `rar5`, `encrypted-headers`, `password-in-nzb`
+- **Verified**: rar5 · encrypted headers · password in NZB
+- **Size**: 5.2 GiB posted · 57 files · 7,537 segments · NZB 0.7 MB
+- **Health**: 16/16 sampled articles present
+- **Obfuscation**: `opaque-subjects`
+- **Source**: `An_Awesome_Piece_Of_Media.nzb`
+- **sha256**: `d8e5a0d0cd14e2d1…`
+
+### `rar-hdrenc-large`
+
+Header-encrypted RAR5 at 24 GiB.
+
+- **Axes**: `rar5`, `encrypted-headers`, `password-in-nzb`
+- **Verified**: rar5 · encrypted headers · password in NZB
+- **Size**: 24.0 GiB posted · 128 files · 36,001 segments · NZB 3.2 MB
+- **Health**: 16/16 sampled articles present
+- **Obfuscation**: `opaque-subjects`
+- **Source**: `Eden (2025) [BDRip x264 1080p AC3 5.1 Castellano].nzb`
+- **sha256**: `01431cbac254d552…`
+
+### `7z-split-bugonia`
+
+Split 7z .001 volumes, 21 GiB.
+
+- **Axes**: `7z`, `split-7z.NNN`, `password-in-nzb`
+- **Verified**: 7z · AES-encrypted header · header: encrypted · password in NZB
+- **Size**: 20.8 GiB posted · 117 files · 31,275 segments · NZB 2.8 MB
+- **Health**: 16/16 sampled articles present
+- **Source**: `Bugonia.2025.SPANiSH.MULTi.1080p.BluRay.x264-USENETHD.nzb`
+- **sha256**: `3d3aa512f73872c8…`
+
+### `7z-split-tardes`
+
+Split 7z .001 volumes, 19 GiB.
+
+- **Axes**: `7z`, `split-7z.NNN`, `password-in-nzb`
+- **Verified**: 7z · AES-encrypted header · header: encrypted · password in NZB
+- **Size**: 19.3 GiB posted · 112 files · 29,068 segments · NZB 2.6 MB
+- **Health**: 16/16 sampled articles present
+- **Source**: `Tardes.De.Soledad.2024.SPANiSH.1080p.BluRay.x264-USENETHD.nzb`
+- **sha256**: `87a5066e0aeccf85…`
+
+
+## failure
+
+Damaged or dead posts. Robustness only, never performance.
+
+### `rar-partNN-large`
+
+Dead post: 94% of articles gone from the provider (STAT sweep 2026-09-05). Must be refused.
+
+- **Axes**: `rar`, `partNN`, `password-in-nzb`
+- **Verified**: password in NZB
+- **Size**: 19.5 GiB posted · 72 files · 29,160 segments · NZB 2.6 MB
+- **Health**: availability not sampled
+- **Source**: `2012 (2009) [BDRip x264 1080p DTS-HD MA 5.1 Castellano].nzb`
+- **sha256**: `bc3e1ebe3c25efca…`
+
+### `rar-partNN-maestras`
+
+Dead post: 76% of articles gone. Must be refused.
+
+- **Axes**: `rar`, `partNN`, `password-in-nzb`
+- **Verified**: password in NZB
+- **Size**: 3.5 GiB posted · 26 files · 5,234 segments · NZB 0.5 MB
+- **Health**: availability not sampled
+- **Obfuscation**: `opaque-subjects`
+- **Source**: `Las maestras de la republica.nzb`
+- **sha256**: `8897062c4e8778de…`
+
+### `rar-partNN-satans`
+
+Mid-size partNN RAR, opaque subjects.
+
+- **Axes**: `rar`, `partNN`, `password-in-nzb`
+- **Verified**: password in NZB
+- **Size**: 3.1 GiB posted · 21 files · 4,660 segments · NZB 0.4 MB
+- **Health**: availability not sampled
+- **Obfuscation**: `opaque-subjects`
+- **Source**: `Satans.Blood.Recuerdos.de.Escalofrio.2016.1080P.BLURAY.X264-WATCHABLE.nzb`
+- **sha256**: `072bf2a684bdfca9…`
+
+### `damaged-partial`
+
+Lightly damaged direct MKV; should still serve.
+
+- **Axes**: `direct-video`, `missing-articles`
+- **Verified**: matroska
+- **Size**: 6.7 GiB posted · 7 files · 1,662 segments · NZB 0.2 MB
+- **Health**: 16/16 sampled articles present
+- **Obfuscation**: `per-file-unique-stems`
+- **Source**: `ToyStory5Damaged.nzb`
+- **sha256**: `90b9bdccb56a8f91…`
+

--- a/bench/nzb-streaming-benchmarks/RESULTS.md
+++ b/bench/nzb-streaming-benchmarks/RESULTS.md
@@ -1,0 +1,718 @@
+# NZB streaming benchmark (AltMount rerun, 2026-09-05)
+
+This is a local rerun of Viren070's public harness
+[nzb-streaming-benchmarks](https://github.com/Viren070/nzb-streaming-benchmarks)
+(harness commit `7192cab`) against AltMount `2f9a80d7` (`v0.3.2-68`) and the same field of
+applications the published
+[docs/RESULTS.md](https://github.com/Viren070/nzb-streaming-benchmarks/blob/main/docs/RESULTS.md)
+measures. The generated report follows unchanged below; `results.json` is the raw
+run data and `CORPUS.md` describes the entries.
+
+## How this run differs from the published one
+
+- **Different corpus.** The published NZBs are not distributed, so this run uses a
+  14-entry local corpus built with the harness's own `analyze`/`probe`/`select`
+  pipeline (see `CORPUS.md`). It covers the same axes (direct video, RAR4/RAR5,
+  encrypted headers, split 7z, obfuscation, missing articles, dead posts) but the
+  posts, sizes and article counts differ. **Numbers are comparable across the rows
+  of this report, not against the published tables.**
+- **Different host and link.** Apple M4, 16 GB, macOS, 20 connections to a single
+  Newshosting frontend. The published run is a Ryzen 7800X3D on Windows.
+- **Four rows ran in Docker.** nzbdav, nzbdavex and InfiniDysk cannot reach the
+  provider from source on macOS: .NET rejects the provider's TLS chain with
+  `RevocationStatusUnknown`. Decypharr links cgofuse unconditionally and needs FUSE
+  headers to compile. All four were run with `--docker`, which the report marks as
+  `runtime: docker`. On macOS the harness could not read the container cgroup
+  counters, so their CPU and memory columns are empty. Latency and throughput for
+  those rows cross an extra NAT hop.
+- **Comet is excluded.** Its native usenet engine fails to initialise inside Docker
+  Desktop on macOS (`Native engine startup failed: initialization_failure`; it
+  requires Landlock from the host kernel). The published run excludes it too.
+- **Single pass.** The harness's own caveat applies: treat differences under about
+  20% between applications as unresolved by one run.
+
+## AltMount: this run vs the published row
+
+Shape only, since the corpus differs. Published values are AltMount `3ed4c47`
+from the 2026-08-28 run.
+
+| Metric | Published (`3ed4c47`) | This run (`2f9a80d7`) |
+|---|---:|---:|
+| Capability gaps | 7 | 1 |
+| Wrongly served | 1 | 0 |
+| Click→byte (median) | 3.91 s | 1.18 s |
+| Cold TTFB | 234 ms | 62 ms |
+| Warm TTFB | 328 ms | 11 ms |
+| Full seek | 762 ms | 205 ms |
+| Seek TTFB | 384 ms | 121 ms |
+| Seq MB/s | 39.4 | 43.9 |
+| p05 MB/s | 26.2 | 13.5 |
+| CPU s/GiB | 4.2 | 4.7 |
+| RSS/item | 766 MiB | 508 MiB |
+| Peak RSS | 2026 MiB | 564 MiB |
+| Drift | +618 MiB | -89 MiB |
+
+The one remaining gap is `rar-hdrenc-small`: an encrypted RAR whose inner file is a
+nested RAR using rar2.9 compression. Every application in the field failed that
+entry; only the raw baseline, which serves outer volume bytes, passed it.
+
+Where AltMount does not lead in this run: sequential throughput and p05 sit below
+nzbdav/nzbdavex, Decypharr and AIOStreams, and below the raw baseline's 70 MB/s on
+the same posts. The link is not the limit there; the cause is not established by
+this run.
+
+## Reproducing
+
+```sh
+git clone https://github.com/Viren070/nzb-streaming-benchmarks
+cd nzb-streaming-benchmarks
+ln -s /path/to/altmount apps/altmount        # or let scripts/clone-apps.sh clone it
+cp .env.example .env                          # NNTP_HOST/PORT/TLS/USER/PASS/CONNS
+# drop NZBs into corpus/pool/, then:
+npm run corpus
+node src/cli.mjs run --apps=raw,altmount,aiostreams,nzbdav,nzbdavex,infinidysk,stremthru,streamnzb,decypharr \
+  --docker=nzbdav,nzbdavex,infinidysk,decypharr
+```
+
+On macOS the harness needs a `ps`-based process sampler in `src/metrics/procmon.mjs`
+and a null-check on the timeout waiter in `src/nntp/client.mjs`; both patches are
+small and upstream-worthy but not yet submitted.
+
+---
+
+## Generated report
+
+**Run** `2026-09-05T13-48-25-529Z` · started 2026-09-05T13:48:25.529Z · finished 2026-09-05T14:57:44.374Z
+
+## Environment
+
+darwin 25.5.0 · Apple M4 (10 threads) · 16 GB RAM
+
+| | |
+|---|---|
+| OS | darwin 25.5.0 |
+| CPU | Apple M4 |
+| RAM | 16.00 GiB |
+| Harness | Node v24.19.0 |
+
+### NNTP providers
+
+| Provider | Port | TLS | Max conns | Role |
+|---|---:|:---:|---:|---|
+| `client.fr7.newshosting.com` | 563 | yes | 20 | primary |
+
+> Throughput is bounded by the provider and the link, not only by the application.
+> The `raw` row is this harness fetching the same articles with no application in
+> the middle, so read every other number relative to it.
+
+> **The link is the largest source of error here, and it is not controlled.** These
+> runs are made over consumer Wi-Fi to a commercial provider, and both vary on their
+> own. Repeating a pass with nothing changed but the clock has moved the whole-run
+> median by 14% and individual entries by 55%, and one measured evening had a single
+> post served at 9 MB/s by `raw` while others on the same connection ran at 45 MB/s.
+> Provider variance is per post, not per session: which entries are slow changes from
+> run to run, so a low number for one entry is not a property of the application.
+> Treat differences under roughly 20% between applications, or under 50% on a single
+> entry, as unresolved by one pass. Only repeated runs can separate the two.
+
+### Applications measured
+
+| App | Runtime | Language | Version | Serving | Startup |
+|---|---|---|---|---|---:|
+| **nzbdavex** | docker | C# (.NET 10) | `312d3bc` | webdav | 2.22 s |
+| **raw NNTP baseline** | source | JavaScript (this harness) | `harness-builtin` | http-range | 3 ms |
+| **AltMount** | source | Go | `v0.3.2-68-g2f9a80d7` | webdav | 778 ms |
+| **StreamNZB** | source | Go | `v5.17.0` | http-range | 776 ms |
+| **nzbdav** | docker | C# (.NET 10) | `0c7d8e2` | webdav | 1.64 s |
+| **Decypharr** | docker | Go | `v2.5` (`0dd1cbb`) | webdav | 1.03 s |
+| **StremThru (newz)** | source | Go | `73bf362` | http-range | 559 ms |
+| **InfiniDysk** | docker | C# (.NET 10) | `dev` | webdav | 6.32 s |
+| **AIOStreams** | source | TypeScript | `2026.09.04.2319-nightly` | http-range | 2.93 s |
+
+### Run settings
+
+| Setting | Value |
+|---|---|
+| Sequential read | 244 MiB cap / 30s cap |
+| Seek points | 1%, 25%, 50%, 75%, 95% + backward |
+| Seek read | 8 MiB |
+| Playback sim | 30s @ 25 Mbps |
+| Integrity samples | 3 |
+| Item timeout | 600s |
+
+## Summary
+
+Every median below is taken over **the same 9 entries for every**
+**application**: the perf-tier entries (`smoke`, `core`, `stress`) that at least
+8 of the 9 applications served. Median post size across that set is
+15.9 GiB.
+
+> **Why a quorum and not the entries all of them served.** That strict intersection
+> is 5 entries here, and it is defined by the weakest application in the field:
+> one broken engine collapses the population for everybody, and the set moves between
+> runs as the field changes. A quorum keeps it wide and stable. Where an application
+> missed one of the 9, its `n` column says so.
+
+Entries: `rar4-small`, `plain-medium`, `obfuscated-direct`, `plain-large`, `plain-season-pack`, `rar4-rNN`, `rar-hdrenc-large`, `7z-split-bugonia`, `7z-split-tardes`.
+
+### Verdict
+
+*Correct* is not *served*. Six corpus entries are built to be unservable: three
+`negative` (compressed archives, no password) and three `failure` (dead post,
+severe damage, missing volumes). Refusing those is the right answer, and serving
+one means emitting bytes that cannot be the media, which is a worse result than
+refusing, not a better one.
+
+| App | Served | Capability gaps | Correctly refused | **Wrongly served** |
+|---|---:|---:|---:|---:|
+| **nzbdavex** | 10/11 | 1 | 3/3 | 0 |
+| **raw NNTP baseline** | 11/11 | 0 | 3/3 | 0 |
+| **AltMount** | 10/11 | 1 | 3/3 | 0 |
+| **StreamNZB** | 9/11 | 2 | 3/3 | 0 |
+| **nzbdav** | 10/11 | 1 | 3/3 | 0 |
+| **Decypharr** | 7/11 | 4 | 3/3 | 0 |
+| **StremThru (newz)** | 10/11 | 1 | 3/3 | 0 |
+| **InfiniDysk** | 10/11 | 1 | 3/3 | 0 |
+| **AIOStreams** | 10/11 | 1 | 3/3 | 0 |
+
+A *capability gap* is the number that ranks engines: entries that should stream
+and did not. `raw` is not an application and its row is not a verdict: it serves
+outer volume bytes without opening an archive, so it "wrongly serves" entries no
+player could open. That is the point of the baseline, not a defect in it.
+
+### Time to picture
+
+| App | n | Click&rarr;byte | Import | Cold TTFB | Warm TTFB |
+|---|---:|---:|---:|---:|---:|
+| **nzbdavex** | 9/9 | **1.66 s** | 1.51 s | 197 ms | 140 ms |
+| **raw NNTP baseline** | 9/9 | **382 ms** | 240 ms | 113 ms | 108 ms |
+| **AltMount** | 9/9 | **1.18 s** | 1.09 s | 62 ms | 11 ms |
+| **StreamNZB** | 8/9 | **1.48 s** | 45 ms | 1.44 s | 1 ms |
+| **nzbdav** | 9/9 | **1.78 s** | 1.62 s | 92 ms | 116 ms |
+| **Decypharr** | 6/9 | **5.02 s** | 4.77 s | 292 ms | 1 ms |
+| **StremThru (newz)** | 9/9 | **3.49 s** | 3.45 s | 59 ms | 41 ms |
+| **InfiniDysk** | 9/9 | **3.24 s** | 3.19 s | 77 ms | 96 ms |
+| **AIOStreams** | 9/9 | **1.12 s** | 804 ms | 134 ms | 4 ms |
+
+*Click&rarr;byte* is import + cold open: what a viewer waits through after pressing
+play, and the only one of these three that is comparable. Every application here but
+one inspects the post at import and then answers the first byte quickly, so import is
+over 80% of the wait. StreamNZB is the exception: it returns a session in
+milliseconds and does the same work on first byte, which is why its import reads as
+free and its cold TTFB does not. Serving mode does not predict this, since AIOStreams
+answers byte ranges like StreamNZB and still front-loads like the mount-style
+applications. *Warm TTFB* is the same open repeated, so it measures what the engine
+cached rather than what it can do cold.
+
+### Streaming and seeks
+
+| App | Seq MB/s | p05 MB/s | Full seek | Seek TTFB | Worst seek |
+|---|---:|---:|---:|---:|---:|
+| **nzbdavex** | 92.2 | **66.9** | **368 ms** | 161 ms | 288 ms |
+| **raw NNTP baseline** | 70.2 | **42.9** | **336 ms** | 190 ms | 415 ms |
+| **AltMount** | 43.9 | **13.5** | **205 ms** | 121 ms | 291 ms |
+| **StreamNZB** | 45.1 | **20.7** | **627 ms** | 237 ms | 614 ms |
+| **nzbdav** | 80.9 | **53.6** | **379 ms** | 165 ms | 360 ms |
+| **Decypharr** | 66.4 | **36.6** | **326 ms** | 134 ms | 450 ms |
+| **StremThru (newz)** | 28.5 | **6.2** | **700 ms** | 217 ms | 432 ms |
+| **InfiniDysk** | 53.6 | **7.7** | **635 ms** | 133 ms | 260 ms |
+| **AIOStreams** | 67.2 | **19.6** | **486 ms** | 121 ms | 198 ms |
+
+*p05 MB/s* is the 5th-percentile one-second windowed rate, which is what a player
+actually feels: a mean rate hides a stall that a p05 does not.
+
+*Full seek* is the median time to complete a whole seek read, acknowledgement plus
+transfer, rather than the moment the first byte appears. An engine that answers a
+Range immediately and then feeds the body slowly wins *Seek TTFB* and loses this
+column, and this column is the one a player waits through. Where the two disagree,
+believe this one.
+
+### CPU
+
+| App | CPU s/GiB | Cores (p95) | Cores (max) | Steady |
+|---|---:|---:|---:|---:|
+| **nzbdavex** | **—** | — | — | — |
+| **raw NNTP baseline** | **21.9** | 0.9 | 0.9 | 95% |
+| **AltMount** | **4.7** | 0.5 | 0.5 | 63% |
+| **StreamNZB** | **6.3** | 0.6 | 0.6 | 64% |
+| **nzbdav** | **—** | — | — | — |
+| **Decypharr** | **—** | — | — | — |
+| **StremThru (newz)** | **13.2** | 0.6 | 0.6 | 59% |
+| **InfiniDysk** | **—** | — | — | — |
+| **AIOStreams** | **6.1** | 0.7 | 0.7 | 86% |
+
+*CPU s/GiB* is CPU-seconds consumed per GiB delivered, the fair efficiency
+comparison, since a raw percentage is meaningless at different throughputs.
+
+The other three are the shape of the draw rather than its size, which a total
+cannot express: ten CPU-seconds is a steady half core for twenty seconds or one
+core pinned for ten, and those cost a shared box differently. *Cores (p95)* is the
+level it sustains, *Cores (max)* the worst single second, and *Steady* the share of
+seconds spent at or above half the p95. A high *Steady* is an engine that hums; a
+low one with a tall *max* burns the same CPU in bursts against an idle baseline,
+which is what makes a box feel busy while the averages look calm.
+
+All three are per entry and then taken as medians, so *Cores (max)* is the typical
+worst second of an entry, not the worst second of the run. They are bounded below
+by the 1s sample interval: a shorter spike is averaged away, so these
+understate burstiness and never overstate it. Entries that finished in fewer than
+four samples carry no shape and are excluded from these three columns only.
+
+### Memory
+
+| App | Idle RSS | RSS/item | Peak RSS | over | Drift | After idle |
+|---|---:|---:|---:|---:|---:|---:|
+| **nzbdavex** | — | **—** | — | 0 entries | — | — |
+| **raw NNTP baseline** | 41 MiB | **661 MiB** | 1521 MiB | 14 entries | -794 MiB | 749 MiB |
+| **AltMount** | 98 MiB | **508 MiB** | 564 MiB | 14 entries | -89 MiB | 204 MiB |
+| **StreamNZB** | 51 MiB | **607 MiB** | 701 MiB | 14 entries | +58 MiB | 491 MiB |
+| **nzbdav** | — | **—** | — | 0 entries | — | — |
+| **Decypharr** | — | **—** | — | 0 entries | — | — |
+| **StremThru (newz)** | 128 MiB | **815 MiB** | 913 MiB | 14 entries | +9 MiB | 684 MiB |
+| **InfiniDysk** | — | **—** | — | 0 entries | — | — |
+| **AIOStreams** | 227 MiB | **447 MiB** | 667 MiB | 14 entries | -142 MiB | 219 MiB |
+
+*RSS/item* is the median of the per-entry peaks and is the comparable number.
+*Peak RSS* is the highest single-entry peak in the run: **not representative of**
+**real-world usage**, since it is a high-water mark reached once, but it is the
+number that decides whether the application fits in the RAM you have. Read it with
+the *over* column beside it, which says how many entries the peak was taken over:
+a run-wide peak rewards failing early, and an application that survived 21 entries
+had fewer chances to spike than one that survived 31.
+
+*Drift* is the median per-entry peak over the last third of the run minus the
+first third. Every application here holds more memory the longer it runs, and this
+states how much rather than letting it inflate the headline. It is measured with no
+idle gap between entries, which is the harshest case: applications that release on
+idle never get the chance to. *After idle* is the median footprint once the work
+stops but before the process is killed, which is where that memory goes back.
+
+These are taken over every measured entry, including failed ones, since a failure
+still occupies a position in the session, and over the whole session rather than
+the shared population. Entries merged from another run are excluded, because their
+footprint is another process's.
+
+> **`runtime: docker` rows were measured in a container, not on this host.**
+> nzbdavex, nzbdav, Decypharr, InfiniDysk are not buildable natively here, so they were run
+> under Docker with `--docker`. The CPU and memory columns are real numbers, read
+> from the daemon's cgroup counters rather than guessed, but they describe a process
+> inside a Linux VM: the CPU is the VM's share of this machine, and every byte
+> crosses an extra NAT hop on the way in.
+>
+> Compare container rows with each other freely. Against a native row, read them as
+> indicative: a container row that is slower is not proof the application is.
+
+## Capability matrix
+
+Every entry scored against what it is supposed to do, not against its status code.
+
+| | |
+|---|---|
+| `pass` | should stream, and did |
+| **`FAIL`** | should stream, and did not |
+| `refused` | unservable, and was refused |
+| **`served`** | unservable, and bytes came back anyway |
+
+> **The `raw` column is not a capability claim.** It streams the outer volume
+> bytes without opening the archive, so it "passes" encrypted and obfuscated
+> entries that no application could actually play. Read it as "the articles are
+> retrievable", which is exactly what makes it useful: a failure everywhere *except*
+> raw is an application limitation, not a dead post.
+
+| Entry | Tier | nzbdavex | raw NNTP baseline | AltMount | StreamNZB | nzbdav | Decypharr | StremThru (newz) | InfiniDysk | AIOStreams |
+|---|---|---|---|---|---|---|---|---|---|---|
+| `rar4-small` | smoke | pass | pass | pass | pass | pass | pass | pass | pass | pass |
+| `plain-medium` | smoke | pass | pass | pass | pass | pass | pass | pass | pass | pass |
+| `obfuscated-direct` | core | pass | pass | pass | pass | pass | **FAIL** | pass | pass | pass |
+| `plain-large` | core | pass | pass | pass | pass | pass | pass | pass | pass | pass |
+| `plain-season-pack` | core | pass | pass | pass | pass | pass | pass | pass | pass | pass |
+| `rar4-rNN` | core | pass | pass | pass | **FAIL** | pass | pass | pass | pass | pass |
+| `rar-hdrenc-small` | core | **FAIL** | pass | **FAIL** | **FAIL** | **FAIL** | **FAIL** | **FAIL** | **FAIL** | **FAIL** |
+| `rar-hdrenc-large` | core | pass | pass | pass | pass | pass | pass | pass | pass | pass |
+| `rar-partNN-large` | failure | refused | refused | refused | refused | refused | refused | refused | refused | refused |
+| `rar-partNN-maestras` | failure | refused | refused | refused | refused | refused | refused | refused | refused | refused |
+| `rar-partNN-satans` | failure | refused | refused | refused | refused | refused | refused | refused | refused | refused |
+| `7z-split-bugonia` | core | pass | pass | pass | pass | pass | **FAIL** | pass | pass | pass |
+| `7z-split-tardes` | core | pass | pass | pass | pass | pass | **FAIL** | pass | pass | pass |
+| `damaged-partial` | failure | pass | pass | pass | pass | pass | pass | pass | pass | pass |
+
+## Byte-identity cross-check
+
+The same byte ranges hashed by every application and compared **against each**
+**other**, since a fast application serving the wrong bytes is not fast. The
+consensus hash is the one at least two applications agree on; a row that differs
+is the one to investigate.
+
+`raw` participates only on `direct-video` entries: for archived posts it serves
+the outer volume stream rather than the assembled inner file, so it is not a
+valid reference there.
+
+**Every application agreed on every comparable range** (10 entries, 81 app-entry pairs).
+
+## Per-entry detail
+
+### nzbdavex
+
+`nzbdavex` · C# (.NET 10) · version `312d3bc` · serving: webdav · runtime: docker · CPU/RSS from container cgroups · CPU/RSS not measurable · startup 2.22 s
+
+**Own set**: 9 entries, median post 15.9 GiB · click&rarr;byte 1.66 s (shared population: 1.66 s, 1.00×) · seq 92.2 MB/s · CPU — s/GiB
+
+Medians over the entries *this application served*, so they are not comparable
+across rows. Import and click&rarr;byte scale with post size, so an application
+that fails the large entries is credited with the fast medians of the small ones
+it survived; the multiplier is the size of that distortion.
+
+| Entry | Import | Cold TTFB | Seq MB/s | Seek TTFB | Playback p05 | To buffer | CPU s/GiB | Peak RSS | Status |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| `rar4-small` | 1.51 s | 149 ms | 42.5 | 93 ms | 28.2 | 1.22 s | — | — | ok |
+| `plain-medium` | 564 ms | 285 ms | 92.2 | 453 ms | 64.4 | 1.78 s | — | — | ok |
+| `obfuscated-direct` | 557 ms | 834 ms | 102.1 | 555 ms | 8.9 | 2.67 s | — | — | ok |
+| `plain-large` | 888 ms | 418 ms | 59.4 | 469 ms | 66.0 | 1.67 s | — | — | ok |
+| `plain-season-pack` | 514 ms | 106 ms | 104.8 | 164 ms | 80.7 | 871 ms | — | — | ok |
+| `rar4-rNN` | 1.85 s | 153 ms | 91.4 | 118 ms | 51.2 | 804 ms | — | — | ok |
+| `rar-hdrenc-small` | — | — | — | — | — | — | — | — | **failed** |
+| `rar-hdrenc-large` | 1.87 s | 796 ms | 94.7 | 125 ms | 78.1 | 585 ms | — | — | ok |
+| `rar-partNN-large` | — | — | — | — | — | — | — | — | **failed** |
+| `rar-partNN-maestras` | — | — | — | — | — | — | — | — | **failed** |
+| `rar-partNN-satans` | — | — | — | — | — | — | — | — | **failed** |
+| `7z-split-bugonia` | 2.01 s | 99 ms | 93.6 | 88 ms | 53.9 | 982 ms | — | — | ok |
+| `7z-split-tardes` | 1.79 s | 197 ms | 75.1 | 161 ms | 56.0 | 920 ms | — | — | ok |
+| `damaged-partial` | 795 ms | 580 ms | 76.2 | 408 ms | 102.5 | 1.37 s | — | — | ok |
+
+<details><summary>Failures (4)</summary>
+
+- `rar-hdrenc-small` (core): import failed: Corrupt file. Cannot find byte position 40747732.
+- `rar-partNN-large` (failure): import failed: Article with message-id 0d98530cfea9409f8dffdc22a94b396a@ngPost not found.
+- `rar-partNN-maestras` (failure): import failed: Article with message-id 86ea8585e28844ea85e01bd23fede30a@ngPost not found.
+- `rar-partNN-satans` (failure): import failed: Article with message-id 226c3ffed91942069ed8821bc4980374@ngPost not found.
+
+</details>
+
+### raw NNTP baseline
+
+`raw` · JavaScript (this harness) · version `harness-builtin` · serving: http-range · runtime: source · startup 3 ms
+
+**Own set**: 10 entries, median post 11.3 GiB · click&rarr;byte 354 ms (shared population: 382 ms, 1.08×) · seq 64.8 MB/s · CPU 23.2 s/GiB
+
+Medians over the entries *this application served*, so they are not comparable
+across rows. Import and click&rarr;byte scale with post size, so an application
+that fails the large entries is credited with the fast medians of the small ones
+it survived; the multiplier is the size of that distortion.
+
+| Entry | Import | Cold TTFB | Seq MB/s | Seek TTFB | Playback p05 | To buffer | CPU s/GiB | Peak RSS | Status |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| `rar4-small` | 605 ms | 55 ms | 63.1† | 90 ms | — | — | — | 192 MiB | ok |
+| `plain-medium` | 335 ms | 873 ms | 111.4 | 998 ms | 39.4 | 1.36 s | 40.0 | 1521 MiB | ok |
+| `obfuscated-direct` | 615 ms | 957 ms | 76.5 | 864 ms | 18.3 | 2.27 s | 38.6 | 1397 MiB | ok |
+| `plain-large` | 179 ms | 146 ms | 74.4 | 277 ms | 61.0 | 1.02 s | 16.3 | 1372 MiB | ok |
+| `plain-season-pack` | 158 ms | 113 ms | 70.2 | 108 ms | 46.2 | 873 ms | 12.6 | 1050 MiB | ok |
+| `rar4-rNN` | 161 ms | 109 ms | 72.9† | 111 ms | — | 468 ms | 26.3 | 794 MiB | ok |
+| `rar-hdrenc-small` | 162 ms | 110 ms | 43.1 | 112 ms | 57.4 | 1.97 s | 25.5 | 716 MiB | ok |
+| `rar-hdrenc-large` | 83 ms | 105 ms | 59.4 | 103 ms | 106.0 | 506 ms | 17.0 | 606 MiB | ok |
+| `rar-partNN-large` | — | — | — | — | — | — | — | 592 MiB | **failed** |
+| `rar-partNN-maestras` | — | — | — | — | — | — | — | 587 MiB | **failed** |
+| `rar-partNN-satans` | — | — | — | — | — | — | — | 588 MiB | **failed** |
+| `7z-split-bugonia` | 297 ms | 106 ms | 55.1 | 190 ms | 29.1 | 798 ms | 20.6 | 593 MiB | ok |
+| `7z-split-tardes` | 240 ms | 143 ms | 37.8 | 214 ms | 57.2 | 785 ms | 23.2 | 464 MiB | ok |
+| `damaged-partial` | 729 ms | 1.01 s | 86.3 | 909 ms | 54.4 | 1.69 s | 37.2 | 1383 MiB | ok |
+
+† transfer too short to measure sustained rate (the file fit in flight).
+
+<details><summary>Failures (3)</summary>
+
+- `rar-partNN-large` (failure): first article missing
+- `rar-partNN-maestras` (failure): first article missing
+- `rar-partNN-satans` (failure): first article missing
+
+</details>
+
+### AltMount
+
+`altmount` · Go · version `v0.3.2-68-g2f9a80d7` · serving: webdav · runtime: source · startup 778 ms
+
+**Own set**: 9 entries, median post 15.9 GiB · click&rarr;byte 1.18 s (shared population: 1.18 s, 1.00×) · seq 43.9 MB/s · CPU 4.7 s/GiB
+
+Medians over the entries *this application served*, so they are not comparable
+across rows. Import and click&rarr;byte scale with post size, so an application
+that fails the large entries is credited with the fast medians of the small ones
+it survived; the multiplier is the size of that distortion.
+
+| Entry | Import | Cold TTFB | Seq MB/s | Seek TTFB | Playback p05 | To buffer | CPU s/GiB | Peak RSS | Status |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| `rar4-small` | 1.09 s | 92 ms | 49.2 | 3 ms | 27.6 | 253 ms | 4.2 | 296 MiB | ok |
+| `plain-medium` | 328 ms | 88 ms | 46.9 | 612 ms | 51.6 | 2.51 s | 4.7 | 536 MiB | ok |
+| `obfuscated-direct` | 868 ms | 61 ms | 103.7 | 169 ms | 57.8 | 2.32 s | 4.1 | 536 MiB | ok |
+| `plain-large` | 1.42 s | 62 ms | 40.1 | 119 ms | 42.1 | 1.07 s | 4.5 | 554 MiB | ok |
+| `plain-season-pack` | 618 ms | 81 ms | 24.6 | 246 ms | 2.6 | 613 ms | 5.3 | 564 MiB | ok |
+| `rar4-rNN` | 5.21 s | 53 ms | 24.6 | 71 ms | 6.5 | 779 ms | 4.5 | 505 MiB | ok |
+| `rar-hdrenc-small` | — | — | — | — | — | — | — | 511 MiB | **failed** |
+| `rar-hdrenc-large` | 2.31 s | 55 ms | 79.5 | 132 ms | 7.7 | 506 ms | 5.7 | 530 MiB | ok |
+| `rar-partNN-large` | — | — | — | — | — | — | — | 444 MiB | **failed** |
+| `rar-partNN-maestras` | — | — | — | — | — | — | — | 400 MiB | **failed** |
+| `rar-partNN-satans` | — | — | — | — | — | — | — | 341 MiB | **failed** |
+| `7z-split-bugonia` | 1.45 s | 73 ms | 43.3 | 99 ms | 7.0 | 508 ms | 5.5 | 444 MiB | ok |
+| `7z-split-tardes` | 692 ms | 50 ms | 43.9 | 121 ms | 14.1 | 560 ms | 5.8 | 450 MiB | ok |
+| `damaged-partial` | 124 ms | 91 ms | 100.2 | 302 ms | 11.2 | 2.10 s | 17.8 | 548 MiB | ok |
+
+<details><summary>Failures (4)</summary>
+
+- `rar-hdrenc-small` (core): import failed: failed to process nested RAR archives: failed to process nested RAR "b-simpson": compressed media files are not supported: b-simpson.iso (uses rar2.9 compression)
+- `rar-partNN-large` (failure): import failed: fast-fail segment check failed: no regular files were successfully processed (all files failed validation)
+- `rar-partNN-maestras` (failure): import failed: fast-fail segment check failed: no regular files were successfully processed (all files failed validation)
+- `rar-partNN-satans` (failure): import failed: fast-fail segment check failed: no regular files were successfully processed (all files failed validation)
+
+</details>
+
+### StreamNZB
+
+`streamnzb` · Go · version `v5.17.0` · serving: http-range · runtime: source · startup 776 ms
+
+**Own set**: 8 entries, median post 17.6 GiB · click&rarr;byte 1.48 s (shared population: 1.48 s, 1.00×) · seq 45.1 MB/s · CPU 6.3 s/GiB
+
+Medians over the entries *this application served*, so they are not comparable
+across rows. Import and click&rarr;byte scale with post size, so an application
+that fails the large entries is credited with the fast medians of the small ones
+it survived; the multiplier is the size of that distortion.
+
+| Entry | Import | Cold TTFB | Seq MB/s | Seek TTFB | Playback p05 | To buffer | CPU s/GiB | Peak RSS | Status |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| `rar4-small` | 6 ms | 4.11 s | 18.0 | 5 ms | 2.9 | 310 ms | 7.0 | 367 MiB | ok |
+| `plain-medium` | 9 ms | 1.48 s | 34.3 | 234 ms | 14.5 | 1.23 s | 5.7 | 565 MiB | ok |
+| `obfuscated-direct` | 7 ms | 1.02 s | 56.8 | 113 ms | 20.7 | 1.05 s | 5.5 | 560 MiB | ok |
+| `plain-large` | 28 ms | 1.17 s | 31.2 | 257 ms | 5.6 | 1.24 s | 6.1 | 595 MiB | ok |
+| `plain-season-pack` | 64 ms | 1.50 s | 23.0 | 309 ms | 2.6 | 1.05 s | 7.1 | 607 MiB | ok |
+| `rar4-rNN` | 32 ms | — | — | — | — | — | — | 434 MiB | **failed** |
+| `rar-hdrenc-small` | 21 ms | — | — | — | — | — | — | 281 MiB | **failed** |
+| `rar-hdrenc-large` | 63 ms | 1.41 s | 88.1 | 375 ms | 24.8 | 1.00 s | 6.4 | 636 MiB | ok |
+| `rar-partNN-large` | 79 ms | — | — | — | — | — | — | 621 MiB | **failed** |
+| `rar-partNN-maestras` | 21 ms | — | — | — | — | — | — | 621 MiB | **failed** |
+| `rar-partNN-satans` | 21 ms | — | — | — | — | — | — | 621 MiB | **failed** |
+| `7z-split-bugonia` | 64 ms | 3.73 s | 56.0 | 126 ms | 97.6 | 1.07 s | 6.1 | 621 MiB | ok |
+| `7z-split-tardes` | 80 ms | 1.31 s | 88.4 | 240 ms | 20.0 | 1.21 s | 6.8 | 607 MiB | ok |
+| `damaged-partial` | 17 ms | 1.05 s | 27.8 | 250 ms | 4.8 | 989 ms | 7.8 | 701 MiB | ok |
+
+<details><summary>Failures (5)</summary>
+
+- `rar4-rNN` (core): served only 2.4 MB from a 6600 MB post. That is a placeholder, a sample, or the wrong file, not the media.
+- `rar-hdrenc-small` (core): served only 2.4 MB from a 5554 MB post. That is a placeholder, a sample, or the wrong file, not the media.
+- `rar-partNN-large` (failure): served only 2.4 MB from a 20891 MB post. That is a placeholder, a sample, or the wrong file, not the media.
+- `rar-partNN-maestras` (failure): served only 2.4 MB from a 3743 MB post. That is a placeholder, a sample, or the wrong file, not the media.
+- `rar-partNN-satans` (failure): served only 2.4 MB from a 3335 MB post. That is a placeholder, a sample, or the wrong file, not the media.
+
+</details>
+
+### nzbdav
+
+`nzbdav` · C# (.NET 10) · version `0c7d8e2` · serving: webdav · runtime: docker · CPU/RSS from container cgroups · CPU/RSS not measurable · startup 1.64 s
+
+**Own set**: 9 entries, median post 15.9 GiB · click&rarr;byte 1.78 s (shared population: 1.78 s, 1.00×) · seq 80.9 MB/s · CPU — s/GiB
+
+Medians over the entries *this application served*, so they are not comparable
+across rows. Import and click&rarr;byte scale with post size, so an application
+that fails the large entries is credited with the fast medians of the small ones
+it survived; the multiplier is the size of that distortion.
+
+| Entry | Import | Cold TTFB | Seq MB/s | Seek TTFB | Playback p05 | To buffer | CPU s/GiB | Peak RSS | Status |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| `rar4-small` | 1.62 s | 154 ms | 28.6 | 112 ms | 35.8 | 815 ms | — | — | ok |
+| `plain-medium` | 657 ms | 65 ms | 92.4 | 334 ms | 82.9 | 1.21 s | — | — | ok |
+| `obfuscated-direct` | 890 ms | 63 ms | 89.6 | 366 ms | 14.5 | 882 ms | — | — | ok |
+| `plain-large` | 876 ms | 64 ms | 109.1 | 342 ms | 2.1 | 876 ms | — | — | ok |
+| `plain-season-pack` | 591 ms | 54 ms | 80.9 | 217 ms | 64.4 | 509 ms | — | — | ok |
+| `rar4-rNN` | 2.13 s | 114 ms | 101.0 | 135 ms | 23.8 | 843 ms | — | — | ok |
+| `rar-hdrenc-small` | — | — | — | — | — | — | — | — | **failed** |
+| `rar-hdrenc-large` | 4.53 s | 129 ms | 74.7 | 133 ms | 28.9 | 750 ms | — | — | ok |
+| `rar-partNN-large` | — | — | — | — | — | — | — | — | **failed** |
+| `rar-partNN-maestras` | — | — | — | — | — | — | — | — | **failed** |
+| `rar-partNN-satans` | — | — | — | — | — | — | — | — | **failed** |
+| `7z-split-bugonia` | 1.75 s | 92 ms | 71.3 | 132 ms | 13.2 | 2.60 s | — | — | ok |
+| `7z-split-tardes` | 1.77 s | 114 ms | 55.7 | 165 ms | 27.7 | 1.14 s | — | — | ok |
+| `damaged-partial` | 547 ms | 62 ms | — | 516 ms | 66.7 | 1.09 s | — | — | ok |
+
+<details><summary>Failures (4)</summary>
+
+- `rar-hdrenc-small` (core): import failed: Article with message-id SbVwZiPuDtFfMaMhFpIeNrFf-1737036699496@nyuu not found.
+- `rar-partNN-large` (failure): import failed: Article with message-id 0d98530cfea9409f8dffdc22a94b396a@ngPost not found.
+- `rar-partNN-maestras` (failure): import failed: Article with message-id 4c30d20d229f498ca1aa5e49bafec4b2@ngPost not found.
+- `rar-partNN-satans` (failure): import failed: Article with message-id 849c252510294df2af955f53d2aae08c@ngPost not found.
+
+</details>
+
+### Decypharr
+
+`decypharr` · Go · version `v2.5` (`0dd1cbb`) · serving: webdav · runtime: docker · CPU/RSS from container cgroups · CPU/RSS not measurable · startup 1.03 s
+
+**Own set**: 6 entries, median post 11.3 GiB · click&rarr;byte 5.02 s (shared population: 5.02 s, 1.00×) · seq 66.4 MB/s · CPU — s/GiB
+
+Medians over the entries *this application served*, so they are not comparable
+across rows. Import and click&rarr;byte scale with post size, so an application
+that fails the large entries is credited with the fast medians of the small ones
+it survived; the multiplier is the size of that distortion.
+
+| Entry | Import | Cold TTFB | Seq MB/s | Seek TTFB | Playback p05 | To buffer | CPU s/GiB | Peak RSS | Status |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| `rar4-small` | 2.55 s | 280 ms | 31.9 | 5 ms | 160.2 | 250 ms | — | — | ok |
+| `plain-medium` | 3.09 s | 181 ms | 121.6 | 450 ms | 9.3 | 1.61 s | — | — | ok |
+| `obfuscated-direct` | — | — | — | — | — | — | — | — | **failed** |
+| `plain-large` | 12.20 s | 332 ms | 26.2 | 230 ms | 13.8 | 540 ms | — | — | ok |
+| `plain-season-pack` | 6.20 s | 304 ms | 65.9 | 124 ms | 34.5 | 850 ms | — | — | ok |
+| `rar4-rNN` | 3.34 s | 200 ms | 66.9 | 103 ms | 57.5 | 791 ms | — | — | ok |
+| `rar-hdrenc-small` | — | — | — | — | — | — | — | — | **failed** |
+| `rar-hdrenc-large` | 7.22 s | 328 ms | 66.9 | 145 ms | 4.4 | 1.75 s | — | — | ok |
+| `rar-partNN-large` | — | — | — | — | — | — | — | — | **failed** |
+| `rar-partNN-maestras` | — | — | — | — | — | — | — | — | **failed** |
+| `rar-partNN-satans` | — | — | — | — | — | — | — | — | **failed** |
+| `7z-split-bugonia` | — | — | — | — | — | — | — | — | **failed** |
+| `7z-split-tardes` | — | — | — | — | — | — | — | — | **failed** |
+| `damaged-partial` | 2.10 s | 508 ms | — | 780 ms | 8.8 | 1.86 s | — | — | ok |
+
+<details><summary>Failures (7)</summary>
+
+- `obfuscated-direct` (core): import failed: failed to process nzb: failed to process NZB archives: no valid files found in NZB
+- `rar-hdrenc-small` (core): import failed: failed to process nzb: failed to process NZB archives: all files were skipped due to size or extension restrictions(error file extension not allowed)
+- `rar-partNN-large` (failure): POST <app>/sabnzbd/api?mode=addfile&output=json&category=bench&cat=bench&action=none -> 500: { "status": false, "error": "Failed to add rar-partNN-large.nzb: usenet parse failed: failed to stat segment XEQWzFs0v7WfZnBBzUxZ.part01.rar \u003cd3ce1d85f18444998817c8c9f5e4c3fb@ngPost\u003e: all providers failed: NNTP ARTICLE_NOT_FOUND (code 430): No Such Article" }
+- `rar-partNN-maestras` (failure): POST <app>/sabnzbd/api?mode=addfile&output=json&category=bench&cat=bench&action=none -> 500: { "status": false, "error": "Failed to add rar-partNN-maestras.nzb: usenet parse failed: failed to stat segment Su7pfShZJ0uazNFfv70sB3.part01.rar \u003cbf4a33b4f2cd47d2829c3c5688da9667@ngPost\u003e: all providers failed: NNTP ARTICLE_NOT_FOUND (code 430): No Such Article" }
+- `rar-partNN-satans` (failure): POST <app>/sabnzbd/api?mode=addfile&output=json&category=bench&cat=bench&action=none -> 500: { "status": false, "error": "Failed to add rar-partNN-satans.nzb: usenet parse failed: failed to stat segment rEN8svtCcJjJ74Q4qpvJf1K8A.part01.rar \u003c4b2b3480fd6543efb4f7bba8e7ccc3b7@ngPost\u003e: all providers failed: NNTP ARTICLE_NOT_FOUND (code 430): No Such Article" }
+- `7z-split-bugonia` (core): import failed: failed to process nzb: content verification failed: head of "7z-split-bugonia.mkv" matches no media container signature: usenet file content is corrupt
+- `7z-split-tardes` (core): import failed: failed to process nzb: content verification failed: head of "7z-split-tardes.mkv" matches no media container signature: usenet file content is corrupt
+
+</details>
+
+### StremThru (newz)
+
+`stremthru` · Go · version `73bf362` · serving: http-range · runtime: source · startup 559 ms
+
+**Own set**: 9 entries, median post 15.9 GiB · click&rarr;byte 3.49 s (shared population: 3.49 s, 1.00×) · seq 28.5 MB/s · CPU 13.2 s/GiB
+
+Medians over the entries *this application served*, so they are not comparable
+across rows. Import and click&rarr;byte scale with post size, so an application
+that fails the large entries is credited with the fast medians of the small ones
+it survived; the multiplier is the size of that distortion.
+
+| Entry | Import | Cold TTFB | Seq MB/s | Seek TTFB | Playback p05 | To buffer | CPU s/GiB | Peak RSS | Status |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| `rar4-small` | 3.45 s | 43 ms | 18.8 | 32 ms | 22.8 | 305 ms | 13.2 | 585 MiB | ok |
+| `plain-medium` | 835 ms | 18 ms | 115.9 | 288 ms | 22.1 | 990 ms | 6.1 | 843 MiB | ok |
+| `obfuscated-direct` | 105 ms | 10 ms | 2667.0† | 13 ms | 31.8 | 250 ms | 2.2 | 913 MiB | ok |
+| `plain-large` | 637 ms | 38 ms | 75.0 | 213 ms | 19.9 | 1.39 s | 6.4 | 770 MiB | ok |
+| `plain-season-pack` | 1.04 s | 76 ms | 35.7 | 211 ms | 2.4 | 12.76 s | 9.4 | 653 MiB | ok |
+| `rar4-rNN` | 5.33 s | 240 ms | 23.0 | 483 ms | — | — | 85.8 | 752 MiB | ok |
+| `rar-hdrenc-small` | — | — | — | — | — | — | — | 708 MiB | **failed** |
+| `rar-hdrenc-large` | 27.85 s | 191 ms | 34.0 | 422 ms | 1.5 | 1.86 s | 27.6 | 860 MiB | ok |
+| `rar-partNN-large` | — | — | — | — | — | — | — | 858 MiB | **failed** |
+| `rar-partNN-maestras` | — | — | — | — | — | — | — | 829 MiB | **failed** |
+| `rar-partNN-satans` | — | — | — | — | — | — | — | 830 MiB | **failed** |
+| `7z-split-bugonia` | 8.22 s | 733 ms | 7.3 | 217 ms | 7.2 | 7.65 s | 60.2 | 834 MiB | ok |
+| `7z-split-tardes` | 4.37 s | 59 ms | 7.1 | 297 ms | 5.3 | 4.66 s | 61.9 | 519 MiB | ok |
+| `damaged-partial` | 630 ms | 21 ms | — | 530 ms | 10.5 | 1.58 s | 7.0 | 801 MiB | ok |
+
+† transfer too short to measure sustained rate (the file fit in flight).
+
+<details><summary>Failures (4)</summary>
+
+- `rar-hdrenc-small` (core): newz status failed
+- `rar-partNN-large` (failure): newz status failed
+- `rar-partNN-maestras` (failure): newz status failed
+- `rar-partNN-satans` (failure): newz status failed
+
+</details>
+
+### InfiniDysk
+
+`infinidysk` · C# (.NET 10) · version `dev` · serving: webdav · runtime: docker · CPU/RSS from container cgroups · CPU/RSS not measurable · startup 6.32 s
+
+**Own set**: 9 entries, median post 15.9 GiB · click&rarr;byte 3.24 s (shared population: 3.24 s, 1.00×) · seq 53.6 MB/s · CPU — s/GiB
+
+Medians over the entries *this application served*, so they are not comparable
+across rows. Import and click&rarr;byte scale with post size, so an application
+that fails the large entries is credited with the fast medians of the small ones
+it survived; the multiplier is the size of that distortion.
+
+| Entry | Import | Cold TTFB | Seq MB/s | Seek TTFB | Playback p05 | To buffer | CPU s/GiB | Peak RSS | Status |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| `rar4-small` | 24.50 s | 77 ms | 20.8 | 51 ms | 40.3 | 548 ms | — | — | ok |
+| `plain-medium` | 1.09 s | 62 ms | 33.1 | 718 ms | 1.6 | 3.21 s | — | — | ok |
+| `obfuscated-direct` | 1.21 s | 67 ms | 25.3 | 652 ms | 3.4 | 5.15 s | — | — | ok |
+| `plain-large` | 1.08 s | 84 ms | 27.6 | 611 ms | 11.1 | 3.50 s | — | — | ok |
+| `plain-season-pack` | 2.44 s | 50 ms | 74.2 | 125 ms | 81.1 | 800 ms | — | — | ok |
+| `rar4-rNN` | 3.19 s | 53 ms | 53.6 | 102 ms | — | — | — | — | ok |
+| `rar-hdrenc-small` | — | — | — | — | — | — | — | — | **failed** |
+| `rar-hdrenc-large` | 5.45 s | 581 ms | 74.3 | 136 ms | 34.1 | 1.08 s | — | — | ok |
+| `rar-partNN-large` | — | — | — | — | — | — | — | — | **failed** |
+| `rar-partNN-maestras` | — | — | — | — | — | — | — | — | **failed** |
+| `rar-partNN-satans` | — | — | — | — | — | — | — | — | **failed** |
+| `7z-split-bugonia` | 16.14 s | 126 ms | 83.9 | 133 ms | 43.7 | 1.05 s | — | — | ok |
+| `7z-split-tardes` | 9.43 s | 133 ms | 87.6 | 86 ms | 50.7 | 907 ms | — | — | ok |
+| `damaged-partial` | 1.45 s | 75 ms | 28.6 | 583 ms | 2.0 | 13.85 s | — | — | ok |
+
+<details><summary>Failures (4)</summary>
+
+- `rar-hdrenc-small` (core): import failed: Article with message-id SbVwZiPuDtFfMaMhFpIeNrFf-1737036699496@nyuu not found.
+- `rar-partNN-large` (failure): import failed: Missing articles: 1 important file(s) have missing segments across all providers (e.g. XEQWzFs0v7WfZnBBzUxZ.part04.rar). NZB is likely DMCA'd or expired.
+- `rar-partNN-maestras` (failure): import failed: Missing articles: 1 important file(s) have missing segments across all providers (e.g. Su7pfShZJ0uazNFfv70sB3.part04.rar). NZB is likely DMCA'd or expired.
+- `rar-partNN-satans` (failure): import failed: Missing articles: 1 important file(s) have missing segments across all providers (e.g. rEN8svtCcJjJ74Q4qpvJf1K8A.part01.rar). NZB is likely DMCA'd or expired.
+
+</details>
+
+### AIOStreams
+
+`aiostreams` · TypeScript · version `2026.09.04.2319-nightly` · serving: http-range · runtime: source · startup 2.93 s
+
+**Own set**: 9 entries, median post 15.9 GiB · click&rarr;byte 1.12 s (shared population: 1.12 s, 1.00×) · seq 67.2 MB/s · CPU 6.1 s/GiB
+
+Medians over the entries *this application served*, so they are not comparable
+across rows. Import and click&rarr;byte scale with post size, so an application
+that fails the large entries is credited with the fast medians of the small ones
+it survived; the multiplier is the size of that distortion.
+
+| Entry | Import | Cold TTFB | Seq MB/s | Seek TTFB | Playback p05 | To buffer | CPU s/GiB | Peak RSS | Status |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| `rar4-small` | 1.34 s | 206 ms | 52.3 | 9 ms | — | 289 ms | 11.0 | 358 MiB | ok |
+| `plain-medium` | 534 ms | 315 ms | 96.0 | 279 ms | 27.2 | 1.79 s | 5.7 | 667 MiB | ok |
+| `obfuscated-direct` | 537 ms | 6 ms | 67.7 | 7 ms | 21.7 | 1.25 s | 5.3 | 642 MiB | ok |
+| `plain-large` | 804 ms | 519 ms | 69.5 | 164 ms | 35.3 | 1.43 s | 4.0 | 598 MiB | ok |
+| `plain-season-pack` | 318 ms | 146 ms | 62.0 | 129 ms | 64.4 | 898 ms | 5.5 | 417 MiB | ok |
+| `rar4-rNN` | 1.82 s | 95 ms | 67.2 | 109 ms | 44.1 | 1.66 s | 6.1 | 464 MiB | ok |
+| `rar-hdrenc-small` | — | — | — | — | — | — | — | 381 MiB | **failed** |
+| `rar-hdrenc-large` | 1.10 s | 134 ms | 76.1 | 121 ms | 35.6 | 1.78 s | 7.5 | 434 MiB | ok |
+| `rar-partNN-large` | — | — | — | — | — | — | — | 438 MiB | **failed** |
+| `rar-partNN-maestras` | — | — | — | — | — | — | — | 326 MiB | **failed** |
+| `rar-partNN-satans` | — | — | — | — | — | — | — | 329 MiB | **failed** |
+| `7z-split-bugonia` | 1.09 s | 23 ms | 44.6 | 112 ms | 22.7 | 1.50 s | 8.0 | 501 MiB | ok |
+| `7z-split-tardes` | 595 ms | 20 ms | 40.5 | 148 ms | 80.3 | 1.34 s | 7.0 | 456 MiB | ok |
+| `damaged-partial` | 547 ms | 167 ms | 32.8 | 229 ms | 30.4 | 3.22 s | 6.2 | 593 MiB | ok |
+
+<details><summary>Failures (4)</summary>
+
+- `rar-hdrenc-small` (core): import failed: Archive incomplete: volumes missing from the post [incomplete_archive]
+- `rar-partNN-large` (failure): import failed: Missing on providers: 8/8 sampled segments unavailable (incomplete or removed) [missing_on_providers]
+- `rar-partNN-maestras` (failure): import failed: Missing on providers: 16/16 sampled segments unavailable (incomplete or removed) [missing_on_providers]
+- `rar-partNN-satans` (failure): import failed: Missing on providers: 2/21 files unavailable (incomplete or removed) [missing_on_providers]
+
+</details>
+
+## Corpus used
+
+See `CORPUS.md` for why each entry is in the set.
+
+| Entry | Tier | Posted | Axes |
+|---|---|---:|---|
+| `rar4-small` | smoke | 0.37 GiB | `rar4`, `stored`, `named-volumes`, `partNN` |
+| `plain-medium` | smoke | 6.67 GiB | `direct-video`, `no-archive`, `per-file-unique-stems` |
+| `obfuscated-direct` | core | 6.67 GiB | `direct-video`, `obfuscated-names`, `extensionless` |
+| `plain-large` | core | 15.93 GiB | `direct-video`, `no-archive` |
+| `plain-season-pack` | core | 22.62 GiB | `direct-video`, `season-pack`, `file-selection` |
+| `rar4-rNN` | core | 6.15 GiB | `rar4`, `stored`, `rar+rNN`, `letter-rollover` |
+| `rar-hdrenc-small` | core | 5.17 GiB | `rar5`, `encrypted-headers`, `password-in-nzb` |
+| `rar-hdrenc-large` | core | 24.01 GiB | `rar5`, `encrypted-headers`, `password-in-nzb` |
+| `rar-partNN-large` | failure | 19.46 GiB | `rar`, `partNN`, `password-in-nzb` |
+| `rar-partNN-maestras` | failure | 3.49 GiB | `rar`, `partNN`, `password-in-nzb` |
+| `rar-partNN-satans` | failure | 3.11 GiB | `rar`, `partNN`, `password-in-nzb` |
+| `7z-split-bugonia` | core | 20.83 GiB | `7z`, `split-7z.NNN`, `password-in-nzb` |
+| `7z-split-tardes` | core | 19.34 GiB | `7z`, `split-7z.NNN`, `password-in-nzb` |
+| `damaged-partial` | failure | 6.67 GiB | `direct-video`, `missing-articles` |
+
+---
+
+Generated from `results.json` by `src/report/markdown.mjs`. Regenerate with
+`node src/cli.mjs report <run-dir>`.

--- a/bench/nzb-streaming-benchmarks/results.json
+++ b/bench/nzb-streaming-benchmarks/results.json
@@ -1,0 +1,14318 @@
+{
+ "runId": "2026-09-05T13-48-25-529Z",
+ "startedAt": "2026-09-05T13:48:25.529Z",
+ "harness": {
+  "node": "v24.19.0",
+  "cwd": "/private/tmp/claude-502/-Users-javi-orca-workspaces-altmount-anchovy/e4a59b5e-ac45-49d3-a951-fec27a3a03c6/scratchpad/nzb-streaming-benchmarks"
+ },
+ "system": {
+  "platform": "darwin",
+  "arch": "arm64",
+  "osRelease": "25.5.0",
+  "cpuModel": "Apple M4",
+  "cpuCount": 10,
+  "totalMemoryBytes": 17179869184,
+  "freeMemoryBytesAtStart": 79298560,
+  "loadAverage": [
+   3.28662109375,
+   3.5126953125,
+   4.4140625
+  ],
+  "nodeVersion": "v24.19.0",
+  "uptimeSeconds": 1361128,
+  "cwdDisk": {
+   "totalBytes": 994662584320,
+   "freeBytes": 340166098944
+  },
+  "collectedAt": "2026-09-05T13:48:25.525Z"
+ },
+ "providers": [
+  {
+   "id": "nntp",
+   "host": "client.fr7.newshosting.com",
+   "port": 563,
+   "tls": true,
+   "maxConnections": 20,
+   "backup": false,
+   "user": "ce***"
+  }
+ ],
+ "config": {
+  "trials": 1,
+  "sequentialBytes": 256000000,
+  "sequentialMaxMs": 30000,
+  "seekReadBytes": 8000000,
+  "seekFractions": [
+   0.01,
+   0.25,
+   0.5,
+   0.75,
+   0.95
+  ],
+  "playbackSeconds": 30,
+  "playbackBitrateMbps": 25,
+  "integritySamples": 3,
+  "itemTimeoutMs": 600000,
+  "importTimeoutMs": 300000,
+  "idleSampleMs": 5000,
+  "sampleIntervalMs": 1000,
+  "appCooldownMs": 15000,
+  "skipPlayback": false,
+  "skipIntegrity": false,
+  "connectionsPerProvider": null,
+  "rebuild": false
+ },
+ "corpus": {
+  "source": "corpus/corpus.json",
+  "selected": [
+   {
+    "id": "rar4-small",
+    "tier": "smoke",
+    "expect": "serve",
+    "axes": [
+     "rar4",
+     "stored",
+     "named-volumes",
+     "partNN"
+    ],
+    "sha256": "55ed581204b3d83b857d87a8c0a1c29e73f883bee9cd546e933690a020bf49ba",
+    "postedGiB": 0.37
+   },
+   {
+    "id": "plain-medium",
+    "tier": "smoke",
+    "expect": "serve",
+    "axes": [
+     "direct-video",
+     "no-archive",
+     "per-file-unique-stems"
+    ],
+    "sha256": "9add0ee889f54187410043f92206ad33c816a44ca92f1563c7296e1f4c930af6",
+    "postedGiB": 6.67
+   },
+   {
+    "id": "obfuscated-direct",
+    "tier": "core",
+    "expect": "serve",
+    "axes": [
+     "direct-video",
+     "obfuscated-names",
+     "extensionless"
+    ],
+    "sha256": "6794d1464e7cb28c39c8301c245549e7e11601175d95eca8a53c0d2b1d021da0",
+    "postedGiB": 6.67
+   },
+   {
+    "id": "plain-large",
+    "tier": "core",
+    "expect": "serve",
+    "axes": [
+     "direct-video",
+     "no-archive"
+    ],
+    "sha256": "97df5ff5d59a3ff1122765288bcd08f153547c9bfe9ce7bccf5942649f757a9e",
+    "postedGiB": 15.93
+   },
+   {
+    "id": "plain-season-pack",
+    "tier": "core",
+    "expect": "serve",
+    "axes": [
+     "direct-video",
+     "season-pack",
+     "file-selection"
+    ],
+    "sha256": "c9b60371473825b08b209c49520a0b3764b193f66ea9b7587827b4eb40619f09",
+    "postedGiB": 22.62
+   },
+   {
+    "id": "rar4-rNN",
+    "tier": "core",
+    "expect": "serve",
+    "axes": [
+     "rar4",
+     "stored",
+     "rar+rNN",
+     "letter-rollover"
+    ],
+    "sha256": "f89633155ab56480d3ec7221e0fcde962a79ddf11ffc28c5de61ff4e2ababba2",
+    "postedGiB": 6.15
+   },
+   {
+    "id": "rar-hdrenc-small",
+    "tier": "core",
+    "expect": "serve",
+    "axes": [
+     "rar5",
+     "encrypted-headers",
+     "password-in-nzb"
+    ],
+    "sha256": "d8e5a0d0cd14e2d189304696b7b783234b3da80d07370db3af88c87260c6ca5a",
+    "postedGiB": 5.17
+   },
+   {
+    "id": "rar-hdrenc-large",
+    "tier": "core",
+    "expect": "serve",
+    "axes": [
+     "rar5",
+     "encrypted-headers",
+     "password-in-nzb"
+    ],
+    "sha256": "01431cbac254d55250a7ea6b7ceb2cf46bb0d4977429e47c449856b125d7ca44",
+    "postedGiB": 24.01
+   },
+   {
+    "id": "rar-partNN-large",
+    "tier": "failure",
+    "expect": "reject",
+    "axes": [
+     "rar",
+     "partNN",
+     "password-in-nzb"
+    ],
+    "sha256": "bc3e1ebe3c25efcada209eb5f0d52648da413a718573173ba263a7f73634dcd1",
+    "postedGiB": 19.46
+   },
+   {
+    "id": "rar-partNN-maestras",
+    "tier": "failure",
+    "expect": "reject",
+    "axes": [
+     "rar",
+     "partNN",
+     "password-in-nzb"
+    ],
+    "sha256": "8897062c4e8778de2b306f2aa3c2ecc5a4dc233bef503ccd523c6a514ab4536c",
+    "postedGiB": 3.49
+   },
+   {
+    "id": "rar-partNN-satans",
+    "tier": "failure",
+    "expect": "reject",
+    "axes": [
+     "rar",
+     "partNN",
+     "password-in-nzb"
+    ],
+    "sha256": "072bf2a684bdfca91cc8ba906bc1a1d4e75d1be8d1db1b460119f3c9627cc97d",
+    "postedGiB": 3.11
+   },
+   {
+    "id": "7z-split-bugonia",
+    "tier": "core",
+    "expect": "serve",
+    "axes": [
+     "7z",
+     "split-7z.NNN",
+     "password-in-nzb"
+    ],
+    "sha256": "3d3aa512f73872c87af6c76db6b8738fa05fe000ac5be49c5836383e72229b85",
+    "postedGiB": 20.83
+   },
+   {
+    "id": "7z-split-tardes",
+    "tier": "core",
+    "expect": "serve",
+    "axes": [
+     "7z",
+     "split-7z.NNN",
+     "password-in-nzb"
+    ],
+    "sha256": "87a5066e0aeccf854f9df1b7efd0b9d0a6187d79c189866842d5dad940e68ba9",
+    "postedGiB": 19.34
+   },
+   {
+    "id": "damaged-partial",
+    "tier": "failure",
+    "expect": "serve",
+    "axes": [
+     "direct-video",
+     "missing-articles"
+    ],
+    "sha256": "90b9bdccb56a8f91389dae720608d1f0feb0854ede2751d599f6fcf4ef222829",
+    "postedGiB": 6.67
+   }
+  ]
+ },
+ "apps": [
+  {
+   "app": "nzbdavex",
+   "displayName": "nzbdavex",
+   "language": "C# (.NET 10)",
+   "repo": "https://github.com/qooode/nzbdavex",
+   "serving": "webdav",
+   "runtime": "docker",
+   "startedAt": "2026-09-05T13:48:25.529Z",
+   "items": [
+    {
+     "id": "rar4-small",
+     "tier": "smoke",
+     "axes": [
+      "rar4",
+      "stored",
+      "named-volumes",
+      "partNN"
+     ],
+     "expect": "serve",
+     "importMs": 1511.4,
+     "target": {
+      "fileName": "father.brown.2013.s02e05.hdtv.x264-tla.mp4",
+      "sizeBytes": 321905886
+     },
+     "coldOpen": {
+      "headerMs": 148.72,
+      "ttfbMs": 148.93,
+      "bytes": 1030011,
+      "status": 200
+     },
+     "coldOpenWallMs": 275.6,
+     "probe": {
+      "totalBytes": 321905886,
+      "rangeSupported": true,
+      "contentType": "video/mp4",
+      "firstByteMs": 81.75
+     },
+     "probeWallMs": 81.9,
+     "sizeBytes": 321905886,
+     "warmOpen": {
+      "headerMs": 146.38,
+      "ttfbMs": 146.5,
+      "bytes": 1006459,
+      "status": 200
+     },
+     "warmOpenWallMs": 246.4,
+     "sequential": {
+      "ttfbMs": 60.55,
+      "bytes": 256024243,
+      "durationMs": 6079.02,
+      "meanMBps": 42.54,
+      "p50MBps": 41.934,
+      "p05MBps": 26.534,
+      "maxMBps": 56.084,
+      "reliable": true
+     },
+     "sequentialWallMs": 6079.4,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 3219058,
+        "ttfbMs": 108.06,
+        "headerMs": 107.77,
+        "bytes": 8031497,
+        "throughputMBps": 47.516,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 80476471,
+        "ttfbMs": 56.87,
+        "headerMs": 56.8,
+        "bytes": 8025106,
+        "throughputMBps": 51.107,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 160952943,
+        "ttfbMs": 92.82,
+        "headerMs": 92.76,
+        "bytes": 8028047,
+        "throughputMBps": 32.77,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 241429414,
+        "ttfbMs": 93.14,
+        "headerMs": 93.07,
+        "bytes": 8023821,
+        "throughputMBps": 36.981,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 305810591,
+        "ttfbMs": 126.18,
+        "headerMs": 126.12,
+        "bytes": 8029154,
+        "throughputMBps": 30.527,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 32190588,
+       "ttfbMs": 123.2,
+       "throughputMBps": 37.062
+      },
+      "medianTtfbMs": 93.14,
+      "worstTtfbMs": 126.18,
+      "failures": 0
+     },
+     "seeksWallMs": 1868.2,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 96571765,
+      "ttfbMs": 94.28,
+      "bytes": 225334121,
+      "durationMs": 4309.34,
+      "meanMBps": 53.459,
+      "p05MBps": 28.183,
+      "timeToBufferMs": 1220,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 4309.9,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "518f4aeb3bdec36905cd82df6113512a9a4919a4fb9c031b789ba4df0034648c"
+      },
+      {
+       "start": 159952943,
+       "bytes": 2000000,
+       "sha256": "cb37e4294880844c4a5d3db895c0ac91a2331fb5bae255f5920184bb8f88d7b6"
+      },
+      {
+       "start": 319905886,
+       "bytes": 2000000,
+       "sha256": "80c39132e3e0dcd3646f6e170c128794169c97e70eca1ebb1af581ed626ee43c"
+      }
+     ],
+     "integrityWallMs": 756.7,
+     "status": "ok",
+     "wallMs": 15129.8,
+     "cpuSeconds": null,
+     "deliveredBytes": 483394834,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "plain-medium",
+     "tier": "smoke",
+     "axes": [
+      "direct-video",
+      "no-archive",
+      "per-file-unique-stems"
+     ],
+     "expect": "serve",
+     "importMs": 564.2,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 284.48,
+      "ttfbMs": 284.56,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "coldOpenWallMs": 292.7,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 471.62
+     },
+     "probeWallMs": 471.8,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 510.26,
+      "ttfbMs": 510.34,
+      "bytes": 1008448,
+      "status": 200
+     },
+     "warmOpenWallMs": 515.7,
+     "sequential": {
+      "ttfbMs": 333.12,
+      "bytes": 256016384,
+      "durationMs": 3110.6,
+      "meanMBps": 92.176,
+      "p50MBps": 109.186,
+      "p05MBps": 27.112,
+      "maxMBps": 147.509,
+      "reliable": true
+     },
+     "sequentialWallMs": 3110.8,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 325.78,
+        "headerMs": 325.5,
+        "bytes": 8031275,
+        "throughputMBps": 19.455,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 400.55,
+        "headerMs": 400.48,
+        "bytes": 8007721,
+        "throughputMBps": 13.392,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 548.92,
+        "headerMs": 548.84,
+        "bytes": 8052818,
+        "throughputMBps": 10.696,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 619.9,
+        "headerMs": 619.81,
+        "bytes": 8065147,
+        "throughputMBps": 9.547,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 452.84,
+        "headerMs": 452.73,
+        "bytes": 8029135,
+        "throughputMBps": 10.904,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 545.83,
+       "throughputMBps": 10.235
+      },
+      "medianTtfbMs": 452.84,
+      "worstTtfbMs": 619.9,
+      "failures": 0
+     },
+     "seeksWallMs": 7023.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 430.61,
+      "bytes": 3910823166,
+      "durationMs": 30002.85,
+      "meanMBps": 132.246,
+      "p05MBps": 64.433,
+      "timeToBufferMs": 1778,
+      "secondsBelowBitrate": 0.41,
+      "sustainable": true
+     },
+     "playbackWallMs": 30003.1,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 1218.9,
+     "status": "ok",
+     "wallMs": 43200.8,
+     "cpuSeconds": null,
+     "deliveredBytes": 4168863806,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "obfuscated-direct",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "obfuscated-names",
+      "extensionless"
+     ],
+     "expect": "serve",
+     "importMs": 556.8,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 834.34,
+      "ttfbMs": 834.43,
+      "bytes": 1021440,
+      "status": 200
+     },
+     "coldOpenWallMs": 843.7,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 423.84
+     },
+     "probeWallMs": 424,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 336.21,
+      "ttfbMs": 336.28,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "warmOpenWallMs": 345.5,
+     "sequential": {
+      "ttfbMs": 429.68,
+      "bytes": 256016384,
+      "durationMs": 2938.01,
+      "meanMBps": 102.067,
+      "p50MBps": 95.672,
+      "p05MBps": 30.767,
+      "maxMBps": 166.59,
+      "reliable": true
+     },
+     "sequentialWallMs": 2938.2,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 305.34,
+        "headerMs": 305.25,
+        "bytes": 8031275,
+        "throughputMBps": 17.522,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 446.36,
+        "headerMs": 446.22,
+        "bytes": 8040489,
+        "throughputMBps": 13.775,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 558.47,
+        "headerMs": 558.38,
+        "bytes": 8020050,
+        "throughputMBps": 4.691,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 555.32,
+        "headerMs": 555.12,
+        "bytes": 8032379,
+        "throughputMBps": 8.034,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 669.38,
+        "headerMs": 669.19,
+        "bytes": 8029135,
+        "throughputMBps": 6.456,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 247.89,
+       "throughputMBps": 6.438
+      },
+      "medianTtfbMs": 555.32,
+      "worstTtfbMs": 669.38,
+      "failures": 0
+     },
+     "seeksWallMs": 9025.6,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 380.54,
+      "bytes": 2763123966,
+      "durationMs": 30002.07,
+      "meanMBps": 93.281,
+      "p05MBps": 8.92,
+      "timeToBufferMs": 2672,
+      "secondsBelowBitrate": 2.63,
+      "sustainable": true
+     },
+     "playbackWallMs": 30002.8,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 2648.1,
+     "status": "ok",
+     "wallMs": 46784.9,
+     "cpuSeconds": null,
+     "deliveredBytes": 3021177598,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "plain-large",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "no-archive"
+     ],
+     "expect": "serve",
+     "importMs": 887.5,
+     "target": {
+      "fileName": "1ca77039eefe6edc3e869fb905878.mkv",
+      "sizeBytes": 15076905867
+     },
+     "coldOpen": {
+      "headerMs": 418.16,
+      "ttfbMs": 418.25,
+      "bytes": 1012224,
+      "status": 200
+     },
+     "coldOpenWallMs": 425.7,
+     "probe": {
+      "totalBytes": 15076905867,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 526.99
+     },
+     "probeWallMs": 527.1,
+     "sizeBytes": 15076905867,
+     "warmOpen": {
+      "headerMs": 523.33,
+      "ttfbMs": 523.41,
+      "bytes": 1008448,
+      "status": 200
+     },
+     "warmOpenWallMs": 531.7,
+     "sequential": {
+      "ttfbMs": 520.2,
+      "bytes": 256016384,
+      "durationMs": 4831.68,
+      "meanMBps": 59.38,
+      "p50MBps": 93.621,
+      "p05MBps": 7.836,
+      "maxMBps": 119.869,
+      "reliable": true
+     },
+     "sequentialWallMs": 4831.9,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 150769058,
+        "ttfbMs": 424.32,
+        "headerMs": 424.19,
+        "bytes": 8024670,
+        "throughputMBps": 13.513,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 3769226466,
+        "ttfbMs": 383.83,
+        "headerMs": 383.72,
+        "bytes": 8006430,
+        "throughputMBps": 12.167,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 7538452933,
+        "ttfbMs": 468.83,
+        "headerMs": 468.76,
+        "bytes": 8017467,
+        "throughputMBps": 10.328,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 11307679400,
+        "ttfbMs": 821.45,
+        "headerMs": 821.25,
+        "bytes": 8028504,
+        "throughputMBps": 10.201,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 14323060573,
+        "ttfbMs": 538.96,
+        "headerMs": 538.9,
+        "bytes": 8024227,
+        "throughputMBps": 16.11,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1507690586,
+       "ttfbMs": 336.93,
+       "throughputMBps": 16.973
+      },
+      "medianTtfbMs": 468.83,
+      "worstTtfbMs": 821.45,
+      "failures": 0
+     },
+     "seeksWallMs": 6761,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 4523071760,
+      "ttfbMs": 426.91,
+      "bytes": 4146587376,
+      "durationMs": 47854.66,
+      "meanMBps": 87.43,
+      "p05MBps": 65.962,
+      "timeToBufferMs": 1665,
+      "secondsBelowBitrate": 19.92,
+      "sustainable": true
+     },
+     "playbackWallMs": 47855,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "f9f305fa3fbc944f62df43ac8c3452bb25fd5d81f018ff874658b5004c8319d1"
+      },
+      {
+       "start": 7537452933,
+       "bytes": 2000000,
+       "sha256": "5551953b14d1450b51a7914a813f0ae27582f40aed6090f9a9a08742f3084e2d"
+      },
+      {
+       "start": 15074905867,
+       "bytes": 2000000,
+       "sha256": "98fdc11b40dbe71e4bf96844181a32f8573cd2b7058f16cf66702a1ff20aea6b"
+      }
+     ],
+     "integrityWallMs": 1428.7,
+     "status": "ok",
+     "wallMs": 63248.7,
+     "cpuSeconds": null,
+     "deliveredBytes": 4404624432,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "plain-season-pack",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "season-pack",
+      "file-selection"
+     ],
+     "expect": "serve",
+     "importMs": 514.1,
+     "target": {
+      "fileName": "Bosch.S01E01.2015.1080p.Amazon.WEB-DL.AVC.DDP.5.1-DBTV.mkv",
+      "sizeBytes": 2210528776
+     },
+     "coldOpen": {
+      "headerMs": 105.89,
+      "ttfbMs": 105.96,
+      "bytes": 1011712,
+      "status": 200
+     },
+     "coldOpenWallMs": 141.1,
+     "probe": {
+      "totalBytes": 2210528776,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 137.85
+     },
+     "probeWallMs": 138.1,
+     "sizeBytes": 2210528776,
+     "warmOpen": {
+      "headerMs": 100.24,
+      "ttfbMs": 100.36,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "warmOpenWallMs": 107.7,
+     "sequential": {
+      "ttfbMs": 61.59,
+      "bytes": 256012288,
+      "durationMs": 2503.49,
+      "meanMBps": 104.842,
+      "p50MBps": 104.41,
+      "p05MBps": 88.463,
+      "maxMBps": 122.531,
+      "reliable": true
+     },
+     "sequentialWallMs": 2503.7,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 22105287,
+        "ttfbMs": 122.21,
+        "headerMs": 121.89,
+        "bytes": 8004409,
+        "throughputMBps": 60.151,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 552632194,
+        "ttfbMs": 288.35,
+        "headerMs": 288.25,
+        "bytes": 8011902,
+        "throughputMBps": 34.134,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 1105264388,
+        "ttfbMs": 163.59,
+        "headerMs": 163.54,
+        "bytes": 8020220,
+        "throughputMBps": 51.456,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 1657896582,
+        "ttfbMs": 246.1,
+        "headerMs": 246.03,
+        "bytes": 8012154,
+        "throughputMBps": 34.694,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 2100002337,
+        "ttfbMs": 87.3,
+        "headerMs": 87.23,
+        "bytes": 8020447,
+        "throughputMBps": 46.516,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 221052877,
+       "ttfbMs": 74.88,
+       "throughputMBps": 48.467
+      },
+      "medianTtfbMs": 163.59,
+      "worstTtfbMs": 288.35,
+      "failures": 0
+     },
+     "seeksWallMs": 2075.2,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 663158632,
+      "ttfbMs": 125.28,
+      "bytes": 1547370144,
+      "durationMs": 21810.44,
+      "meanMBps": 71.356,
+      "p05MBps": 80.685,
+      "timeToBufferMs": 871,
+      "secondsBelowBitrate": 8.63,
+      "sustainable": true
+     },
+     "playbackWallMs": 21810.7,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "c3d52b715e7f6ee76f5a1c103a31853d440f1e96341ff2170ca66646a105f452"
+      },
+      {
+       "start": 1104264388,
+       "bytes": 2000000,
+       "sha256": "9e6e73cef2032c61a18d91b1f4d869f69f33e473b43d21d1fb9f1c7d69c9f09e"
+      },
+      {
+       "start": 2208528776,
+       "bytes": 2000000,
+       "sha256": "01b4b848c553ad2ae59b7bab78a02762acfede9b41415de494e5907413a9881f"
+      }
+     ],
+     "integrityWallMs": 717.7,
+     "status": "ok",
+     "wallMs": 28008.4,
+     "cpuSeconds": null,
+     "deliveredBytes": 1805409952,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar4-rNN",
+     "tier": "core",
+     "axes": [
+      "rar4",
+      "stored",
+      "rar+rNN",
+      "letter-rollover"
+     ],
+     "expect": "serve",
+     "importMs": 1848.2,
+     "target": {
+      "fileName": "It's.Always.Sunny.in.Philadelphia.S07E12.The.High.School.Reunion.BluRay.1080p.Remux.AVC.DTSHD-MA.5.1-PtZ.mkv",
+      "sizeBytes": 5882124203
+     },
+     "coldOpen": {
+      "headerMs": 152.9,
+      "ttfbMs": 152.97,
+      "bytes": 1029974,
+      "status": 200
+     },
+     "coldOpenWallMs": 295.1,
+     "probe": {
+      "totalBytes": 5882124203,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 93.36
+     },
+     "probeWallMs": 93.5,
+     "sizeBytes": 5882124203,
+     "warmOpen": {
+      "headerMs": 103.53,
+      "ttfbMs": 103.61,
+      "bytes": 1029974,
+      "status": 200
+     },
+     "warmOpenWallMs": 218.1,
+     "sequential": {
+      "ttfbMs": 109.99,
+      "bytes": 256006142,
+      "durationMs": 2910.08,
+      "meanMBps": 91.428,
+      "p50MBps": 91.445,
+      "p05MBps": 83.451,
+      "maxMBps": 112.078,
+      "reliable": true
+     },
+     "sequentialWallMs": 2910.2,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 58821242,
+        "ttfbMs": 109.25,
+        "headerMs": 109.09,
+        "bytes": 8015110,
+        "throughputMBps": 38.71,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1470531050,
+        "ttfbMs": 106.44,
+        "headerMs": 106.37,
+        "bytes": 8003076,
+        "throughputMBps": 44.365,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 2941062101,
+        "ttfbMs": 118.13,
+        "headerMs": 118.07,
+        "bytes": 8015025,
+        "throughputMBps": 43.309,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4411593152,
+        "ttfbMs": 165.79,
+        "headerMs": 165.74,
+        "bytes": 8014686,
+        "throughputMBps": 42.011,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 5588017992,
+        "ttfbMs": 124.35,
+        "headerMs": 124.24,
+        "bytes": 8058268,
+        "throughputMBps": 51.828,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 588212420,
+       "ttfbMs": 269.02,
+       "throughputMBps": 22.311
+      },
+      "medianTtfbMs": 118.13,
+      "worstTtfbMs": 165.79,
+      "failures": 0
+     },
+     "seeksWallMs": 2172.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1764637260,
+      "ttfbMs": 150.55,
+      "bytes": 2480537598,
+      "durationMs": 30073.16,
+      "meanMBps": 82.898,
+      "p05MBps": 51.222,
+      "timeToBufferMs": 804,
+      "secondsBelowBitrate": 0.79,
+      "sustainable": true
+     },
+     "playbackWallMs": 30073.4,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "652f1b7a97f8dee12621e5d2c483f33bff7c19d5c8f59fe8a9438bc6581e8c88"
+      },
+      {
+       "start": 2940062101,
+       "bytes": 2000000,
+       "sha256": "58b9cf1d866e3b51cdba10ae584acd95b302c53135d8e929e467214fb16154b9"
+      },
+      {
+       "start": 5880124203,
+       "bytes": 2000000,
+       "sha256": "c3c2d6e2dfb3d4ea8c46f74b8579349829e42c7fdbddc101f5bfe992550c4e07"
+      }
+     ],
+     "integrityWallMs": 661.7,
+     "status": "ok",
+     "wallMs": 38272.9,
+     "cpuSeconds": null,
+     "deliveredBytes": 2738603688,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-hdrenc-small",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "status": "failed",
+     "error": "import failed: Corrupt file. Cannot find byte position 40747732.",
+     "wallMs": 7447,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-hdrenc-large",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 1873.4,
+     "target": {
+      "fileName": "Ed%C3%A9n%20(2024)%20[BDRip%20x264%201080p%20AC3%205.1%20Castellano]%20(MATS%C2%AE).mkv",
+      "sizeBytes": 17174121367
+     },
+     "coldOpen": {
+      "headerMs": 795.5,
+      "ttfbMs": 795.59,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "coldOpenWallMs": 888.5,
+     "probe": {
+      "totalBytes": 17174121367,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 98.76
+     },
+     "probeWallMs": 99,
+     "sizeBytes": 17174121367,
+     "warmOpen": {
+      "headerMs": 93.46,
+      "ttfbMs": 93.53,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "warmOpenWallMs": 206.6,
+     "sequential": {
+      "ttfbMs": 100.32,
+      "bytes": 256016384,
+      "durationMs": 2805.2,
+      "meanMBps": 94.65,
+      "p50MBps": 105.124,
+      "p05MBps": 78.395,
+      "maxMBps": 130.644,
+      "reliable": true
+     },
+     "sequentialWallMs": 2805.4,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 171741213,
+        "ttfbMs": 113.24,
+        "headerMs": 112.99,
+        "bytes": 8028160,
+        "throughputMBps": 55.89,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 4293530341,
+        "ttfbMs": 157.78,
+        "headerMs": 157.68,
+        "bytes": 8028160,
+        "throughputMBps": 50.724,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 8587060683,
+        "ttfbMs": 203.01,
+        "headerMs": 202.94,
+        "bytes": 8028160,
+        "throughputMBps": 13.635,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 12880591025,
+        "ttfbMs": 120.83,
+        "headerMs": 120.75,
+        "bytes": 8028160,
+        "throughputMBps": 32.518,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 16315415298,
+        "ttfbMs": 124.63,
+        "headerMs": 124.53,
+        "bytes": 8028160,
+        "throughputMBps": 29.483,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1717412136,
+       "ttfbMs": 102.26,
+       "throughputMBps": 48.983
+      },
+      "medianTtfbMs": 124.63,
+      "worstTtfbMs": 203.01,
+      "failures": 0
+     },
+     "seeksWallMs": 2395.9,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 5152236410,
+      "ttfbMs": 84.99,
+      "bytes": 3446079488,
+      "durationMs": 30029.95,
+      "meanMBps": 115.08,
+      "p05MBps": 78.114,
+      "timeToBufferMs": 585,
+      "secondsBelowBitrate": 0.31,
+      "sustainable": true
+     },
+     "playbackWallMs": 30030.2,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "ca5f5f5d72bc03c73ec554b87f09293056cc64f898d9ba0c6009c0f31cf92035"
+      },
+      {
+       "start": 8586060683,
+       "bytes": 2000000,
+       "sha256": "ed802261f0ff5ea16496bbf3e08828cab7d130093e0b0bd504b5e93ccf9fac78"
+      },
+      {
+       "start": 17172121367,
+       "bytes": 2000000,
+       "sha256": "2cf8c04c6895c85ab6c884ddaea22a03d619822747aa358a1e9d975709bcecc3"
+      }
+     ],
+     "integrityWallMs": 829.3,
+     "status": "ok",
+     "wallMs": 39128.5,
+     "cpuSeconds": null,
+     "deliveredBytes": 3704127488,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-large",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "import failed: Article with message-id 0d98530cfea9409f8dffdc22a94b396a@ngPost not found.",
+     "wallMs": 14221.7,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-maestras",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "import failed: Article with message-id 86ea8585e28844ea85e01bd23fede30a@ngPost not found.",
+     "wallMs": 6024.7,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-satans",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "import failed: Article with message-id 226c3ffed91942069ed8821bc4980374@ngPost not found.",
+     "wallMs": 6120.2,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "7z-split-bugonia",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 2006.8,
+     "target": {
+      "fileName": "Bugonia.2025.SPANiSH.MULTi.1080p.BluRay.x264-USENETHD.mkv",
+      "sizeBytes": 21169663096
+     },
+     "coldOpen": {
+      "headerMs": 99.18,
+      "ttfbMs": 99.27,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "coldOpenWallMs": 206.9,
+     "probe": {
+      "totalBytes": 21169663096,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 121.8
+     },
+     "probeWallMs": 122,
+     "sizeBytes": 21169663096,
+     "warmOpen": {
+      "headerMs": 102.52,
+      "ttfbMs": 102.75,
+      "bytes": 1048576,
+      "status": 200
+     },
+     "warmOpenWallMs": 231.2,
+     "sequential": {
+      "ttfbMs": 137.51,
+      "bytes": 256016384,
+      "durationMs": 2872.04,
+      "meanMBps": 93.624,
+      "p50MBps": 96.102,
+      "p05MBps": 84.065,
+      "maxMBps": 126.276,
+      "reliable": true
+     },
+     "sequentialWallMs": 2872.3,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 211696630,
+        "ttfbMs": 80.56,
+        "headerMs": 80.35,
+        "bytes": 8028160,
+        "throughputMBps": 31.344,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 5292415774,
+        "ttfbMs": 88.03,
+        "headerMs": 87.97,
+        "bytes": 8028160,
+        "throughputMBps": 55.187,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 10584831548,
+        "ttfbMs": 82.71,
+        "headerMs": 82.63,
+        "bytes": 8028160,
+        "throughputMBps": 32.257,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 15877247322,
+        "ttfbMs": 166.74,
+        "headerMs": 166.66,
+        "bytes": 8028160,
+        "throughputMBps": 39.078,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 20111179941,
+        "ttfbMs": 123.43,
+        "headerMs": 123.34,
+        "bytes": 8028160,
+        "throughputMBps": 35.896,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 2116966309,
+       "ttfbMs": 173.48,
+       "throughputMBps": 38.85
+      },
+      "medianTtfbMs": 88.03,
+      "worstTtfbMs": 166.74,
+      "failures": 0
+     },
+     "seeksWallMs": 2001.7,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 6350898928,
+      "ttfbMs": 151.12,
+      "bytes": 2732163072,
+      "durationMs": 30002.27,
+      "meanMBps": 91.526,
+      "p05MBps": 53.946,
+      "timeToBufferMs": 982,
+      "secondsBelowBitrate": 0.49,
+      "sustainable": true
+     },
+     "playbackWallMs": 30002.5,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "dc90fbf4517651e76aca1b4c57f43ec37a25a92bdc1fd9294e806c2228ca39aa"
+      },
+      {
+       "start": 10583831548,
+       "bytes": 2000000,
+       "sha256": "911ad58d080637c505d2d3a768a6bb31ea30f3c4ee925cdb7ecc5003d10e7c2d"
+      },
+      {
+       "start": 21167663096,
+       "bytes": 2000000,
+       "sha256": "3a59d97512411e4b8a542cbf88a7af356b2916175b792ec5e6c2bfe2aeff3b5b"
+      }
+     ],
+     "integrityWallMs": 823.3,
+     "status": "ok",
+     "wallMs": 38266.8,
+     "cpuSeconds": null,
+     "deliveredBytes": 2990243840,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "7z-split-tardes",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 1786.2,
+     "target": {
+      "fileName": "Tardes.De.Soledad.2024.SPANiSH.1080p.BluRay.x264-USENETHD.mkv",
+      "sizeBytes": 19222688752
+     },
+     "coldOpen": {
+      "headerMs": 197.01,
+      "ttfbMs": 197.3,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "coldOpenWallMs": 489,
+     "probe": {
+      "totalBytes": 19222688752,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 112.07
+     },
+     "probeWallMs": 112.3,
+     "sizeBytes": 19222688752,
+     "warmOpen": {
+      "headerMs": 139.61,
+      "ttfbMs": 139.69,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "warmOpenWallMs": 345.1,
+     "sequential": {
+      "ttfbMs": 89.48,
+      "bytes": 256016384,
+      "durationMs": 3497.46,
+      "meanMBps": 75.123,
+      "p50MBps": 78.035,
+      "p05MBps": 66.943,
+      "maxMBps": 91.228,
+      "reliable": true
+     },
+     "sequentialWallMs": 3497.7,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 192226887,
+        "ttfbMs": 161.43,
+        "headerMs": 161.3,
+        "bytes": 8028160,
+        "throughputMBps": 8.477,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 4805672188,
+        "ttfbMs": 83.46,
+        "headerMs": 83.42,
+        "bytes": 8028160,
+        "throughputMBps": 26.584,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 9611344376,
+        "ttfbMs": 152.04,
+        "headerMs": 151.94,
+        "bytes": 8028160,
+        "throughputMBps": 42.883,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 14417016564,
+        "ttfbMs": 184.32,
+        "headerMs": 184.24,
+        "bytes": 8028160,
+        "throughputMBps": 19.777,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 18261554314,
+        "ttfbMs": 361.09,
+        "headerMs": 360.96,
+        "bytes": 8028160,
+        "throughputMBps": 21.727,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1922268875,
+       "ttfbMs": 185.44,
+       "throughputMBps": 30.573
+      },
+      "medianTtfbMs": 161.43,
+      "worstTtfbMs": 361.09,
+      "failures": 0
+     },
+     "seeksWallMs": 3602.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 5766806625,
+      "ttfbMs": 420.12,
+      "bytes": 2947219456,
+      "durationMs": 30001.93,
+      "meanMBps": 99.629,
+      "p05MBps": 56.036,
+      "timeToBufferMs": 920,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30002.2,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "676926b1cace4d63b9055ee16516ed2e86ababef4e6b3807d5e2529fe33fa4da"
+      },
+      {
+       "start": 9610344376,
+       "bytes": 2000000,
+       "sha256": "3037000cc41414ff7c6fa8f1ae5b95ca1a797239cde68dca8394bc5ce9f152e5"
+      },
+      {
+       "start": 19220688752,
+       "bytes": 2000000,
+       "sha256": "441fa0ef78afac308dd1fee5b4c5bac65486f670997aed25a54daafcb8e3f024"
+      }
+     ],
+     "integrityWallMs": 809.7,
+     "status": "ok",
+     "wallMs": 40644.7,
+     "cpuSeconds": null,
+     "deliveredBytes": 3205267456,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "damaged-partial",
+     "tier": "failure",
+     "axes": [
+      "direct-video",
+      "missing-articles"
+     ],
+     "expect": "serve",
+     "importMs": 795.4,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 580.19,
+      "ttfbMs": 580.27,
+      "bytes": 1002368,
+      "status": 200
+     },
+     "coldOpenWallMs": 587.4,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 432.05
+     },
+     "probeWallMs": 432.3,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 640.03,
+      "ttfbMs": 640.12,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "warmOpenWallMs": 648.5,
+     "sequential": {
+      "ttfbMs": 591.72,
+      "bytes": 256049152,
+      "durationMs": 3950.84,
+      "meanMBps": 76.225,
+      "p50MBps": 59.947,
+      "p05MBps": 14.04,
+      "maxMBps": 169.705,
+      "reliable": true
+     },
+     "sequentialWallMs": 3951,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 431.16,
+        "headerMs": 431,
+        "bytes": 8031275,
+        "throughputMBps": 12.786,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 396.29,
+        "headerMs": 396.13,
+        "bytes": 8007721,
+        "throughputMBps": 14.136,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 313.36,
+        "headerMs": 313.27,
+        "bytes": 8020050,
+        "throughputMBps": 19.01,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 546.94,
+        "headerMs": 546.86,
+        "bytes": 8032379,
+        "throughputMBps": 7.427,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 408.08,
+        "headerMs": 407.96,
+        "bytes": 8029135,
+        "throughputMBps": 14.708,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 404.18,
+       "throughputMBps": 13.802
+      },
+      "medianTtfbMs": 408.08,
+      "worstTtfbMs": 546.94,
+      "failures": 0
+     },
+     "seeksWallMs": 6325.7,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 287.76,
+      "bytes": 4331891966,
+      "durationMs": 30000.74,
+      "meanMBps": 145.791,
+      "p05MBps": 102.481,
+      "timeToBufferMs": 1369,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30000.9,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 1195.7,
+     "status": "ok",
+     "wallMs": 43937,
+     "cpuSeconds": null,
+     "deliveredBytes": 4589959294,
+     "cpuSecondsPerGB": null
+    }
+   ],
+   "prepareMs": 536.3,
+   "buildReused": true,
+   "buildStamp": "usenet-bench/nzbdavex:312d3bc",
+   "startupMs": 2215.3,
+   "version": {
+    "version": "312d3bc"
+   },
+   "port": 51605,
+   "pids": [],
+   "idle": {
+    "samples": 0,
+    "cpuSeconds": 0,
+    "unavailable": true,
+    "source": "docker"
+   },
+   "resourcesMeasured": false,
+   "resourceSource": "docker",
+   "resources": {
+    "samples": 0,
+    "cpuSeconds": 0,
+    "unavailable": true,
+    "source": "docker"
+   },
+   "idleAfter": {
+    "samples": 0,
+    "cpuSeconds": 0,
+    "unavailable": true,
+    "source": "docker"
+   },
+   "status": "ok",
+   "finishedAt": "2026-09-05T13:56:29.171Z"
+  },
+  {
+   "app": "raw",
+   "displayName": "raw NNTP baseline",
+   "language": "JavaScript (this harness)",
+   "repo": "(built in)",
+   "serving": "http-range",
+   "runtime": "source",
+   "startedAt": "2026-09-05T13:56:44.179Z",
+   "items": [
+    {
+     "id": "rar4-small",
+     "tier": "smoke",
+     "axes": [
+      "rar4",
+      "stored",
+      "named-volumes",
+      "partNN"
+     ],
+     "expect": "serve",
+     "importMs": 604.5,
+     "target": {
+      "fileName": "pxAk22i5JixP284KGhEVpp_Sb.part09.rar",
+      "sizeBytes": 30000000,
+      "note": "outer archive volume stream (transport ceiling, not the inner file)"
+     },
+     "coldOpen": {
+      "headerMs": 54.96,
+      "ttfbMs": 55.01,
+      "bytes": 1039360,
+      "status": 206
+     },
+     "coldOpenWallMs": 515.1,
+     "probe": {
+      "totalBytes": 30000000,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 102.72
+     },
+     "probeWallMs": 102.8,
+     "sizeBytes": 30000000,
+     "warmOpen": {
+      "headerMs": 106.09,
+      "ttfbMs": 106.13,
+      "bytes": 1047862,
+      "status": 206
+     },
+     "warmOpenWallMs": 107.3,
+     "sequential": {
+      "ttfbMs": 89.03,
+      "bytes": 30000000,
+      "durationMs": 564.13,
+      "meanMBps": 63.146,
+      "p50MBps": null,
+      "p05MBps": null,
+      "maxMBps": null,
+      "reliable": false,
+      "unreliableReason": "only 30 MB in 0.5s"
+     },
+     "sequentialWallMs": 564.2,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 300000,
+        "ttfbMs": 94.69,
+        "headerMs": 94.63,
+        "bytes": 8035360,
+        "throughputMBps": 85.977,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 7500000,
+        "ttfbMs": 67.3,
+        "headerMs": 67.26,
+        "bytes": 8056608,
+        "throughputMBps": 54.554,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 15000000,
+        "ttfbMs": 62.4,
+        "headerMs": 62.32,
+        "bytes": 8049216,
+        "throughputMBps": 34.32,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 22500000,
+        "ttfbMs": 90.26,
+        "headerMs": 90.16,
+        "bytes": 7500000,
+        "throughputMBps": 75.518,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 28500000,
+        "ttfbMs": 100.05,
+        "headerMs": 99.99,
+        "bytes": 1500000,
+        "throughputMBps": 1966.782,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 3000000,
+       "ttfbMs": 69.12,
+       "throughputMBps": 65.433
+      },
+      "medianTtfbMs": 90.26,
+      "worstTtfbMs": 100.05,
+      "failures": 0
+     },
+     "seeksWallMs": 1182.3,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 9000000,
+      "ttfbMs": 100.84,
+      "bytes": 21000000,
+      "durationMs": 332.89,
+      "meanMBps": 90.496,
+      "p05MBps": null,
+      "timeToBufferMs": null,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 332.9,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "a687fd9a9d34db9f541476cae29022210a66814c7e9f6c8ddc017730da457983"
+      },
+      {
+       "start": 14000000,
+       "bytes": 2000000,
+       "sha256": "3587588d828215991d87d0f3601ce1ac27b1899b8b9a8c304b0ed647ea3bfbde"
+      },
+      {
+       "start": 28000000,
+       "bytes": 2000000,
+       "sha256": "a05188aba19c891e2366d5fafdecf623170fb9c75b95a1984c6a2043e11d49d9"
+      }
+     ],
+     "integrityWallMs": 346.1,
+     "status": "ok",
+     "wallMs": 3755.4,
+     "cpuSeconds": 71.31,
+     "rssPeakBytes": 201375744,
+     "rssMeanBytes": 129056768,
+     "cpuShape": null,
+     "deliveredBytes": 53087222,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "plain-medium",
+     "tier": "smoke",
+     "axes": [
+      "direct-video",
+      "no-archive",
+      "per-file-unique-stems"
+     ],
+     "expect": "serve",
+     "importMs": 334.5,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6608994141,
+      "note": "direct video (1 posted part)"
+     },
+     "coldOpen": {
+      "headerMs": 872.84,
+      "ttfbMs": 872.93,
+      "bytes": 1047856,
+      "status": 206
+     },
+     "coldOpenWallMs": 992.4,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 996.45
+     },
+     "probeWallMs": 996.5,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 1059.4,
+      "ttfbMs": 1059.49,
+      "bytes": 1047856,
+      "status": 206
+     },
+     "warmOpenWallMs": 1062.5,
+     "sequential": {
+      "ttfbMs": 1010.47,
+      "bytes": 256049152,
+      "durationMs": 3308.7,
+      "meanMBps": 111.411,
+      "p50MBps": 100.688,
+      "p05MBps": 83.619,
+      "maxMBps": 135.929,
+      "reliable": true
+     },
+     "sequentialWallMs": 3308.8,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 1054.37,
+        "headerMs": 1053.76,
+        "bytes": 8063575,
+        "throughputMBps": 10.108,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 1144.84,
+        "headerMs": 1144.78,
+        "bytes": 8056247,
+        "throughputMBps": 1501.211,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 998.26,
+        "headerMs": 998.17,
+        "bytes": 8035786,
+        "throughputMBps": 43.301,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 996.68,
+        "headerMs": 996.6,
+        "bytes": 8025143,
+        "throughputMBps": 44.679,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 991.52,
+        "headerMs": 991.46,
+        "bytes": 8058887,
+        "throughputMBps": 64.879,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 746.09,
+       "throughputMBps": 24.904
+      },
+      "medianTtfbMs": 998.26,
+      "worstTtfbMs": 1144.84,
+      "failures": 0
+     },
+     "seeksWallMs": 7545.7,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 1056.83,
+      "bytes": 2148756734,
+      "durationMs": 30710.34,
+      "meanMBps": 72.462,
+      "p05MBps": 39.448,
+      "timeToBufferMs": 1364,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30710.4,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 2604.8,
+     "status": "ok",
+     "wallMs": 47555.7,
+     "cpuSeconds": 89.65,
+     "rssPeakBytes": 1594851328,
+     "rssMeanBytes": 1218619711,
+     "cpuShape": {
+      "intervals": 44,
+      "maxCores": 4.63,
+      "p95Cores": 3.25,
+      "medianCores": 1.99,
+      "busyFraction": 0.75
+     },
+     "deliveredBytes": 2406901598,
+     "cpuSecondsPerGB": 39.99
+    },
+    {
+     "id": "obfuscated-direct",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "obfuscated-names",
+      "extensionless"
+     ],
+     "expect": "serve",
+     "importMs": 614.9,
+     "target": {
+      "fileName": "[7/7]",
+      "sizeBytes": 6608994141,
+      "note": "outer archive volume stream (transport ceiling, not the inner file)"
+     },
+     "coldOpen": {
+      "headerMs": 956.49,
+      "ttfbMs": 956.54,
+      "bytes": 1047856,
+      "status": 206
+     },
+     "coldOpenWallMs": 980.6,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 967.98
+     },
+     "probeWallMs": 968,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 715.76,
+      "ttfbMs": 715.83,
+      "bytes": 1047856,
+      "status": 206
+     },
+     "warmOpenWallMs": 875.7,
+     "sequential": {
+      "ttfbMs": 862.76,
+      "bytes": 256049152,
+      "durationMs": 4209.33,
+      "meanMBps": 76.511,
+      "p50MBps": 76.371,
+      "p05MBps": 19.015,
+      "maxMBps": 109.005,
+      "reliable": true
+     },
+     "sequentialWallMs": 4209.4,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 864.07,
+        "headerMs": 864.02,
+        "bytes": 8030495,
+        "throughputMBps": 11.192,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 1062.09,
+        "headerMs": 1062.03,
+        "bytes": 8009879,
+        "throughputMBps": 144.473,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 1173.18,
+        "headerMs": 1172.98,
+        "bytes": 8018594,
+        "throughputMBps": 70.419,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 737.19,
+        "headerMs": 737.08,
+        "bytes": 8014019,
+        "throughputMBps": 20.32,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 828.45,
+        "headerMs": 828.39,
+        "bytes": 8002479,
+        "throughputMBps": 37.246,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 724.41,
+       "throughputMBps": 20.552
+      },
+      "medianTtfbMs": 864.07,
+      "worstTtfbMs": 1173.18,
+      "failures": 0
+     },
+     "seeksWallMs": 7276.8,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 452.44,
+      "bytes": 2211671294,
+      "durationMs": 30149.68,
+      "meanMBps": 74.474,
+      "p05MBps": 18.325,
+      "timeToBufferMs": 2272,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30149.8,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 2364.4,
+     "status": "ok",
+     "wallMs": 47439.6,
+     "cpuSeconds": 88.86,
+     "rssPeakBytes": 1464598528,
+     "rssMeanBytes": 1172431220,
+     "cpuShape": {
+      "intervals": 43,
+      "maxCores": 3.86,
+      "p95Cores": 2.68,
+      "medianCores": 1.93,
+      "busyFraction": 0.95
+     },
+     "deliveredBytes": 2469816158,
+     "cpuSecondsPerGB": 38.63
+    },
+    {
+     "id": "plain-large",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "no-archive"
+     ],
+     "expect": "serve",
+     "importMs": 179.4,
+     "target": {
+      "fileName": "1ca77039eefe6edc3e869fb905878.mkv",
+      "sizeBytes": 15076905867,
+      "note": "direct video (1 posted part)"
+     },
+     "coldOpen": {
+      "headerMs": 145.54,
+      "ttfbMs": 145.63,
+      "bytes": 1047853,
+      "status": 206
+     },
+     "coldOpenWallMs": 147.3,
+     "probe": {
+      "totalBytes": 15076905867,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 267.44
+     },
+     "probeWallMs": 267.5,
+     "sizeBytes": 15076905867,
+     "warmOpen": {
+      "headerMs": 481.65,
+      "ttfbMs": 481.73,
+      "bytes": 1047853,
+      "status": 206
+     },
+     "warmOpenWallMs": 490.7,
+     "sequential": {
+      "ttfbMs": 266.5,
+      "bytes": 256049152,
+      "durationMs": 3708.86,
+      "meanMBps": 74.382,
+      "p50MBps": 73.61,
+      "p05MBps": 57.8,
+      "maxMBps": 92.912,
+      "reliable": true
+     },
+     "sequentialWallMs": 3708.9,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 150769058,
+        "ttfbMs": 366.49,
+        "headerMs": 366.42,
+        "bytes": 8020770,
+        "throughputMBps": 1914.189,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 3769226466,
+        "ttfbMs": 415.29,
+        "headerMs": 415.24,
+        "bytes": 8037846,
+        "throughputMBps": 2088.792,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 7538452933,
+        "ttfbMs": 277.47,
+        "headerMs": 277.43,
+        "bytes": 8021967,
+        "throughputMBps": 27.225,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 11307679400,
+        "ttfbMs": 265.55,
+        "headerMs": 265.5,
+        "bytes": 8028504,
+        "throughputMBps": 72.98,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 14323060573,
+        "ttfbMs": 213.54,
+        "headerMs": 213.48,
+        "bytes": 8024227,
+        "throughputMBps": 41.333,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1507690586,
+       "ttfbMs": 434.05,
+       "throughputMBps": 2172.494
+      },
+      "medianTtfbMs": 277.47,
+      "worstTtfbMs": 415.29,
+      "failures": 0
+     },
+     "seeksWallMs": 2583.1,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 4523071760,
+      "ttfbMs": 346,
+      "bytes": 2252891888,
+      "durationMs": 30118.44,
+      "meanMBps": 75.67,
+      "p05MBps": 61.024,
+      "timeToBufferMs": 1024,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30118.5,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "f9f305fa3fbc944f62df43ac8c3452bb25fd5d81f018ff874658b5004c8319d1"
+      },
+      {
+       "start": 7537452933,
+       "bytes": 2000000,
+       "sha256": "5551953b14d1450b51a7914a813f0ae27582f40aed6090f9a9a08742f3084e2d"
+      },
+      {
+       "start": 15074905867,
+       "bytes": 2000000,
+       "sha256": "98fdc11b40dbe71e4bf96844181a32f8573cd2b7058f16cf66702a1ff20aea6b"
+      }
+     ],
+     "integrityWallMs": 1431.3,
+     "status": "ok",
+     "wallMs": 38926.9,
+     "cpuSeconds": 38.08,
+     "rssPeakBytes": 1438760960,
+     "rssMeanBytes": 1133991673,
+     "cpuShape": {
+      "intervals": 38,
+      "maxCores": 1.46,
+      "p95Cores": 1.28,
+      "medianCores": 0.96,
+      "busyFraction": 0.97
+     },
+     "deliveredBytes": 2511036746,
+     "cpuSecondsPerGB": 16.28
+    },
+    {
+     "id": "plain-season-pack",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "season-pack",
+      "file-selection"
+     ],
+     "expect": "serve",
+     "importMs": 158.3,
+     "target": {
+      "fileName": "Bosch.S01E01.2015.1080p.Amazon.WEB-DL.AVC.DDP.5.1-DBTV.mkv",
+      "sizeBytes": 2210528776,
+      "note": "direct video (1 posted part)"
+     },
+     "coldOpen": {
+      "headerMs": 112.54,
+      "ttfbMs": 112.69,
+      "bytes": 1044480,
+      "status": 206
+     },
+     "coldOpenWallMs": 194.2,
+     "probe": {
+      "totalBytes": 2210528776,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 123.15
+     },
+     "probeWallMs": 123.2,
+     "sizeBytes": 2210528776,
+     "warmOpen": {
+      "headerMs": 103.29,
+      "ttfbMs": 103.34,
+      "bytes": 1044480,
+      "status": 206
+     },
+     "warmOpenWallMs": 197.2,
+     "sequential": {
+      "ttfbMs": 176.85,
+      "bytes": 256036864,
+      "durationMs": 3823.28,
+      "meanMBps": 70.216,
+      "p50MBps": 69.056,
+      "p05MBps": 64.006,
+      "maxMBps": 75.737,
+      "reliable": true
+     },
+     "sequentialWallMs": 3823.4,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 22105287,
+        "ttfbMs": 104.22,
+        "headerMs": 104.18,
+        "bytes": 8000313,
+        "throughputMBps": 219.275,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 552632194,
+        "ttfbMs": 126.52,
+        "headerMs": 126.48,
+        "bytes": 8052862,
+        "throughputMBps": 46.371,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 1105264388,
+        "ttfbMs": 116.85,
+        "headerMs": 116.79,
+        "bytes": 8061180,
+        "throughputMBps": 96.226,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 1657896582,
+        "ttfbMs": 108.15,
+        "headerMs": 108.09,
+        "bytes": 8001050,
+        "throughputMBps": 48.31,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 2100002337,
+        "ttfbMs": 100.27,
+        "headerMs": 100.21,
+        "bytes": 8057311,
+        "throughputMBps": 54.222,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 221052877,
+       "ttfbMs": 116.91,
+       "throughputMBps": 72.008
+      },
+      "medianTtfbMs": 108.15,
+      "worstTtfbMs": 126.52,
+      "failures": 0
+     },
+     "seeksWallMs": 1392.6,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 663158632,
+      "ttfbMs": 318.09,
+      "bytes": 1547370144,
+      "durationMs": 21893.59,
+      "meanMBps": 71.719,
+      "p05MBps": 46.204,
+      "timeToBufferMs": 873,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 21893.7,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "c3d52b715e7f6ee76f5a1c103a31853d440f1e96341ff2170ca66646a105f452"
+      },
+      {
+       "start": 1104264388,
+       "bytes": 2000000,
+       "sha256": "9e6e73cef2032c61a18d91b1f4d869f69f33e473b43d21d1fb9f1c7d69c9f09e"
+      },
+      {
+       "start": 2208528776,
+       "bytes": 2000000,
+       "sha256": "01b4b848c553ad2ae59b7bab78a02762acfede9b41415de494e5907413a9881f"
+      }
+     ],
+     "integrityWallMs": 381.3,
+     "status": "ok",
+     "wallMs": 28164,
+     "cpuSeconds": 21.25,
+     "rssPeakBytes": 1101070336,
+     "rssMeanBytes": 990333221,
+     "cpuShape": {
+      "intervals": 27,
+      "maxCores": 0.9,
+      "p95Cores": 0.89,
+      "medianCores": 0.78,
+      "busyFraction": 0.96
+     },
+     "deliveredBytes": 1805495968,
+     "cpuSecondsPerGB": 12.64
+    },
+    {
+     "id": "rar4-rNN",
+     "tier": "core",
+     "axes": [
+      "rar4",
+      "stored",
+      "rar+rNN",
+      "letter-rollover"
+     ],
+     "expect": "serve",
+     "importMs": 160.8,
+     "target": {
+      "fileName": "It's.Always.Sunny.in.Philadelphia.S07E12.The.High.School.Reunion.BluRay.1080p.Remux.AVC.DTSHD-MA.5.1-PtZ-BeyondHD.me.r02",
+      "sizeBytes": 52428800,
+      "note": "outer archive volume stream (transport ceiling, not the inner file)"
+     },
+     "coldOpen": {
+      "headerMs": 108.62,
+      "ttfbMs": 108.66,
+      "bytes": 1047862,
+      "status": 206
+     },
+     "coldOpenWallMs": 109.7,
+     "probe": {
+      "totalBytes": 52428800,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 123.75
+     },
+     "probeWallMs": 123.8,
+     "sizeBytes": 52428800,
+     "warmOpen": {
+      "headerMs": 110.34,
+      "ttfbMs": 110.38,
+      "bytes": 1047862,
+      "status": 206
+     },
+     "warmOpenWallMs": 111.7,
+     "sequential": {
+      "ttfbMs": 119.06,
+      "bytes": 52428800,
+      "durationMs": 838.32,
+      "meanMBps": 72.893,
+      "p50MBps": 70.981,
+      "p05MBps": 68.023,
+      "maxMBps": 73.939,
+      "reliable": false,
+      "unreliableReason": "only 52 MB in 0.7s"
+     },
+     "sequentialWallMs": 838.4,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 524288,
+        "ttfbMs": 137.17,
+        "headerMs": 137.11,
+        "bytes": 8063164,
+        "throughputMBps": 444.595,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 13107200,
+        "ttfbMs": 111.42,
+        "headerMs": 111.37,
+        "bytes": 8059075,
+        "throughputMBps": 67.103,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 26214400,
+        "ttfbMs": 153.97,
+        "headerMs": 153.93,
+        "bytes": 8013546,
+        "throughputMBps": 2608.965,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 39321600,
+        "ttfbMs": 87.58,
+        "headerMs": 87.55,
+        "bytes": 8050958,
+        "throughputMBps": 50.848,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 49807360,
+        "ttfbMs": 108.53,
+        "headerMs": 108.49,
+        "bytes": 2621440,
+        "throughputMBps": 2724.519,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 5242880,
+       "ttfbMs": 131.62,
+       "throughputMBps": 352.052
+      },
+      "medianTtfbMs": 111.42,
+      "worstTtfbMs": 153.97,
+      "failures": 0
+     },
+     "seeksWallMs": 1053.9,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 15728640,
+      "ttfbMs": 145.31,
+      "bytes": 36700160,
+      "durationMs": 467.66,
+      "meanMBps": 113.855,
+      "p05MBps": null,
+      "timeToBufferMs": 468,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 467.7,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "f37b11321eddf03153d2fa0b7909f514f8b896cc5466570f32c283e8eee27a33"
+      },
+      {
+       "start": 25214400,
+       "bytes": 2000000,
+       "sha256": "e51494516b0030f25c8c5d451425b18152b07e1682bd3b29e25d1bf3ce27b0b6"
+      },
+      {
+       "start": 50428800,
+       "bytes": 2000000,
+       "sha256": "20c89664a80a6f0ca7af2551dd2a42dc54e12945420ccab120feedeba0c0fbea"
+      }
+     ],
+     "integrityWallMs": 389.9,
+     "status": "ok",
+     "wallMs": 3255.9,
+     "cpuSeconds": 2.23,
+     "rssPeakBytes": 832946176,
+     "rssMeanBytes": 809795584,
+     "cpuShape": null,
+     "deliveredBytes": 91224684,
+     "cpuSecondsPerGB": 26.25
+    },
+    {
+     "id": "rar-hdrenc-small",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 162,
+     "target": {
+      "fileName": "3b90183365614f85aec3b6f804331f07.part29.rar",
+      "sizeBytes": 100000000,
+      "note": "outer archive volume stream (transport ceiling, not the inner file)"
+     },
+     "coldOpen": {
+      "headerMs": 110.14,
+      "ttfbMs": 110.18,
+      "bytes": 1044480,
+      "status": 206
+     },
+     "coldOpenWallMs": 131.3,
+     "probe": {
+      "totalBytes": 100000000,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 97.88
+     },
+     "probeWallMs": 97.9,
+     "sizeBytes": 100000000,
+     "warmOpen": {
+      "headerMs": 54.3,
+      "ttfbMs": 54.35,
+      "bytes": 1044480,
+      "status": 206
+     },
+     "warmOpenWallMs": 96.5,
+     "sequential": {
+      "ttfbMs": 122.55,
+      "bytes": 100000000,
+      "durationMs": 2444.63,
+      "meanMBps": 43.065,
+      "p50MBps": 27.97,
+      "p05MBps": 18.777,
+      "maxMBps": 38.492,
+      "reliable": true
+     },
+     "sequentialWallMs": 2444.8,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 1000000,
+        "ttfbMs": 84.71,
+        "headerMs": 84.64,
+        "bytes": 8064448,
+        "throughputMBps": 121.88,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 25000000,
+        "ttfbMs": 118.82,
+        "headerMs": 118.77,
+        "bytes": 8033720,
+        "throughputMBps": 126.082,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 50000000,
+        "ttfbMs": 87.11,
+        "headerMs": 87.05,
+        "bytes": 8006772,
+        "throughputMBps": 6.77,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 75000000,
+        "ttfbMs": 173.28,
+        "headerMs": 173.21,
+        "bytes": 8034112,
+        "throughputMBps": 77.483,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 95000000,
+        "ttfbMs": 111.99,
+        "headerMs": 111.93,
+        "bytes": 5000000,
+        "throughputMBps": 179.004,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 10000000,
+       "ttfbMs": 162.26,
+       "throughputMBps": 2068.49
+      },
+      "medianTtfbMs": 111.99,
+      "worstTtfbMs": 173.28,
+      "failures": 0
+     },
+     "seeksWallMs": 2186.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 30000000,
+      "ttfbMs": 98.51,
+      "bytes": 70000000,
+      "durationMs": 2139.9,
+      "meanMBps": 34.29,
+      "p05MBps": 57.438,
+      "timeToBufferMs": 1972,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 2140,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "42e3504354d052a58eb44e7ff84c062266c77e793c907570d8022a9506a7d77c"
+      },
+      {
+       "start": 49000000,
+       "bytes": 2000000,
+       "sha256": "60a0c3e9e78c3e961ca3693d0abf4d1128619877ca925bde482dc7c84e7bc69f"
+      },
+      {
+       "start": 98000000,
+       "bytes": 2000000,
+       "sha256": "9544cf76bea69198cae3c68099235214573a24df39d1c2044e091b08625f2d9a"
+      }
+     ],
+     "integrityWallMs": 405.1,
+     "status": "ok",
+     "wallMs": 7664,
+     "cpuSeconds": 4.08,
+     "rssPeakBytes": 750338048,
+     "rssMeanBytes": 746168320,
+     "cpuShape": {
+      "intervals": 7,
+      "maxCores": 0.77,
+      "p95Cores": 0.77,
+      "medianCores": 0.55,
+      "busyFraction": 0.57
+     },
+     "deliveredBytes": 172088960,
+     "cpuSecondsPerGB": 25.46
+    },
+    {
+     "id": "rar-hdrenc-large",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 82.8,
+     "target": {
+      "fileName": "09FgoKDUlAp6ticrK802.part01.rar",
+      "sizeBytes": 209715200,
+      "note": "outer archive volume stream (transport ceiling, not the inner file)"
+     },
+     "coldOpen": {
+      "headerMs": 105.21,
+      "ttfbMs": 105.26,
+      "bytes": 1044480,
+      "status": 206
+     },
+     "coldOpenWallMs": 131.2,
+     "probe": {
+      "totalBytes": 209715200,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 121.82
+     },
+     "probeWallMs": 121.9,
+     "sizeBytes": 209715200,
+     "warmOpen": {
+      "headerMs": 96.84,
+      "ttfbMs": 96.9,
+      "bytes": 1044480,
+      "status": 206
+     },
+     "warmOpenWallMs": 101.4,
+     "sequential": {
+      "ttfbMs": 111.57,
+      "bytes": 209715200,
+      "durationMs": 3640.26,
+      "meanMBps": 59.431,
+      "p50MBps": 54.998,
+      "p05MBps": 42.912,
+      "maxMBps": 72.458,
+      "reliable": true
+     },
+     "sequentialWallMs": 3640.6,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 2097152,
+        "ttfbMs": 122.39,
+        "headerMs": 122.35,
+        "bytes": 8047756,
+        "throughputMBps": 282.77,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 52428800,
+        "ttfbMs": 78.9,
+        "headerMs": 78.83,
+        "bytes": 8044544,
+        "throughputMBps": 58.562,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 104857600,
+        "ttfbMs": 102.51,
+        "headerMs": 102.46,
+        "bytes": 8007680,
+        "throughputMBps": 79.389,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 157286400,
+        "ttfbMs": 73.75,
+        "headerMs": 73.71,
+        "bytes": 8010996,
+        "throughputMBps": 119.134,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 199229440,
+        "ttfbMs": 109.8,
+        "headerMs": 109.76,
+        "bytes": 8003584,
+        "throughputMBps": 87.568,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 20971520,
+       "ttfbMs": 134.44,
+       "throughputMBps": 473.651
+      },
+      "medianTtfbMs": 102.51,
+      "worstTtfbMs": 122.39,
+      "failures": 0
+     },
+     "seeksWallMs": 1064.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 62914560,
+      "ttfbMs": 62.14,
+      "bytes": 146800640,
+      "durationMs": 1442.71,
+      "meanMBps": 106.333,
+      "p05MBps": 105.984,
+      "timeToBufferMs": 506,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 1442.8,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "703207a14ad507110557d8c3ee165a485c2467ffedf240399e24d2f2e6d8c78f"
+      },
+      {
+       "start": 103857600,
+       "bytes": 2000000,
+       "sha256": "8756aad6688347be479cd849784c829ff352103d9f008620da12142faf62194c"
+      },
+      {
+       "start": 207715200,
+       "bytes": 2000000,
+       "sha256": "72cc205ed8293e4aefa789249f89c19a3443ca1b6813866ed6780324d4f9b703"
+      }
+     ],
+     "integrityWallMs": 360,
+     "status": "ok",
+     "wallMs": 6945.2,
+     "cpuSeconds": 5.67,
+     "rssPeakBytes": 635158528,
+     "rssMeanBytes": 620920832,
+     "cpuShape": {
+      "intervals": 6,
+      "maxCores": 0.94,
+      "p95Cores": 0.94,
+      "medianCores": 0.78,
+      "busyFraction": 1
+     },
+     "deliveredBytes": 358604800,
+     "cpuSecondsPerGB": 16.98
+    },
+    {
+     "id": "rar-partNN-large",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "first article missing",
+     "wallMs": 1284.4,
+     "cpuSeconds": 0.46,
+     "rssPeakBytes": 621248512,
+     "rssMeanBytes": 621248512,
+     "cpuShape": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-maestras",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "first article missing",
+     "wallMs": 1280.8,
+     "cpuSeconds": 0.05,
+     "rssPeakBytes": 615645184,
+     "rssMeanBytes": 615645184,
+     "cpuShape": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-satans",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "first article missing",
+     "wallMs": 1275.2,
+     "cpuSeconds": 0.04,
+     "rssPeakBytes": 616087552,
+     "rssMeanBytes": 616087552,
+     "cpuShape": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "7z-split-bugonia",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 297,
+     "target": {
+      "fileName": "9Z4eNEoMNngqK2Z8S5OGCphOSs6jlk.7z.001",
+      "sizeBytes": 213909504,
+      "note": "outer archive volume stream (transport ceiling, not the inner file)"
+     },
+     "coldOpen": {
+      "headerMs": 105.89,
+      "ttfbMs": 106.13,
+      "bytes": 1044480,
+      "status": 206
+     },
+     "coldOpenWallMs": 280.4,
+     "probe": {
+      "totalBytes": 213909504,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 118.46
+     },
+     "probeWallMs": 118.5,
+     "sizeBytes": 213909504,
+     "warmOpen": {
+      "headerMs": 107.51,
+      "ttfbMs": 107.56,
+      "bytes": 1047859,
+      "status": 206
+     },
+     "warmOpenWallMs": 108.6,
+     "sequential": {
+      "ttfbMs": 96.32,
+      "bytes": 213909504,
+      "durationMs": 3979.82,
+      "meanMBps": 55.082,
+      "p50MBps": 55.738,
+      "p05MBps": 34.558,
+      "maxMBps": 60.203,
+      "reliable": true
+     },
+     "sequentialWallMs": 3979.9,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 2139095,
+        "ttfbMs": 138.44,
+        "headerMs": 138.36,
+        "bytes": 8055225,
+        "throughputMBps": 1371.034,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 53477376,
+        "ttfbMs": 1616.31,
+        "headerMs": 1616.17,
+        "bytes": 8008344,
+        "throughputMBps": 12.863,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 106954752,
+        "ttfbMs": 195.73,
+        "headerMs": 195.33,
+        "bytes": 8060928,
+        "throughputMBps": 39.125,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 160432128,
+        "ttfbMs": 190.2,
+        "headerMs": 190.14,
+        "bytes": 8058016,
+        "throughputMBps": 10.952,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 203214028,
+        "ttfbMs": 119.24,
+        "headerMs": 119.17,
+        "bytes": 8049460,
+        "throughputMBps": 45.843,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 21390950,
+       "ttfbMs": 177.37,
+       "throughputMBps": 12.679
+      },
+      "medianTtfbMs": 190.2,
+      "worstTtfbMs": 1616.31,
+      "failures": 0
+     },
+     "seeksWallMs": 4814.6,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 64172851,
+      "ttfbMs": 198.91,
+      "bytes": 149736653,
+      "durationMs": 3008.92,
+      "meanMBps": 53.287,
+      "p05MBps": 29.143,
+      "timeToBufferMs": 798,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 3009,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "fafd3afe288695bd40ef8cda6c3cec3bab4e26155cdc87657ca65b3fdaec5fb2"
+      },
+      {
+       "start": 105954752,
+       "bytes": 2000000,
+       "sha256": "6bd760e94626c5f21cab7dd7a5273bd57b7046900b0573d9cd158135454cb7f1"
+      },
+      {
+       "start": 211909504,
+       "bytes": 2000000,
+       "sha256": "d036d955f3ba2f013d79b35760a9d8741a09cf409c1d6783da1b00873c2209eb"
+      }
+     ],
+     "integrityWallMs": 867.6,
+     "status": "ok",
+     "wallMs": 13475.8,
+     "cpuSeconds": 7.03,
+     "rssPeakBytes": 621854720,
+     "rssMeanBytes": 479356770,
+     "cpuShape": {
+      "intervals": 12,
+      "maxCores": 0.82,
+      "p95Cores": 0.82,
+      "medianCores": 0.54,
+      "busyFraction": 0.92
+     },
+     "deliveredBytes": 365738496,
+     "cpuSecondsPerGB": 20.64
+    },
+    {
+     "id": "7z-split-tardes",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 239.8,
+     "target": {
+      "fileName": "3uWAwn0mnSYup2VT0q6uInzGe.7z.001",
+      "sizeBytes": 195035136,
+      "note": "outer archive volume stream (transport ceiling, not the inner file)"
+     },
+     "coldOpen": {
+      "headerMs": 142.48,
+      "ttfbMs": 142.53,
+      "bytes": 1044480,
+      "status": 206
+     },
+     "coldOpenWallMs": 314.9,
+     "probe": {
+      "totalBytes": 195035136,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 250.74
+     },
+     "probeWallMs": 250.8,
+     "sizeBytes": 195035136,
+     "warmOpen": {
+      "headerMs": 96.39,
+      "ttfbMs": 96.44,
+      "bytes": 1044480,
+      "status": 206
+     },
+     "warmOpenWallMs": 110,
+     "sequential": {
+      "ttfbMs": 193.29,
+      "bytes": 195035136,
+      "durationMs": 5349.28,
+      "meanMBps": 37.827,
+      "p50MBps": 36.76,
+      "p05MBps": 18.019,
+      "maxMBps": 51.347,
+      "reliable": true
+     },
+     "sequentialWallMs": 5349.4,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 1950351,
+        "ttfbMs": 242.01,
+        "headerMs": 241.94,
+        "bytes": 8055501,
+        "throughputMBps": 665.618,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 48758784,
+        "ttfbMs": 144.81,
+        "headerMs": 144.74,
+        "bytes": 8007680,
+        "throughputMBps": 41.865,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 97517568,
+        "ttfbMs": 194.96,
+        "headerMs": 194.89,
+        "bytes": 8065024,
+        "throughputMBps": 5.706,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 146276352,
+        "ttfbMs": 464.25,
+        "headerMs": 464.17,
+        "bytes": 8002284,
+        "throughputMBps": 1409.597,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 185283379,
+        "ttfbMs": 214.17,
+        "headerMs": 214.12,
+        "bytes": 8002765,
+        "throughputMBps": 73.734,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 19503513,
+       "ttfbMs": 228.42,
+       "throughputMBps": 1675.453
+      },
+      "medianTtfbMs": 214.17,
+      "worstTtfbMs": 464.25,
+      "failures": 0
+     },
+     "seeksWallMs": 3224.6,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 58510540,
+      "ttfbMs": 224.51,
+      "bytes": 136524596,
+      "durationMs": 2303.38,
+      "meanMBps": 65.672,
+      "p05MBps": 57.241,
+      "timeToBufferMs": 785,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 2303.7,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "e5d623e6e1c9f8368be55594a505033155f880ea24f74e6890cd554efc639196"
+      },
+      {
+       "start": 96517568,
+       "bytes": 2000000,
+       "sha256": "04c6ee07f7f0a9f70617df06b3f13ed7ffd9638266873032460b3788805213b1"
+      },
+      {
+       "start": 193035136,
+       "bytes": 2000000,
+       "sha256": "e3be92a54a0a452e2c07666c47350b78c09bbadb2c62a39d00ca63c9fa4ed6f1"
+      }
+     ],
+     "integrityWallMs": 620.6,
+     "status": "ok",
+     "wallMs": 12414,
+     "cpuSeconds": 7.22,
+     "rssPeakBytes": 486670336,
+     "rssMeanBytes": 475530476,
+     "cpuShape": {
+      "intervals": 12,
+      "maxCores": 0.71,
+      "p95Cores": 0.71,
+      "medianCores": 0.64,
+      "busyFraction": 0.83
+     },
+     "deliveredBytes": 333648692,
+     "cpuSecondsPerGB": 23.24
+    },
+    {
+     "id": "damaged-partial",
+     "tier": "failure",
+     "axes": [
+      "direct-video",
+      "missing-articles"
+     ],
+     "expect": "serve",
+     "importMs": 729.4,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6608994141,
+      "note": "direct video (1 posted part)"
+     },
+     "coldOpen": {
+      "headerMs": 1013.47,
+      "ttfbMs": 1013.55,
+      "bytes": 1047856,
+      "status": 206
+     },
+     "coldOpenWallMs": 1038.7,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 1000.48
+     },
+     "probeWallMs": 1000.5,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 993.47,
+      "ttfbMs": 993.54,
+      "bytes": 1047856,
+      "status": 206
+     },
+     "warmOpenWallMs": 1021.9,
+     "sequential": {
+      "ttfbMs": 822.32,
+      "bytes": 256049152,
+      "durationMs": 3790.97,
+      "meanMBps": 86.251,
+      "p50MBps": 69.326,
+      "p05MBps": 20.861,
+      "maxMBps": 103.785,
+      "reliable": true
+     },
+     "sequentialWallMs": 3791,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 1126.7,
+        "headerMs": 1126.19,
+        "bytes": 8013487,
+        "throughputMBps": 2139.616,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 908.52,
+        "headerMs": 908.47,
+        "bytes": 8051257,
+        "throughputMBps": 75.354,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 1119.38,
+        "headerMs": 1119.31,
+        "bytes": 8001035,
+        "throughputMBps": 29.319,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 897.86,
+        "headerMs": 897.8,
+        "bytes": 8006451,
+        "throughputMBps": 54.622,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 538.93,
+        "headerMs": 538.84,
+        "bytes": 8023935,
+        "throughputMBps": 16.817,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 858.65,
+       "throughputMBps": 37.747
+      },
+      "medianTtfbMs": 908.52,
+      "worstTtfbMs": 1126.7,
+      "failures": 0
+     },
+     "seeksWallMs": 6669.5,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 968.47,
+      "bytes": 1850961150,
+      "durationMs": 30064.76,
+      "meanMBps": 63.615,
+      "p05MBps": 54.429,
+      "timeToBufferMs": 1693,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30064.8,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 2706.4,
+     "status": "ok",
+     "wallMs": 47022.5,
+     "cpuSeconds": 73.09,
+     "rssPeakBytes": 1450377216,
+     "rssMeanBytes": 1204946716,
+     "cpuShape": {
+      "intervals": 44,
+      "maxCores": 4.76,
+      "p95Cores": 2.39,
+      "medianCores": 1.67,
+      "busyFraction": 0.89
+     },
+     "deliveredBytes": 2109106014,
+     "cpuSecondsPerGB": 37.21
+    }
+   ],
+   "prepareMs": 5.3,
+   "buildReused": false,
+   "buildStamp": null,
+   "startupMs": 3.4,
+   "version": {
+    "version": "harness-builtin"
+   },
+   "port": 54623,
+   "pids": [
+    7200
+   ],
+   "idle": {
+    "samples": 10,
+    "cpuSeconds": 69.81,
+    "rssPeakBytes": 43204608,
+    "rssMedianBytes": 43073536,
+    "rssMeanBytes": 42183885,
+    "maxProcesses": 2
+   },
+   "resourcesMeasured": true,
+   "resourceSource": "host",
+   "resources": {
+    "samples": 253,
+    "cpuSeconds": 409.02,
+    "rssPeakBytes": 1594851328,
+    "rssMedianBytes": 1088405504,
+    "rssMeanBytes": 1030618488,
+    "maxProcesses": 2
+   },
+   "idleAfter": {
+    "samples": 45,
+    "cpuSeconds": 410.51,
+    "rssPeakBytes": 1399750656,
+    "rssMedianBytes": 785334272,
+    "rssMeanBytes": 851107658,
+    "maxProcesses": 2
+   },
+   "status": "ok",
+   "finishedAt": "2026-09-05T14:01:54.670Z"
+  },
+  {
+   "app": "altmount",
+   "displayName": "AltMount",
+   "language": "Go",
+   "repo": "https://github.com/javi11/altmount",
+   "serving": "webdav",
+   "runtime": "source",
+   "startedAt": "2026-09-05T14:02:09.679Z",
+   "items": [
+    {
+     "id": "rar4-small",
+     "tier": "smoke",
+     "axes": [
+      "rar4",
+      "stored",
+      "named-volumes",
+      "partNN"
+     ],
+     "expect": "serve",
+     "importMs": 1087.5,
+     "target": {
+      "fileName": "father.brown.2013.s02e05.hdtv.x264-tla.mp4",
+      "sizeBytes": 321905886
+     },
+     "coldOpen": {
+      "headerMs": 92.21,
+      "ttfbMs": 92.34,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "coldOpenWallMs": 137.4,
+     "probe": {
+      "totalBytes": 321905886,
+      "rangeSupported": true,
+      "contentType": "video/mp4",
+      "firstByteMs": 1.11
+     },
+     "probeWallMs": 1.2,
+     "sizeBytes": 321905886,
+     "warmOpen": {
+      "headerMs": 1.92,
+      "ttfbMs": 2,
+      "bytes": 1049088,
+      "status": 206
+     },
+     "warmOpenWallMs": 4.4,
+     "sequential": {
+      "ttfbMs": 1.44,
+      "bytes": 256049664,
+      "durationMs": 5208.91,
+      "meanMBps": 49.17,
+      "p50MBps": 44.742,
+      "p05MBps": 27.771,
+      "maxMBps": 68.425,
+      "reliable": true
+     },
+     "sequentialWallMs": 5209.2,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 3219058,
+        "ttfbMs": 16.55,
+        "headerMs": 16.17,
+        "bytes": 8060689,
+        "throughputMBps": 951.067,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 80476471,
+        "ttfbMs": 2.72,
+        "headerMs": 2.67,
+        "bytes": 8061440,
+        "throughputMBps": 1140.629,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 160952943,
+        "ttfbMs": 1.77,
+        "headerMs": 1.73,
+        "bytes": 8061440,
+        "throughputMBps": 1712.376,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 241429414,
+        "ttfbMs": 1.24,
+        "headerMs": 1.21,
+        "bytes": 8028672,
+        "throughputMBps": 2889.528,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 305810591,
+        "ttfbMs": 53.05,
+        "headerMs": 53.01,
+        "bytes": 8061440,
+        "throughputMBps": 71.629,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 32190588,
+       "ttfbMs": 3.76,
+       "throughputMBps": 74.08
+      },
+      "medianTtfbMs": 2.72,
+      "worstTtfbMs": 53.05,
+      "failures": 0
+     },
+     "seeksWallMs": 323.6,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 96571765,
+      "ttfbMs": 3.39,
+      "bytes": 225334121,
+      "durationMs": 1201.26,
+      "meanMBps": 188.113,
+      "p05MBps": 27.57,
+      "timeToBufferMs": 253,
+      "secondsBelowBitrate": 0.37,
+      "sustainable": true
+     },
+     "playbackWallMs": 1201.6,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "518f4aeb3bdec36905cd82df6113512a9a4919a4fb9c031b789ba4df0034648c"
+      },
+      {
+       "start": 159952943,
+       "bytes": 2000000,
+       "sha256": "cb37e4294880844c4a5d3db895c0ac91a2331fb5bae255f5920184bb8f88d7b6"
+      },
+      {
+       "start": 319905886,
+       "bytes": 2000000,
+       "sha256": "80c39132e3e0dcd3646f6e170c128794169c97e70eca1ebb1af581ed626ee43c"
+      }
+     ],
+     "integrityWallMs": 74.2,
+     "status": "ok",
+     "wallMs": 8039.3,
+     "cpuSeconds": 1.88,
+     "rssPeakBytes": 310312960,
+     "rssMeanBytes": 204083200,
+     "cpuShape": {
+      "intervals": 7,
+      "maxCores": 0.4,
+      "p95Cores": 0.4,
+      "medianCores": 0.27,
+      "busyFraction": 0.71
+     },
+     "deliveredBytes": 483449193,
+     "cpuSecondsPerGB": 4.18
+    },
+    {
+     "id": "plain-medium",
+     "tier": "smoke",
+     "axes": [
+      "direct-video",
+      "no-archive",
+      "per-file-unique-stems"
+     ],
+     "expect": "serve",
+     "importMs": 327.6,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 88.02,
+      "ttfbMs": 88.19,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "coldOpenWallMs": 187.5,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 473.61
+     },
+     "probeWallMs": 473.8,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 45.76,
+      "ttfbMs": 45.87,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "warmOpenWallMs": 276.8,
+     "sequential": {
+      "ttfbMs": 66.44,
+      "bytes": 256016896,
+      "durationMs": 5527.44,
+      "meanMBps": 46.881,
+      "p50MBps": 38.548,
+      "p05MBps": 21.518,
+      "maxMBps": 75.148,
+      "reliable": true
+     },
+     "sequentialWallMs": 5527.7,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 773.14,
+        "headerMs": 772.79,
+        "bytes": 8061440,
+        "throughputMBps": 61.855,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 133.93,
+        "headerMs": 133.71,
+        "bytes": 8028672,
+        "throughputMBps": 20.789,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 731.55,
+        "headerMs": 731.41,
+        "bytes": 8028672,
+        "throughputMBps": 53.854,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 611.75,
+        "headerMs": 611.62,
+        "bytes": 8028672,
+        "throughputMBps": 9.632,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 199.4,
+        "headerMs": 199,
+        "bytes": 8061440,
+        "throughputMBps": 35.851,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 655.64,
+       "throughputMBps": 12.659
+      },
+      "medianTtfbMs": 611.75,
+      "worstTtfbMs": 773.14,
+      "failures": 0
+     },
+     "seeksWallMs": 5464.5,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 946.26,
+      "bytes": 2531131904,
+      "durationMs": 30032.77,
+      "meanMBps": 87.021,
+      "p05MBps": 51.632,
+      "timeToBufferMs": 2513,
+      "secondsBelowBitrate": 0.55,
+      "sustainable": true
+     },
+     "playbackWallMs": 30033.2,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 1542.7,
+     "status": "ok",
+     "wallMs": 43833.9,
+     "cpuSeconds": 12.15,
+     "rssPeakBytes": 562446336,
+     "rssMeanBytes": 530980864,
+     "cpuShape": {
+      "intervals": 43,
+      "maxCores": 0.52,
+      "p95Cores": 0.48,
+      "medianCores": 0.27,
+      "busyFraction": 0.63
+     },
+     "deliveredBytes": 2789181440,
+     "cpuSecondsPerGB": 4.68
+    },
+    {
+     "id": "obfuscated-direct",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "obfuscated-names",
+      "extensionless"
+     ],
+     "expect": "serve",
+     "importMs": 868,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 60.12,
+      "ttfbMs": 60.55,
+      "bytes": 1049088,
+      "status": 206
+     },
+     "coldOpenWallMs": 532.9,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 91.82
+     },
+     "probeWallMs": 92.1,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 46.18,
+      "ttfbMs": 46.34,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "warmOpenWallMs": 61.4,
+     "sequential": {
+      "ttfbMs": 288.69,
+      "bytes": 256049664,
+      "durationMs": 2757.72,
+      "meanMBps": 103.704,
+      "p50MBps": 106.638,
+      "p05MBps": 25.352,
+      "maxMBps": 152.185,
+      "reliable": true
+     },
+     "sequentialWallMs": 2758,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 1.36,
+        "headerMs": 1.27,
+        "bytes": 8028672,
+        "throughputMBps": 27.096,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 168.94,
+        "headerMs": 168.7,
+        "bytes": 8061440,
+        "throughputMBps": 57.506,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 579.39,
+        "headerMs": 578.97,
+        "bytes": 8012236,
+        "throughputMBps": 23.374,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 170.36,
+        "headerMs": 170.13,
+        "bytes": 8028672,
+        "throughputMBps": 7.645,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 157.58,
+        "headerMs": 157.43,
+        "bytes": 8012236,
+        "throughputMBps": 31.242,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 227.7,
+       "throughputMBps": 31.213
+      },
+      "medianTtfbMs": 168.94,
+      "worstTtfbMs": 579.39,
+      "failures": 0
+     },
+     "seeksWallMs": 3649.2,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 507.36,
+      "bytes": 3280110080,
+      "durationMs": 30020.92,
+      "meanMBps": 111.139,
+      "p05MBps": 57.758,
+      "timeToBufferMs": 2320,
+      "secondsBelowBitrate": 0.27,
+      "sustainable": true
+     },
+     "playbackWallMs": 30021.5,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 367,
+     "status": "ok",
+     "wallMs": 38350.2,
+     "cpuSeconds": 13.42,
+     "rssPeakBytes": 561840128,
+     "rssMeanBytes": 539922957,
+     "cpuShape": {
+      "intervals": 38,
+      "maxCores": 0.51,
+      "p95Cores": 0.51,
+      "medianCores": 0.35,
+      "busyFraction": 0.87
+     },
+     "deliveredBytes": 3538225152,
+     "cpuSecondsPerGB": 4.07
+    },
+    {
+     "id": "plain-large",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "no-archive"
+     ],
+     "expect": "serve",
+     "importMs": 1418.1,
+     "target": {
+      "fileName": "plain-large.mkv",
+      "sizeBytes": 15076905867
+     },
+     "coldOpen": {
+      "headerMs": 61.33,
+      "ttfbMs": 61.58,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "coldOpenWallMs": 451,
+     "probe": {
+      "totalBytes": 15076905867,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 75.7
+     },
+     "probeWallMs": 76,
+     "sizeBytes": 15076905867,
+     "warmOpen": {
+      "headerMs": 41.35,
+      "ttfbMs": 41.62,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "warmOpenWallMs": 84.9,
+     "sequential": {
+      "ttfbMs": 369.26,
+      "bytes": 256049560,
+      "durationMs": 6747.57,
+      "meanMBps": 40.144,
+      "p50MBps": 46.713,
+      "p05MBps": 13.528,
+      "maxMBps": 58.005,
+      "reliable": true
+     },
+     "sequentialWallMs": 6747.9,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 150769058,
+        "ttfbMs": 3.32,
+        "headerMs": 3.24,
+        "bytes": 8061440,
+        "throughputMBps": 1386.517,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 3769226466,
+        "ttfbMs": 96.31,
+        "headerMs": 96.03,
+        "bytes": 8060816,
+        "throughputMBps": 20.642,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 7538452933,
+        "ttfbMs": 634.78,
+        "headerMs": 634.66,
+        "bytes": 8028672,
+        "throughputMBps": 8.415,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 11307679400,
+        "ttfbMs": 118.9,
+        "headerMs": 118.73,
+        "bytes": 8028672,
+        "throughputMBps": 8.29,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 14323060573,
+        "ttfbMs": 268.49,
+        "headerMs": 267.82,
+        "bytes": 8028672,
+        "throughputMBps": 16.165,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1507690586,
+       "ttfbMs": 392.66,
+       "throughputMBps": 11.027
+      },
+      "medianTtfbMs": 118.9,
+      "worstTtfbMs": 634.78,
+      "failures": 0
+     },
+     "seeksWallMs": 5058.9,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 4523071760,
+      "ttfbMs": 161.41,
+      "bytes": 2789507584,
+      "durationMs": 30053.69,
+      "meanMBps": 93.319,
+      "p05MBps": 42.108,
+      "timeToBufferMs": 1071,
+      "secondsBelowBitrate": 3.44,
+      "sustainable": true
+     },
+     "playbackWallMs": 30054,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "f9f305fa3fbc944f62df43ac8c3452bb25fd5d81f018ff874658b5004c8319d1"
+      },
+      {
+       "start": 7537452933,
+       "bytes": 2000000,
+       "sha256": "5551953b14d1450b51a7914a813f0ae27582f40aed6090f9a9a08742f3084e2d"
+      },
+      {
+       "start": 15074905867,
+       "bytes": 2000000,
+       "sha256": "98fdc11b40dbe71e4bf96844181a32f8573cd2b7058f16cf66702a1ff20aea6b"
+      }
+     ],
+     "integrityWallMs": 595.6,
+     "status": "ok",
+     "wallMs": 44486.6,
+     "cpuSeconds": 12.8,
+     "rssPeakBytes": 580534272,
+     "rssMeanBytes": 544586287,
+     "cpuShape": {
+      "intervals": 43,
+      "maxCores": 0.48,
+      "p95Cores": 0.46,
+      "medianCores": 0.35,
+      "busyFraction": 0.67
+     },
+     "deliveredBytes": 3047589784,
+     "cpuSecondsPerGB": 4.51
+    },
+    {
+     "id": "plain-season-pack",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "season-pack",
+      "file-selection"
+     ],
+     "expect": "serve",
+     "importMs": 618.3,
+     "target": {
+      "fileName": "Bosch.S01E01.2015.1080p.Amazon.WEB-DL.AVC.DDP.5.1-DBTV.mkv",
+      "sizeBytes": 2210528776
+     },
+     "coldOpen": {
+      "headerMs": 80.87,
+      "ttfbMs": 81.05,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "coldOpenWallMs": 96.7,
+     "probe": {
+      "totalBytes": 2210528776,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 3.33
+     },
+     "probeWallMs": 3.5,
+     "sizeBytes": 2210528776,
+     "warmOpen": {
+      "headerMs": 1.35,
+      "ttfbMs": 1.48,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "warmOpenWallMs": 168.7,
+     "sequential": {
+      "ttfbMs": 2.11,
+      "bytes": 256049664,
+      "durationMs": 10417.2,
+      "meanMBps": 24.584,
+      "p50MBps": 23.146,
+      "p05MBps": 3.628,
+      "maxMBps": 83.137,
+      "reliable": true
+     },
+     "sequentialWallMs": 10417.4,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 22105287,
+        "ttfbMs": 3.4,
+        "headerMs": 3.32,
+        "bytes": 8028568,
+        "throughputMBps": 1946.241,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 552632194,
+        "ttfbMs": 245.58,
+        "headerMs": 245.37,
+        "bytes": 8028672,
+        "throughputMBps": 11.482,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 1105264388,
+        "ttfbMs": 157.59,
+        "headerMs": 157.35,
+        "bytes": 8061440,
+        "throughputMBps": 76.436,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 1657896582,
+        "ttfbMs": 468.59,
+        "headerMs": 468.35,
+        "bytes": 8061440,
+        "throughputMBps": 237.661,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 2100002337,
+        "ttfbMs": 318.83,
+        "headerMs": 318.19,
+        "bytes": 8028672,
+        "throughputMBps": 36.786,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 221052877,
+       "ttfbMs": 3.74,
+       "throughputMBps": 944.67
+      },
+      "medianTtfbMs": 245.58,
+      "worstTtfbMs": 468.59,
+      "failures": 0
+     },
+     "seeksWallMs": 2267.8,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 663158632,
+      "ttfbMs": 96.06,
+      "bytes": 1114505728,
+      "durationMs": 30749.28,
+      "meanMBps": 36.359,
+      "p05MBps": 2.646,
+      "timeToBufferMs": 613,
+      "secondsBelowBitrate": 10.17,
+      "sustainable": true
+     },
+     "playbackWallMs": 30749.7,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "c3d52b715e7f6ee76f5a1c103a31853d440f1e96341ff2170ca66646a105f452"
+      },
+      {
+       "start": 1104264388,
+       "bytes": 2000000,
+       "sha256": "9e6e73cef2032c61a18d91b1f4d869f69f33e473b43d21d1fb9f1c7d69c9f09e"
+      },
+      {
+       "start": 2208528776,
+       "bytes": 2000000,
+       "sha256": "01b4b848c553ad2ae59b7bab78a02762acfede9b41415de494e5907413a9881f"
+      }
+     ],
+     "integrityWallMs": 735.4,
+     "status": "ok",
+     "wallMs": 45057.6,
+     "cpuSeconds": 6.76,
+     "rssPeakBytes": 591872000,
+     "rssMeanBytes": 542949740,
+     "cpuShape": {
+      "intervals": 44,
+      "maxCores": 0.42,
+      "p95Cores": 0.38,
+      "medianCores": 0.13,
+      "busyFraction": 0.39
+     },
+     "deliveredBytes": 1372588032,
+     "cpuSecondsPerGB": 5.29
+    },
+    {
+     "id": "rar4-rNN",
+     "tier": "core",
+     "axes": [
+      "rar4",
+      "stored",
+      "rar+rNN",
+      "letter-rollover"
+     ],
+     "expect": "serve",
+     "importMs": 5208.1,
+     "target": {
+      "fileName": "It's.Always.Sunny.in.Philadelphia.S07E12.The.High.School.Reunion.BluRay.1080p.Remux.AVC.DTSHD-MA.5.1-PtZ.mkv",
+      "sizeBytes": 5882124203
+     },
+     "coldOpen": {
+      "headerMs": 52.63,
+      "ttfbMs": 52.87,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "coldOpenWallMs": 209.2,
+     "probe": {
+      "totalBytes": 5882124203,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 4.91
+     },
+     "probeWallMs": 5.2,
+     "sizeBytes": 5882124203,
+     "warmOpen": {
+      "headerMs": 5.97,
+      "ttfbMs": 6.1,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "warmOpenWallMs": 60.3,
+     "sequential": {
+      "ttfbMs": 4.72,
+      "bytes": 256049664,
+      "durationMs": 10420.53,
+      "meanMBps": 24.583,
+      "p50MBps": 25.456,
+      "p05MBps": 3.148,
+      "maxMBps": 94.477,
+      "reliable": true
+     },
+     "sequentialWallMs": 10420.8,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 58821242,
+        "ttfbMs": 4.13,
+        "headerMs": 4.05,
+        "bytes": 8061440,
+        "throughputMBps": 1759.419,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1470531050,
+        "ttfbMs": 157.14,
+        "headerMs": 157.07,
+        "bytes": 8028672,
+        "throughputMBps": 169.201,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 2941062101,
+        "ttfbMs": 174.83,
+        "headerMs": 174.64,
+        "bytes": 8028672,
+        "throughputMBps": 17.966,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4411593152,
+        "ttfbMs": 70.97,
+        "headerMs": 70.58,
+        "bytes": 8012236,
+        "throughputMBps": 87.423,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 5588017992,
+        "ttfbMs": 49.03,
+        "headerMs": 48.56,
+        "bytes": 8061440,
+        "throughputMBps": 29.704,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 588212420,
+       "ttfbMs": 145.4,
+       "throughputMBps": 4.1
+      },
+      "medianTtfbMs": 70.97,
+      "worstTtfbMs": 174.83,
+      "failures": 0
+     },
+     "seeksWallMs": 3430.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1764637260,
+      "ttfbMs": 260.83,
+      "bytes": 1783005696,
+      "durationMs": 30025.36,
+      "meanMBps": 59.904,
+      "p05MBps": 6.529,
+      "timeToBufferMs": 779,
+      "secondsBelowBitrate": 0.47,
+      "sustainable": true
+     },
+     "playbackWallMs": 30025.6,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "652f1b7a97f8dee12621e5d2c483f33bff7c19d5c8f59fe8a9438bc6581e8c88"
+      },
+      {
+       "start": 2940062101,
+       "bytes": 2000000,
+       "sha256": "58b9cf1d866e3b51cdba10ae584acd95b302c53135d8e929e467214fb16154b9"
+      },
+      {
+       "start": 5880124203,
+       "bytes": 2000000,
+       "sha256": "c3c2d6e2dfb3d4ea8c46f74b8579349829e42c7fdbddc101f5bfe992550c4e07"
+      }
+     ],
+     "integrityWallMs": 769.3,
+     "status": "ok",
+     "wallMs": 50129.1,
+     "cpuSeconds": 8.63,
+     "rssPeakBytes": 529154048,
+     "rssMeanBytes": 469069332,
+     "cpuShape": {
+      "intervals": 49,
+      "maxCores": 0.62,
+      "p95Cores": 0.49,
+      "medianCores": 0.14,
+      "busyFraction": 0.31
+     },
+     "deliveredBytes": 2041088000,
+     "cpuSecondsPerGB": 4.54
+    },
+    {
+     "id": "rar-hdrenc-small",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "status": "failed",
+     "error": "import failed: failed to process nested RAR archives: failed to process nested RAR \"b-simpson\": compressed media files are not supported: b-simpson.iso (uses rar2.9 compression)",
+     "wallMs": 6585.5,
+     "cpuSeconds": 1.12,
+     "rssPeakBytes": 536166400,
+     "rssMeanBytes": 528372297,
+     "cpuShape": {
+      "intervals": 6,
+      "maxCores": 0.38,
+      "p95Cores": 0.38,
+      "medianCores": 0.2,
+      "busyFraction": 0.5
+     },
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-hdrenc-large",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 2313.5,
+     "target": {
+      "fileName": "Ed\u00e9n (2024) [BDRip x264 1080p AC3 5.1 Castellano] (MATS\u00ae).mkv",
+      "sizeBytes": 17174121367
+     },
+     "coldOpen": {
+      "headerMs": 55.17,
+      "ttfbMs": 55.23,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "coldOpenWallMs": 176,
+     "probe": {
+      "totalBytes": 17174121367,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 18.37
+     },
+     "probeWallMs": 18.8,
+     "sizeBytes": 17174121367,
+     "warmOpen": {
+      "headerMs": 13.15,
+      "ttfbMs": 13.22,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "warmOpenWallMs": 15.2,
+     "sequential": {
+      "ttfbMs": 12.6,
+      "bytes": 256016896,
+      "durationMs": 3232.54,
+      "meanMBps": 79.51,
+      "p50MBps": 90.151,
+      "p05MBps": 31.967,
+      "maxMBps": 116.169,
+      "reliable": true
+     },
+     "sequentialWallMs": 3232.8,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 171741213,
+        "ttfbMs": 9.66,
+        "headerMs": 9.55,
+        "bytes": 8028672,
+        "throughputMBps": 833.996,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 4293530341,
+        "ttfbMs": 121.63,
+        "headerMs": 121.5,
+        "bytes": 8028672,
+        "throughputMBps": 285.766,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 8587060683,
+        "ttfbMs": 132.31,
+        "headerMs": 132.18,
+        "bytes": 8028672,
+        "throughputMBps": 92.949,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 12880591025,
+        "ttfbMs": 192.94,
+        "headerMs": 192.89,
+        "bytes": 8028672,
+        "throughputMBps": 1158.476,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 16315415298,
+        "ttfbMs": 291.3,
+        "headerMs": 291.25,
+        "bytes": 8028672,
+        "throughputMBps": 75.46,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1717412136,
+       "ttfbMs": 87.7,
+       "throughputMBps": 111.835
+      },
+      "medianTtfbMs": 132.31,
+      "worstTtfbMs": 291.3,
+      "failures": 0
+     },
+     "seeksWallMs": 1145.1,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 5152236410,
+      "ttfbMs": 100.3,
+      "bytes": 2080571904,
+      "durationMs": 31026.91,
+      "meanMBps": 67.274,
+      "p05MBps": 7.675,
+      "timeToBufferMs": 506,
+      "secondsBelowBitrate": 0.26,
+      "sustainable": true
+     },
+     "playbackWallMs": 31027.4,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "ca5f5f5d72bc03c73ec554b87f09293056cc64f898d9ba0c6009c0f31cf92035"
+      },
+      {
+       "start": 8586060683,
+       "bytes": 2000000,
+       "sha256": "ed802261f0ff5ea16496bbf3e08828cab7d130093e0b0bd504b5e93ccf9fac78"
+      },
+      {
+       "start": 17172121367,
+       "bytes": 2000000,
+       "sha256": "2cf8c04c6895c85ab6c884ddaea22a03d619822747aa358a1e9d975709bcecc3"
+      }
+     ],
+     "integrityWallMs": 877,
+     "status": "ok",
+     "wallMs": 38805.9,
+     "cpuSeconds": 12.48,
+     "rssPeakBytes": 556171264,
+     "rssMeanBytes": 487272664,
+     "cpuShape": {
+      "intervals": 37,
+      "maxCores": 0.75,
+      "p95Cores": 0.69,
+      "medianCores": 0.33,
+      "busyFraction": 0.49
+     },
+     "deliveredBytes": 2338621440,
+     "cpuSecondsPerGB": 5.73
+    },
+    {
+     "id": "rar-partNN-large",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "import failed: fast-fail segment check failed: no regular files were successfully processed (all files failed validation)",
+     "wallMs": 11448.9,
+     "cpuSeconds": 0.43,
+     "rssPeakBytes": 465076224,
+     "rssMeanBytes": 443173547,
+     "cpuShape": {
+      "intervals": 11,
+      "maxCores": 0.13,
+      "p95Cores": 0.13,
+      "medianCores": 0.02,
+      "busyFraction": 0.09
+     },
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-maestras",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "import failed: fast-fail segment check failed: no regular files were successfully processed (all files failed validation)",
+     "wallMs": 11548,
+     "cpuSeconds": 0.28,
+     "rssPeakBytes": 419790848,
+     "rssMeanBytes": 405416122,
+     "cpuShape": {
+      "intervals": 10,
+      "maxCores": 0.03,
+      "p95Cores": 0.03,
+      "medianCores": 0.02,
+      "busyFraction": 0.9
+     },
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-satans",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "import failed: fast-fail segment check failed: no regular files were successfully processed (all files failed validation)",
+     "wallMs": 11090.3,
+     "cpuSeconds": 0.33,
+     "rssPeakBytes": 357433344,
+     "rssMeanBytes": 330027008,
+     "cpuShape": {
+      "intervals": 11,
+      "maxCores": 0.04,
+      "p95Cores": 0.04,
+      "medianCores": 0.02,
+      "busyFraction": 1
+     },
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "7z-split-bugonia",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 1450.1,
+     "target": {
+      "fileName": "Bugonia.2025.SPANiSH.MULTi.1080p.BluRay.x264-USENETHD.mkv",
+      "sizeBytes": 21169663096
+     },
+     "coldOpen": {
+      "headerMs": 72.97,
+      "ttfbMs": 73.1,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "coldOpenWallMs": 318.1,
+     "probe": {
+      "totalBytes": 21169663096,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 12.9
+     },
+     "probeWallMs": 13,
+     "sizeBytes": 21169663096,
+     "warmOpen": {
+      "headerMs": 9.43,
+      "ttfbMs": 9.45,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "warmOpenWallMs": 10.7,
+     "sequential": {
+      "ttfbMs": 10.15,
+      "bytes": 256016896,
+      "durationMs": 5917.12,
+      "meanMBps": 43.341,
+      "p50MBps": 29.888,
+      "p05MBps": 6.702,
+      "maxMBps": 82.796,
+      "reliable": true
+     },
+     "sequentialWallMs": 5917.4,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 211696630,
+        "ttfbMs": 15.31,
+        "headerMs": 15.23,
+        "bytes": 8028672,
+        "throughputMBps": 814.656,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 5292415774,
+        "ttfbMs": 83.4,
+        "headerMs": 83.3,
+        "bytes": 8028672,
+        "throughputMBps": 65.297,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 10584831548,
+        "ttfbMs": 99.1,
+        "headerMs": 98.99,
+        "bytes": 8028672,
+        "throughputMBps": 108.652,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 15877247322,
+        "ttfbMs": 162.66,
+        "headerMs": 162.44,
+        "bytes": 8028672,
+        "throughputMBps": 211.43,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 20111179941,
+        "ttfbMs": 129.59,
+        "headerMs": 129.39,
+        "bytes": 8028672,
+        "throughputMBps": 92.139,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 2116966309,
+       "ttfbMs": 170.79,
+       "throughputMBps": 313.044
+      },
+      "medianTtfbMs": 99.1,
+      "worstTtfbMs": 162.66,
+      "failures": 0
+     },
+     "seeksWallMs": 1019,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 6350898928,
+      "ttfbMs": 164.56,
+      "bytes": 2524021248,
+      "durationMs": 30006.8,
+      "meanMBps": 84.579,
+      "p05MBps": 6.977,
+      "timeToBufferMs": 508,
+      "secondsBelowBitrate": 4.01,
+      "sustainable": true
+     },
+     "playbackWallMs": 30007,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "dc90fbf4517651e76aca1b4c57f43ec37a25a92bdc1fd9294e806c2228ca39aa"
+      },
+      {
+       "start": 10583831548,
+       "bytes": 2000000,
+       "sha256": "911ad58d080637c505d2d3a768a6bb31ea30f3c4ee925cdb7ecc5003d10e7c2d"
+      },
+      {
+       "start": 21167663096,
+       "bytes": 2000000,
+       "sha256": "3a59d97512411e4b8a542cbf88a7af356b2916175b792ec5e6c2bfe2aeff3b5b"
+      }
+     ],
+     "integrityWallMs": 333.7,
+     "status": "ok",
+     "wallMs": 39069.1,
+     "cpuSeconds": 14.35,
+     "rssPeakBytes": 465780736,
+     "rssMeanBytes": 424897615,
+     "cpuShape": {
+      "intervals": 38,
+      "maxCores": 0.71,
+      "p95Cores": 0.69,
+      "medianCores": 0.4,
+      "busyFraction": 0.55
+     },
+     "deliveredBytes": 2782070784,
+     "cpuSecondsPerGB": 5.54
+    },
+    {
+     "id": "7z-split-tardes",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 692.3,
+     "target": {
+      "fileName": "Tardes.De.Soledad.2024.SPANiSH.1080p.BluRay.x264-USENETHD.mkv",
+      "sizeBytes": 19222688752
+     },
+     "coldOpen": {
+      "headerMs": 49.6,
+      "ttfbMs": 49.65,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "coldOpenWallMs": 90.1,
+     "probe": {
+      "totalBytes": 19222688752,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 14.84
+     },
+     "probeWallMs": 14.9,
+     "sizeBytes": 19222688752,
+     "warmOpen": {
+      "headerMs": 10.46,
+      "ttfbMs": 10.54,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "warmOpenWallMs": 89.9,
+     "sequential": {
+      "ttfbMs": 15.8,
+      "bytes": 256016896,
+      "durationMs": 5845.4,
+      "meanMBps": 43.917,
+      "p50MBps": 53.464,
+      "p05MBps": 12.656,
+      "maxMBps": 88.977,
+      "reliable": true
+     },
+     "sequentialWallMs": 5845.8,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 192226887,
+        "ttfbMs": 14.51,
+        "headerMs": 14.38,
+        "bytes": 8028672,
+        "throughputMBps": 647.191,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 4805672188,
+        "ttfbMs": 128.15,
+        "headerMs": 127.97,
+        "bytes": 8028672,
+        "throughputMBps": 110.948,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 9611344376,
+        "ttfbMs": 117.12,
+        "headerMs": 117.02,
+        "bytes": 8028672,
+        "throughputMBps": 153.667,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 14417016564,
+        "ttfbMs": 135.84,
+        "headerMs": 135.69,
+        "bytes": 8028672,
+        "throughputMBps": 120.258,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 18261554314,
+        "ttfbMs": 120.8,
+        "headerMs": 120.75,
+        "bytes": 8028672,
+        "throughputMBps": 115.477,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1922268875,
+       "ttfbMs": 191.92,
+       "throughputMBps": 300.767
+      },
+      "medianTtfbMs": 120.8,
+      "worstTtfbMs": 135.84,
+      "failures": 0
+     },
+     "seeksWallMs": 1008.9,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 5766806625,
+      "ttfbMs": 203.17,
+      "bytes": 3053158912,
+      "durationMs": 30000.95,
+      "meanMBps": 102.463,
+      "p05MBps": 14.12,
+      "timeToBufferMs": 560,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30001.1,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "676926b1cace4d63b9055ee16516ed2e86ababef4e6b3807d5e2529fe33fa4da"
+      },
+      {
+       "start": 9610344376,
+       "bytes": 2000000,
+       "sha256": "3037000cc41414ff7c6fa8f1ae5b95ca1a797239cde68dca8394bc5ce9f152e5"
+      },
+      {
+       "start": 19220688752,
+       "bytes": 2000000,
+       "sha256": "441fa0ef78afac308dd1fee5b4c5bac65486f670997aed25a54daafcb8e3f024"
+      }
+     ],
+     "integrityWallMs": 329.2,
+     "status": "ok",
+     "wallMs": 38072.3,
+     "cpuSeconds": 17.79,
+     "rssPeakBytes": 471810048,
+     "rssMeanBytes": 442968603,
+     "cpuShape": {
+      "intervals": 37,
+      "maxCores": 0.77,
+      "p95Cores": 0.77,
+      "medianCores": 0.58,
+      "busyFraction": 0.65
+     },
+     "deliveredBytes": 3311208448,
+     "cpuSecondsPerGB": 5.77
+    },
+    {
+     "id": "damaged-partial",
+     "tier": "failure",
+     "axes": [
+      "direct-video",
+      "missing-articles"
+     ],
+     "expect": "serve",
+     "importMs": 123.8,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 90.53,
+      "ttfbMs": 91.06,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "coldOpenWallMs": 111,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 448.93
+     },
+     "probeWallMs": 449.3,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 445.06,
+      "ttfbMs": 445.55,
+      "bytes": 1016320,
+      "status": 206
+     },
+     "warmOpenWallMs": 479.1,
+     "sequential": {
+      "ttfbMs": 308.6,
+      "bytes": 256016896,
+      "durationMs": 2863.57,
+      "meanMBps": 100.204,
+      "p50MBps": 111.011,
+      "p05MBps": 6.964,
+      "maxMBps": 137.057,
+      "reliable": true
+     },
+     "sequentialWallMs": 2863.9,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 3.07,
+        "headerMs": 2.94,
+        "bytes": 8028672,
+        "throughputMBps": 29.936,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 267.36,
+        "headerMs": 267.19,
+        "bytes": 8028672,
+        "throughputMBps": 30.946,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 789.02,
+        "headerMs": 788.81,
+        "bytes": 8028672,
+        "throughputMBps": 12.772,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 306.05,
+        "headerMs": 305.86,
+        "bytes": 8028672,
+        "throughputMBps": 5.631,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 301.72,
+        "headerMs": 301.46,
+        "bytes": 8028672,
+        "throughputMBps": 26.352,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 143.15,
+       "throughputMBps": 16.964
+      },
+      "medianTtfbMs": 301.72,
+      "worstTtfbMs": 789.02,
+      "failures": 0
+     },
+     "seeksWallMs": 5172.9,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 618.31,
+      "bytes": 2063499776,
+      "durationMs": 30023.61,
+      "meanMBps": 70.174,
+      "p05MBps": 11.181,
+      "timeToBufferMs": 2100,
+      "secondsBelowBitrate": 2.93,
+      "sustainable": true
+     },
+     "playbackWallMs": 30024,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 515.8,
+     "status": "ok",
+     "wallMs": 39739.9,
+     "cpuSeconds": 38.43,
+     "rssPeakBytes": 574521344,
+     "rssMeanBytes": 541516826,
+     "cpuShape": {
+      "intervals": 38,
+      "maxCores": 2.68,
+      "p95Cores": 2.13,
+      "medianCores": 1,
+      "busyFraction": 0.45
+     },
+     "deliveredBytes": 2321549312,
+     "cpuSecondsPerGB": 17.77
+    }
+   ],
+   "prepareMs": 23.2,
+   "buildReused": true,
+   "buildStamp": "altmount@2f9a80d7",
+   "startupMs": 778,
+   "version": {
+    "version": "v0.3.2-68-g2f9a80d7"
+   },
+   "port": 56555,
+   "pids": [
+    44427
+   ],
+   "idle": {
+    "samples": 10,
+    "cpuSeconds": 0.11,
+    "rssPeakBytes": 102842368,
+    "rssMedianBytes": 102842368,
+    "rssMeanBytes": 102803046,
+    "maxProcesses": 1
+   },
+   "resourcesMeasured": true,
+   "resourceSource": "host",
+   "resources": {
+    "samples": 426,
+    "cpuSeconds": 140.85,
+    "rssPeakBytes": 591872000,
+    "rssMedianBytes": 510558208,
+    "rssMeanBytes": 489147281,
+    "maxProcesses": 1
+   },
+   "idleAfter": {
+    "samples": 45,
+    "cpuSeconds": 141.08,
+    "rssPeakBytes": 462487552,
+    "rssMedianBytes": 214089728,
+    "rssMeanBytes": 199170094,
+    "maxProcesses": 1
+   },
+   "status": "ok",
+   "finishedAt": "2026-09-05T14:10:07.049Z"
+  },
+  {
+   "app": "streamnzb",
+   "displayName": "StreamNZB",
+   "language": "Go",
+   "repo": "https://github.com/Gaisberg/streamnzb",
+   "serving": "http-range",
+   "runtime": "source",
+   "startedAt": "2026-09-05T14:10:22.058Z",
+   "items": [
+    {
+     "id": "rar4-small",
+     "tier": "smoke",
+     "axes": [
+      "rar4",
+      "stored",
+      "named-volumes",
+      "partNN"
+     ],
+     "expect": "serve",
+     "importMs": 5.5,
+     "target": {
+      "fileName": "rar4-small"
+     },
+     "coldOpen": {
+      "headerMs": 4107.18,
+      "ttfbMs": 4107.28,
+      "bytes": 1003165,
+      "status": 206
+     },
+     "coldOpenWallMs": 4108.7,
+     "probe": {
+      "totalBytes": 321905886,
+      "rangeSupported": true,
+      "contentType": "video/mp4",
+      "firstByteMs": 1.56
+     },
+     "probeWallMs": 1.7,
+     "sizeBytes": 321905886,
+     "warmOpen": {
+      "headerMs": 0.64,
+      "ttfbMs": 0.67,
+      "bytes": 1052369,
+      "status": 206
+     },
+     "warmOpenWallMs": 1.5,
+     "sequential": {
+      "ttfbMs": 0.78,
+      "bytes": 256048944,
+      "durationMs": 14241.3,
+      "meanMBps": 17.98,
+      "p50MBps": 14.493,
+      "p05MBps": 1.03,
+      "maxMBps": 66.631,
+      "reliable": true
+     },
+     "sequentialWallMs": 14241.6,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 3219058,
+        "ttfbMs": 6.64,
+        "headerMs": 6.14,
+        "bytes": 8060720,
+        "throughputMBps": 752.085,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 80476471,
+        "ttfbMs": 5.36,
+        "headerMs": 5.27,
+        "bytes": 8060928,
+        "throughputMBps": 1061.294,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 160952943,
+        "ttfbMs": 2.49,
+        "headerMs": 2.44,
+        "bytes": 8060928,
+        "throughputMBps": 1337.238,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 241429414,
+        "ttfbMs": 2.98,
+        "headerMs": 2.94,
+        "bytes": 8011724,
+        "throughputMBps": 2909.872,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 305810591,
+        "ttfbMs": 198.25,
+        "headerMs": 198,
+        "bytes": 8060928,
+        "throughputMBps": 10.159,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 32190588,
+       "ttfbMs": 4.77,
+       "throughputMBps": 975.404
+      },
+      "medianTtfbMs": 5.36,
+      "worstTtfbMs": 198.25,
+      "failures": 0
+     },
+     "seeksWallMs": 1049.9,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 96571765,
+      "ttfbMs": 3.11,
+      "bytes": 225334121,
+      "durationMs": 5459.47,
+      "meanMBps": 41.297,
+      "p05MBps": 2.864,
+      "timeToBufferMs": 310,
+      "secondsBelowBitrate": 2.11,
+      "sustainable": true
+     },
+     "playbackWallMs": 5459.9,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "518f4aeb3bdec36905cd82df6113512a9a4919a4fb9c031b789ba4df0034648c"
+      },
+      {
+       "start": 159952943,
+       "bytes": 2000000,
+       "sha256": "cb37e4294880844c4a5d3db895c0ac91a2331fb5bae255f5920184bb8f88d7b6"
+      },
+      {
+       "start": 319905886,
+       "bytes": 2000000,
+       "sha256": "80c39132e3e0dcd3646f6e170c128794169c97e70eca1ebb1af581ed626ee43c"
+      }
+     ],
+     "integrityWallMs": 13.6,
+     "status": "ok",
+     "wallMs": 24885.7,
+     "cpuSeconds": 3.13,
+     "rssPeakBytes": 385318912,
+     "rssMeanBytes": 190265426,
+     "cpuShape": {
+      "intervals": 24,
+      "maxCores": 0.46,
+      "p95Cores": 0.33,
+      "medianCores": 0.06,
+      "busyFraction": 0.25
+     },
+     "deliveredBytes": 483438599,
+     "cpuSecondsPerGB": 6.95
+    },
+    {
+     "id": "plain-medium",
+     "tier": "smoke",
+     "axes": [
+      "direct-video",
+      "no-archive",
+      "per-file-unique-stems"
+     ],
+     "expect": "serve",
+     "importMs": 8.8,
+     "target": {
+      "fileName": "plain-medium"
+     },
+     "coldOpen": {
+      "headerMs": 1476.84,
+      "ttfbMs": 1476.93,
+      "bytes": 1003140,
+      "status": 206
+     },
+     "coldOpenWallMs": 1478.7,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 1.89
+     },
+     "probeWallMs": 2,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 0.65,
+      "ttfbMs": 0.68,
+      "bytes": 1003140,
+      "status": 206
+     },
+     "warmOpenWallMs": 1.4,
+     "sequential": {
+      "ttfbMs": 1.04,
+      "bytes": 256049152,
+      "durationMs": 7467.91,
+      "meanMBps": 34.291,
+      "p50MBps": 52.508,
+      "p05MBps": 5.577,
+      "maxMBps": 66.272,
+      "reliable": true
+     },
+     "sequentialWallMs": 7468.1,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 1.43,
+        "headerMs": 1.38,
+        "bytes": 8028056,
+        "throughputMBps": 4554.602,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 2090.81,
+        "headerMs": 2090.49,
+        "bytes": 8043972,
+        "throughputMBps": 16.661,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 177.82,
+        "headerMs": 177.6,
+        "bytes": 8060928,
+        "throughputMBps": 26.185,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 234.14,
+        "headerMs": 234.06,
+        "bytes": 8060928,
+        "throughputMBps": 2.008,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 430.59,
+        "headerMs": 430.36,
+        "bytes": 8060928,
+        "throughputMBps": 15.209,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 167.92,
+       "throughputMBps": 29.349
+      },
+      "medianTtfbMs": 234.14,
+      "worstTtfbMs": 2090.81,
+      "failures": 0
+     },
+     "seeksWallMs": 8715,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 270.81,
+      "bytes": 2324758528,
+      "durationMs": 30016.91,
+      "meanMBps": 78.153,
+      "p05MBps": 14.454,
+      "timeToBufferMs": 1226,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30017.4,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 1178.1,
+     "status": "ok",
+     "wallMs": 48869.4,
+     "cpuSeconds": 13.77,
+     "rssPeakBytes": 592822272,
+     "rssMeanBytes": 557088099,
+     "cpuShape": {
+      "intervals": 48,
+      "maxCores": 0.61,
+      "p95Cores": 0.55,
+      "medianCores": 0.33,
+      "busyFraction": 0.6
+     },
+     "deliveredBytes": 2582813960,
+     "cpuSecondsPerGB": 5.72
+    },
+    {
+     "id": "obfuscated-direct",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "obfuscated-names",
+      "extensionless"
+     ],
+     "expect": "serve",
+     "importMs": 6.9,
+     "target": {
+      "fileName": "obfuscated-direct"
+     },
+     "coldOpen": {
+      "headerMs": 1016.63,
+      "ttfbMs": 1016.67,
+      "bytes": 1052344,
+      "status": 206
+     },
+     "coldOpenWallMs": 1017.2,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 2.27
+     },
+     "probeWallMs": 2.3,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 0.34,
+      "ttfbMs": 0.35,
+      "bytes": 1054828,
+      "status": 206
+     },
+     "warmOpenWallMs": 0.9,
+     "sequential": {
+      "ttfbMs": 1.84,
+      "bytes": 256048944,
+      "durationMs": 4508.88,
+      "meanMBps": 56.811,
+      "p50MBps": 56.053,
+      "p05MBps": 45.25,
+      "maxMBps": 75.653,
+      "reliable": true
+     },
+     "sequentialWallMs": 4509.1,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 5.49,
+        "headerMs": 5.27,
+        "bytes": 8031817,
+        "throughputMBps": 1998.545,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 294.83,
+        "headerMs": 294.66,
+        "bytes": 8060928,
+        "throughputMBps": 27.85,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 3.26,
+        "headerMs": 3.12,
+        "bytes": 8051280,
+        "throughputMBps": 564.059,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 112.93,
+        "headerMs": 112.77,
+        "bytes": 8060928,
+        "throughputMBps": 11.01,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 268.42,
+        "headerMs": 268.37,
+        "bytes": 8010996,
+        "throughputMBps": 42.988,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 389.89,
+       "throughputMBps": 40.646
+      },
+      "medianTtfbMs": 112.93,
+      "worstTtfbMs": 294.83,
+      "failures": 0
+     },
+     "seeksWallMs": 2499.5,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 140.92,
+      "bytes": 2576416768,
+      "durationMs": 30184.47,
+      "meanMBps": 85.756,
+      "p05MBps": 20.654,
+      "timeToBufferMs": 1054,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30184.8,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 687.3,
+     "status": "ok",
+     "wallMs": 38908,
+     "cpuSeconds": 14.51,
+     "rssPeakBytes": 587235328,
+     "rssMeanBytes": 580288932,
+     "cpuShape": {
+      "intervals": 38,
+      "maxCores": 0.62,
+      "p95Cores": 0.61,
+      "medianCores": 0.45,
+      "busyFraction": 0.68
+     },
+     "deliveredBytes": 2834572884,
+     "cpuSecondsPerGB": 5.5
+    },
+    {
+     "id": "plain-large",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "no-archive"
+     ],
+     "expect": "serve",
+     "importMs": 27.7,
+     "target": {
+      "fileName": "plain-large"
+     },
+     "coldOpen": {
+      "headerMs": 1172.03,
+      "ttfbMs": 1172.17,
+      "bytes": 1052365,
+      "status": 206
+     },
+     "coldOpenWallMs": 1175,
+     "probe": {
+      "totalBytes": 15076905867,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 4.89
+     },
+     "probeWallMs": 5.3,
+     "sizeBytes": 15076905867,
+     "warmOpen": {
+      "headerMs": 2.59,
+      "ttfbMs": 2.92,
+      "bytes": 1048269,
+      "status": 206
+     },
+     "warmOpenWallMs": 6.7,
+     "sequential": {
+      "ttfbMs": 3.13,
+      "bytes": 256048944,
+      "durationMs": 8204.88,
+      "meanMBps": 31.219,
+      "p50MBps": 33.498,
+      "p05MBps": 1.53,
+      "maxMBps": 96.478,
+      "reliable": true
+     },
+     "sequentialWallMs": 8205.1,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 150769058,
+        "ttfbMs": 2.55,
+        "headerMs": 2.47,
+        "bytes": 8060613,
+        "throughputMBps": 1398.674,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 3769226466,
+        "ttfbMs": 834.83,
+        "headerMs": 834.52,
+        "bytes": 8060928,
+        "throughputMBps": 11.598,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 7538452933,
+        "ttfbMs": 162.76,
+        "headerMs": 162.56,
+        "bytes": 8060720,
+        "throughputMBps": 22.861,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 11307679400,
+        "ttfbMs": 710.5,
+        "headerMs": 710.38,
+        "bytes": 8060612,
+        "throughputMBps": 1935.166,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 14323060573,
+        "ttfbMs": 257.08,
+        "headerMs": 256.88,
+        "bytes": 8060928,
+        "throughputMBps": 19.518,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1507690586,
+       "ttfbMs": 375.29,
+       "throughputMBps": 148.529
+      },
+      "medianTtfbMs": 257.08,
+      "worstTtfbMs": 834.83,
+      "failures": 0
+     },
+     "seeksWallMs": 3868.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 4523071760,
+      "ttfbMs": 171.08,
+      "bytes": 1961164800,
+      "durationMs": 30080.19,
+      "meanMBps": 65.571,
+      "p05MBps": 5.587,
+      "timeToBufferMs": 1237,
+      "secondsBelowBitrate": 1.19,
+      "sustainable": true
+     },
+     "playbackWallMs": 30080.6,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "f9f305fa3fbc944f62df43ac8c3452bb25fd5d81f018ff874658b5004c8319d1"
+      },
+      {
+       "start": 7537452933,
+       "bytes": 2000000,
+       "sha256": "5551953b14d1450b51a7914a813f0ae27582f40aed6090f9a9a08742f3084e2d"
+      },
+      {
+       "start": 15074905867,
+       "bytes": 2000000,
+       "sha256": "98fdc11b40dbe71e4bf96844181a32f8573cd2b7058f16cf66702a1ff20aea6b"
+      }
+     ],
+     "integrityWallMs": 802,
+     "status": "ok",
+     "wallMs": 44170.9,
+     "cpuSeconds": 12.65,
+     "rssPeakBytes": 624099328,
+     "rssMeanBytes": 604562153,
+     "cpuShape": {
+      "intervals": 43,
+      "maxCores": 0.6,
+      "p95Cores": 0.59,
+      "medianCores": 0.32,
+      "busyFraction": 0.51
+     },
+     "deliveredBytes": 2219314378,
+     "cpuSecondsPerGB": 6.12
+    },
+    {
+     "id": "plain-season-pack",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "season-pack",
+      "file-selection"
+     ],
+     "expect": "serve",
+     "importMs": 64.2,
+     "target": {
+      "fileName": "plain-season-pack"
+     },
+     "coldOpen": {
+      "headerMs": 1503.42,
+      "ttfbMs": 1503.47,
+      "bytes": 1019471,
+      "status": 206
+     },
+     "coldOpenWallMs": 1504.1,
+     "probe": {
+      "totalBytes": 2210528776,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 3.17
+     },
+     "probeWallMs": 3.3,
+     "sizeBytes": 2210528776,
+     "warmOpen": {
+      "headerMs": 0.65,
+      "ttfbMs": 0.68,
+      "bytes": 1035803,
+      "status": 206
+     },
+     "warmOpenWallMs": 1.2,
+     "sequential": {
+      "ttfbMs": 2.26,
+      "bytes": 256049152,
+      "durationMs": 11142.11,
+      "meanMBps": 22.985,
+      "p50MBps": 16.279,
+      "p05MBps": 0.722,
+      "maxMBps": 77.53,
+      "reliable": true
+     },
+     "sequentialWallMs": 11142.5,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 22105287,
+        "ttfbMs": 6.67,
+        "headerMs": 6.38,
+        "bytes": 8060928,
+        "throughputMBps": 1251.495,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 552632194,
+        "ttfbMs": 1177.66,
+        "headerMs": 1177.6,
+        "bytes": 8060928,
+        "throughputMBps": 76.461,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 1105264388,
+        "ttfbMs": 308.8,
+        "headerMs": 308.58,
+        "bytes": 8031814,
+        "throughputMBps": 743.056,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 1657896582,
+        "ttfbMs": 590.97,
+        "headerMs": 590.78,
+        "bytes": 8060720,
+        "throughputMBps": 76.556,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 2100002337,
+        "ttfbMs": 225.96,
+        "headerMs": 225.87,
+        "bytes": 8060720,
+        "throughputMBps": 19.75,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 221052877,
+       "ttfbMs": 4.18,
+       "throughputMBps": 886.497
+      },
+      "medianTtfbMs": 308.8,
+      "worstTtfbMs": 1177.66,
+      "failures": 0
+     },
+     "seeksWallMs": 2960.6,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 663158632,
+      "ttfbMs": 103.13,
+      "bytes": 944570160,
+      "durationMs": 37185.09,
+      "meanMBps": 25.472,
+      "p05MBps": 2.617,
+      "timeToBufferMs": 1051,
+      "secondsBelowBitrate": 24.34,
+      "sustainable": true
+     },
+     "playbackWallMs": 37185.4,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "c3d52b715e7f6ee76f5a1c103a31853d440f1e96341ff2170ca66646a105f452"
+      },
+      {
+       "start": 1104264388,
+       "bytes": 2000000,
+       "sha256": "9e6e73cef2032c61a18d91b1f4d869f69f33e473b43d21d1fb9f1c7d69c9f09e"
+      },
+      {
+       "start": 2208528776,
+       "bytes": 2000000,
+       "sha256": "01b4b848c553ad2ae59b7bab78a02762acfede9b41415de494e5907413a9881f"
+      }
+     ],
+     "integrityWallMs": 1497.5,
+     "status": "ok",
+     "wallMs": 54358.8,
+     "cpuSeconds": 7.97,
+     "rssPeakBytes": 636682240,
+     "rssMeanBytes": 550707200,
+     "cpuShape": {
+      "intervals": 53,
+      "maxCores": 0.56,
+      "p95Cores": 0.49,
+      "medianCores": 0.01,
+      "busyFraction": 0.28
+     },
+     "deliveredBytes": 1202674586,
+     "cpuSecondsPerGB": 7.12
+    },
+    {
+     "id": "rar4-rNN",
+     "tier": "core",
+     "axes": [
+      "rar4",
+      "stored",
+      "rar+rNN",
+      "letter-rollover"
+     ],
+     "expect": "serve",
+     "importMs": 31.8,
+     "target": {
+      "fileName": "rar4-rNN"
+     },
+     "coldOpen": {
+      "error": "HTTP 502 for http://127.0.0.1:59519/cbecb1c31527c11ba84fdcd31235c856484f1eb60538791cb3678afe3f97e832/play/direct-216fd79bedfd39fe: playback failed: playback startup timeout during probe after 5s: no suitable media stream: RAR scan failed: archive fast probe incomplete: context canceled\n"
+     },
+     "probe": {
+      "totalBytes": 2390705,
+      "rangeSupported": true,
+      "contentType": "video/mp4",
+      "firstByteMs": 5.08
+     },
+     "probeWallMs": 5.2,
+     "sizeBytes": 2390705,
+     "status": "failed",
+     "error": "served only 2.4 MB from a 6600 MB post. That is a placeholder, a sample, or the wrong file, not the media.",
+     "wallMs": 5044.7,
+     "cpuSeconds": 0.39,
+     "rssPeakBytes": 455475200,
+     "rssMeanBytes": 352521421,
+     "cpuShape": {
+      "intervals": 4,
+      "maxCores": 0.13,
+      "p95Cores": 0.13,
+      "medianCores": 0.05,
+      "busyFraction": 0.25
+     },
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-hdrenc-small",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 21.1,
+     "target": {
+      "fileName": "rar-hdrenc-small"
+     },
+     "coldOpen": {
+      "error": "HTTP 502 for http://127.0.0.1:59519/cbecb1c31527c11ba84fdcd31235c856484f1eb60538791cb3678afe3f97e832/play/direct-00cc8d4f7490253d: playback failed: playback startup timeout during probe after 5s: no suitable media stream: RAR scan failed: archive fast probe incomplete: context canceled\n"
+     },
+     "probe": {
+      "totalBytes": 2390705,
+      "rangeSupported": true,
+      "contentType": "video/mp4",
+      "firstByteMs": 1.54
+     },
+     "probeWallMs": 1.6,
+     "sizeBytes": 2390705,
+     "status": "failed",
+     "error": "served only 2.4 MB from a 5554 MB post. That is a placeholder, a sample, or the wrong file, not the media.",
+     "wallMs": 5027.5,
+     "cpuSeconds": 0.15,
+     "rssPeakBytes": 294469632,
+     "rssMeanBytes": 291926835,
+     "cpuShape": {
+      "intervals": 4,
+      "maxCores": 0.03,
+      "p95Cores": 0.03,
+      "medianCores": 0.03,
+      "busyFraction": 0.75
+     },
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-hdrenc-large",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 63.2,
+     "target": {
+      "fileName": "rar-hdrenc-large"
+     },
+     "coldOpen": {
+      "headerMs": 1412.54,
+      "ttfbMs": 1412.64,
+      "bytes": 1048239,
+      "status": 206
+     },
+     "coldOpenWallMs": 1413.7,
+     "probe": {
+      "totalBytes": 17174121367,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 1.62
+     },
+     "probeWallMs": 1.7,
+     "sizeBytes": 17174121367,
+     "warmOpen": {
+      "headerMs": 1.1,
+      "ttfbMs": 1.13,
+      "bytes": 1048576,
+      "status": 206
+     },
+     "warmOpenWallMs": 2.2,
+     "sequential": {
+      "ttfbMs": 2.38,
+      "bytes": 256049152,
+      "durationMs": 2908.12,
+      "meanMBps": 88.118,
+      "p50MBps": 109.816,
+      "p05MBps": 70.094,
+      "maxMBps": 135.398,
+      "reliable": true
+     },
+     "sequentialWallMs": 2908.3,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 171741213,
+        "ttfbMs": 1.27,
+        "headerMs": 1.21,
+        "bytes": 8060928,
+        "throughputMBps": 1117.93,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 4293530341,
+        "ttfbMs": 410.22,
+        "headerMs": 410.15,
+        "bytes": 8060928,
+        "throughputMBps": 22.095,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 8587060683,
+        "ttfbMs": 650.42,
+        "headerMs": 650.21,
+        "bytes": 8060928,
+        "throughputMBps": 213.626,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 12880591025,
+        "ttfbMs": 374.51,
+        "headerMs": 374.3,
+        "bytes": 8060928,
+        "throughputMBps": 32.731,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 16315415298,
+        "ttfbMs": 81.62,
+        "headerMs": 81.48,
+        "bytes": 8060928,
+        "throughputMBps": 39.164,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1717412136,
+       "ttfbMs": 553.53,
+       "throughputMBps": 35.838
+      },
+      "medianTtfbMs": 374.51,
+      "worstTtfbMs": 650.42,
+      "failures": 0
+     },
+     "seeksWallMs": 3159.1,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 5152236410,
+      "ttfbMs": 234.32,
+      "bytes": 3155492656,
+      "durationMs": 30048.99,
+      "meanMBps": 105.837,
+      "p05MBps": 24.827,
+      "timeToBufferMs": 1005,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30049.3,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "ca5f5f5d72bc03c73ec554b87f09293056cc64f898d9ba0c6009c0f31cf92035"
+      },
+      {
+       "start": 8586060683,
+       "bytes": 2000000,
+       "sha256": "ed802261f0ff5ea16496bbf3e08828cab7d130093e0b0bd504b5e93ccf9fac78"
+      },
+      {
+       "start": 17172121367,
+       "bytes": 2000000,
+       "sha256": "2cf8c04c6895c85ab6c884ddaea22a03d619822747aa358a1e9d975709bcecc3"
+      }
+     ],
+     "integrityWallMs": 1103.1,
+     "status": "ok",
+     "wallMs": 38700.6,
+     "cpuSeconds": 20.31,
+     "rssPeakBytes": 667271168,
+     "rssMeanBytes": 609675106,
+     "cpuShape": {
+      "intervals": 38,
+      "maxCores": 0.84,
+      "p95Cores": 0.83,
+      "medianCores": 0.65,
+      "busyFraction": 0.74
+     },
+     "deliveredBytes": 3413638623,
+     "cpuSecondsPerGB": 6.39
+    },
+    {
+     "id": "rar-partNN-large",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "importMs": 78.7,
+     "target": {
+      "fileName": "rar-partNN-large"
+     },
+     "coldOpen": {
+      "error": "HTTP 502 for http://127.0.0.1:59519/cbecb1c31527c11ba84fdcd31235c856484f1eb60538791cb3678afe3f97e832/play/direct-169763f8813875af: playback failed: archive volume [20/72] - \"XEQWzFs0v7WfZnBBzUxZ.part19.rar\" yEnc (1/439) 314572800 segment unavailable: first segment not found (430)\n"
+     },
+     "probe": {
+      "totalBytes": 2390705,
+      "rangeSupported": true,
+      "contentType": "video/mp4",
+      "firstByteMs": 6.11
+     },
+     "probeWallMs": 6.3,
+     "sizeBytes": 2390705,
+     "status": "failed",
+     "error": "served only 2.4 MB from a 20891 MB post. That is a placeholder, a sample, or the wrong file, not the media.",
+     "wallMs": 1385.1,
+     "cpuSeconds": 0.45,
+     "rssPeakBytes": 651018240,
+     "rssMeanBytes": 651018240,
+     "cpuShape": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-maestras",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "importMs": 21,
+     "target": {
+      "fileName": "rar-partNN-maestras"
+     },
+     "coldOpen": {
+      "error": "HTTP 502 for http://127.0.0.1:59519/cbecb1c31527c11ba84fdcd31235c856484f1eb60538791cb3678afe3f97e832/play/direct-e23292ba026a1910: playback failed: archive volume [03/26] - \"Su7pfShZJ0uazNFfv70sB3.part02.rar\" yEnc (1/293) 209715200 segment unavailable: first segment not found (430)\n"
+     },
+     "probe": {
+      "totalBytes": 2390705,
+      "rangeSupported": true,
+      "contentType": "video/mp4",
+      "firstByteMs": 5.66
+     },
+     "probeWallMs": 6.2,
+     "sizeBytes": 2390705,
+     "status": "failed",
+     "error": "served only 2.4 MB from a 3743 MB post. That is a placeholder, a sample, or the wrong file, not the media.",
+     "wallMs": 1514.4,
+     "cpuSeconds": 0.13,
+     "rssPeakBytes": 651329536,
+     "rssMeanBytes": 651182080,
+     "cpuShape": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-satans",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "importMs": 21,
+     "target": {
+      "fileName": "rar-partNN-satans"
+     },
+     "coldOpen": {
+      "error": "HTTP 502 for http://127.0.0.1:59519/cbecb1c31527c11ba84fdcd31235c856484f1eb60538791cb3678afe3f97e832/play/direct-ba17d59329d90190: playback failed: archive volume [06/21] - \"rEN8svtCcJjJ74Q4qpvJf1K8A.part05.rar\" yEnc (1/366) 262144000 segment unavailable: first segment not found (430)\n"
+     },
+     "probe": {
+      "totalBytes": 2390705,
+      "rangeSupported": true,
+      "contentType": "video/mp4",
+      "firstByteMs": 3.9
+     },
+     "probeWallMs": 4,
+     "sizeBytes": 2390705,
+     "status": "failed",
+     "error": "served only 2.4 MB from a 3335 MB post. That is a placeholder, a sample, or the wrong file, not the media.",
+     "wallMs": 1524.8,
+     "cpuSeconds": 0.13,
+     "rssPeakBytes": 651476992,
+     "rssMeanBytes": 651476992,
+     "cpuShape": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "7z-split-bugonia",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 63.7,
+     "target": {
+      "fileName": "7z-split-bugonia"
+     },
+     "coldOpen": {
+      "headerMs": 3734.48,
+      "ttfbMs": 3734.55,
+      "bytes": 1048576,
+      "status": 206
+     },
+     "coldOpenWallMs": 3736.5,
+     "probe": {
+      "totalBytes": 21169663096,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 33.99
+     },
+     "probeWallMs": 34,
+     "sizeBytes": 21169663096,
+     "warmOpen": {
+      "headerMs": 21.88,
+      "ttfbMs": 21.9,
+      "bytes": 1048576,
+      "status": 206
+     },
+     "warmOpenWallMs": 22.9,
+     "sequential": {
+      "ttfbMs": 20.42,
+      "bytes": 256049152,
+      "durationMs": 4593.94,
+      "meanMBps": 55.985,
+      "p50MBps": 63.117,
+      "p05MBps": 35.733,
+      "maxMBps": 128.398,
+      "reliable": true
+     },
+     "sequentialWallMs": 4594.1,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 211696630,
+        "ttfbMs": 22.95,
+        "headerMs": 22.91,
+        "bytes": 8060512,
+        "throughputMBps": 914.041,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 5292415774,
+        "ttfbMs": 551.52,
+        "headerMs": 551.44,
+        "bytes": 8060720,
+        "throughputMBps": 10.673,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 10584831548,
+        "ttfbMs": 109.58,
+        "headerMs": 109.53,
+        "bytes": 8060928,
+        "throughputMBps": 24.29,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 15877247322,
+        "ttfbMs": 325.9,
+        "headerMs": 325.75,
+        "bytes": 8060928,
+        "throughputMBps": 36.876,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 20111179941,
+        "ttfbMs": 125.92,
+        "headerMs": 125.78,
+        "bytes": 8060928,
+        "throughputMBps": 27.196,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 2116966309,
+       "ttfbMs": 104.94,
+       "throughputMBps": 24.459
+      },
+      "medianTtfbMs": 125.92,
+      "worstTtfbMs": 551.52,
+      "failures": 0
+     },
+     "seeksWallMs": 3181.8,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 6350898928,
+      "ttfbMs": 435.8,
+      "bytes": 3996975104,
+      "durationMs": 30001.9,
+      "meanMBps": 135.188,
+      "p05MBps": 97.624,
+      "timeToBufferMs": 1072,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30002.1,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "dc90fbf4517651e76aca1b4c57f43ec37a25a92bdc1fd9294e806c2228ca39aa"
+      },
+      {
+       "start": 10583831548,
+       "bytes": 2000000,
+       "sha256": "911ad58d080637c505d2d3a768a6bb31ea30f3c4ee925cdb7ecc5003d10e7c2d"
+      },
+      {
+       "start": 21167663096,
+       "bytes": 2000000,
+       "sha256": "3a59d97512411e4b8a542cbf88a7af356b2916175b792ec5e6c2bfe2aeff3b5b"
+      }
+     ],
+     "integrityWallMs": 1710.7,
+     "status": "ok",
+     "wallMs": 43346,
+     "cpuSeconds": 24.24,
+     "rssPeakBytes": 650674176,
+     "rssMeanBytes": 628917367,
+     "cpuShape": {
+      "intervals": 42,
+      "maxCores": 0.79,
+      "p95Cores": 0.72,
+      "medianCores": 0.66,
+      "busyFraction": 0.81
+     },
+     "deliveredBytes": 4255121408,
+     "cpuSecondsPerGB": 6.12
+    },
+    {
+     "id": "7z-split-tardes",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 80.2,
+     "target": {
+      "fileName": "7z-split-tardes"
+     },
+     "coldOpen": {
+      "headerMs": 1305.31,
+      "ttfbMs": 1305.41,
+      "bytes": 1048576,
+      "status": 206
+     },
+     "coldOpenWallMs": 1307.9,
+     "probe": {
+      "totalBytes": 19222688752,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 30.62
+     },
+     "probeWallMs": 30.8,
+     "sizeBytes": 19222688752,
+     "warmOpen": {
+      "headerMs": 20.31,
+      "ttfbMs": 20.33,
+      "bytes": 1048368,
+      "status": 206
+     },
+     "warmOpenWallMs": 21.4,
+     "sequential": {
+      "ttfbMs": 18.86,
+      "bytes": 256049152,
+      "durationMs": 2915.68,
+      "meanMBps": 88.39,
+      "p50MBps": 89.376,
+      "p05MBps": 62.712,
+      "maxMBps": 123.234,
+      "reliable": true
+     },
+     "sequentialWallMs": 2915.8,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 192226887,
+        "ttfbMs": 18.7,
+        "headerMs": 18.67,
+        "bytes": 8060720,
+        "throughputMBps": 974.1,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 4805672188,
+        "ttfbMs": 578.22,
+        "headerMs": 578.04,
+        "bytes": 8060720,
+        "throughputMBps": 6.129,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 9611344376,
+        "ttfbMs": 240.21,
+        "headerMs": 240.05,
+        "bytes": 8060928,
+        "throughputMBps": 13.029,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 14417016564,
+        "ttfbMs": 215.05,
+        "headerMs": 214.9,
+        "bytes": 8060928,
+        "throughputMBps": 14.311,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 18261554314,
+        "ttfbMs": 248.35,
+        "headerMs": 248.12,
+        "bytes": 8060720,
+        "throughputMBps": 7.341,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1922268875,
+       "ttfbMs": 359.04,
+       "throughputMBps": 11.706
+      },
+      "medianTtfbMs": 240.21,
+      "worstTtfbMs": 578.22,
+      "failures": 0
+     },
+     "seeksWallMs": 5952.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 5766806625,
+      "ttfbMs": 291.96,
+      "bytes": 2869755904,
+      "durationMs": 30318.87,
+      "meanMBps": 95.573,
+      "p05MBps": 20.025,
+      "timeToBufferMs": 1207,
+      "secondsBelowBitrate": 0.39,
+      "sustainable": true
+     },
+     "playbackWallMs": 30319.4,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "676926b1cace4d63b9055ee16516ed2e86ababef4e6b3807d5e2529fe33fa4da"
+      },
+      {
+       "start": 9610344376,
+       "bytes": 2000000,
+       "sha256": "3037000cc41414ff7c6fa8f1ae5b95ca1a797239cde68dca8394bc5ce9f152e5"
+      },
+      {
+       "start": 19220688752,
+       "bytes": 2000000,
+       "sha256": "441fa0ef78afac308dd1fee5b4c5bac65486f670997aed25a54daafcb8e3f024"
+      }
+     ],
+     "integrityWallMs": 2064.7,
+     "status": "ok",
+     "wallMs": 42692.7,
+     "cpuSeconds": 19.91,
+     "rssPeakBytes": 636633088,
+     "rssMeanBytes": 607835867,
+     "cpuShape": {
+      "intervals": 41,
+      "maxCores": 0.75,
+      "p95Cores": 0.69,
+      "medianCores": 0.54,
+      "busyFraction": 0.76
+     },
+     "deliveredBytes": 3127902000,
+     "cpuSecondsPerGB": 6.83
+    },
+    {
+     "id": "damaged-partial",
+     "tier": "failure",
+     "axes": [
+      "direct-video",
+      "missing-articles"
+     ],
+     "expect": "serve",
+     "importMs": 17,
+     "target": {
+      "fileName": "damaged-partial"
+     },
+     "coldOpen": {
+      "headerMs": 1050.05,
+      "ttfbMs": 1050.1,
+      "bytes": 1052344,
+      "status": 206
+     },
+     "coldOpenWallMs": 1050.9,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 2.78
+     },
+     "probeWallMs": 2.9,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 0.49,
+      "ttfbMs": 0.51,
+      "bytes": 1012672,
+      "status": 206
+     },
+     "warmOpenWallMs": 1.1,
+     "sequential": {
+      "ttfbMs": 0.77,
+      "bytes": 256049152,
+      "durationMs": 9223.48,
+      "meanMBps": 27.763,
+      "p50MBps": 47.703,
+      "p05MBps": 2.021,
+      "maxMBps": 66.441,
+      "reliable": true
+     },
+     "sequentialWallMs": 9223.8,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 6.05,
+        "headerMs": 5.98,
+        "bytes": 8002648,
+        "throughputMBps": 2412.04,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 468.13,
+        "headerMs": 468.03,
+        "bytes": 8060928,
+        "throughputMBps": 16.903,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 202.62,
+        "headerMs": 202.48,
+        "bytes": 8060928,
+        "throughputMBps": 23.734,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 249.61,
+        "headerMs": 249.52,
+        "bytes": 8060720,
+        "throughputMBps": 26.055,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 262.46,
+        "headerMs": 262.29,
+        "bytes": 8060928,
+        "throughputMBps": 11.028,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 3749.08,
+       "throughputMBps": 15.163
+      },
+      "medianTtfbMs": 249.61,
+      "worstTtfbMs": 468.13,
+      "failures": 0
+     },
+     "seeksWallMs": 7332.7,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 214.02,
+      "bytes": 1431371776,
+      "durationMs": 30039.83,
+      "meanMBps": 47.991,
+      "p05MBps": 4.802,
+      "timeToBufferMs": 989,
+      "secondsBelowBitrate": 14.87,
+      "sustainable": true
+     },
+     "playbackWallMs": 30040.3,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 1747.5,
+     "status": "ok",
+     "wallMs": 49416.3,
+     "cpuSeconds": 12.34,
+     "rssPeakBytes": 734773248,
+     "rssMeanBytes": 663644078,
+     "cpuShape": {
+      "intervals": 49,
+      "maxCores": 0.61,
+      "p95Cores": 0.6,
+      "medianCores": 0.15,
+      "busyFraction": 0.43
+     },
+     "deliveredBytes": 1689485944,
+     "cpuSecondsPerGB": 7.84
+    }
+   ],
+   "prepareMs": 26.5,
+   "buildReused": true,
+   "buildStamp": "streamnzb@018807c",
+   "startupMs": 775.7,
+   "version": {
+    "version": "v5.17.0"
+   },
+   "port": 59519,
+   "pids": [
+    67041
+   ],
+   "idle": {
+    "samples": 10,
+    "cpuSeconds": 0.55,
+    "rssPeakBytes": 53854208,
+    "rssMedianBytes": 53854208,
+    "rssMeanBytes": 52104397,
+    "maxProcesses": 1
+   },
+   "resourcesMeasured": true,
+   "resourceSource": "host",
+   "resources": {
+    "samples": 400,
+    "cpuSeconds": 130.08,
+    "rssPeakBytes": 734773248,
+    "rssMedianBytes": 596443136,
+    "rssMeanBytes": 567587021,
+    "maxProcesses": 2
+   },
+   "idleAfter": {
+    "samples": 45,
+    "cpuSeconds": 129.95,
+    "rssPeakBytes": 677707776,
+    "rssMedianBytes": 514490368,
+    "rssMeanBytes": 482947163,
+    "maxProcesses": 1
+   },
+   "status": "ok",
+   "finishedAt": "2026-09-05T14:17:53.006Z"
+  },
+  {
+   "app": "nzbdav",
+   "displayName": "nzbdav",
+   "language": "C# (.NET 10)",
+   "repo": "https://github.com/nzbdav-dev/nzbdav",
+   "serving": "webdav",
+   "runtime": "docker",
+   "startedAt": "2026-09-05T14:18:08.016Z",
+   "items": [
+    {
+     "id": "rar4-small",
+     "tier": "smoke",
+     "axes": [
+      "rar4",
+      "stored",
+      "named-volumes",
+      "partNN"
+     ],
+     "expect": "serve",
+     "importMs": 1624.5,
+     "target": {
+      "fileName": "father.brown.2013.s02e05.hdtv.x264-tla.mp4",
+      "sizeBytes": 321905886
+     },
+     "coldOpen": {
+      "headerMs": 154.07,
+      "ttfbMs": 154.13,
+      "bytes": 1030011,
+      "status": 200
+     },
+     "coldOpenWallMs": 692.8,
+     "probe": {
+      "totalBytes": 321905886,
+      "rangeSupported": true,
+      "contentType": "video/mp4",
+      "firstByteMs": 140.35
+     },
+     "probeWallMs": 140.5,
+     "sizeBytes": 321905886,
+     "warmOpen": {
+      "headerMs": 119.5,
+      "ttfbMs": 119.56,
+      "bytes": 1030011,
+      "status": 200
+     },
+     "warmOpenWallMs": 180.7,
+     "sequential": {
+      "ttfbMs": 116.39,
+      "bytes": 256061107,
+      "durationMs": 9077.37,
+      "meanMBps": 28.575,
+      "p50MBps": 30.021,
+      "p05MBps": 11.665,
+      "maxMBps": 50,
+      "reliable": true
+     },
+     "sequentialWallMs": 9077.6,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 3219058,
+        "ttfbMs": 97.97,
+        "headerMs": 97.91,
+        "bytes": 8028425,
+        "throughputMBps": 25.283,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 80476471,
+        "ttfbMs": 109.32,
+        "headerMs": 109.27,
+        "bytes": 8004626,
+        "throughputMBps": 37.149,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 160952943,
+        "ttfbMs": 186.15,
+        "headerMs": 186.09,
+        "bytes": 8046479,
+        "throughputMBps": 161.976,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 241429414,
+        "ttfbMs": 149.31,
+        "headerMs": 149.25,
+        "bytes": 8004365,
+        "throughputMBps": 49.011,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 305810591,
+        "ttfbMs": 111.56,
+        "headerMs": 111.48,
+        "bytes": 8023010,
+        "throughputMBps": 37.47,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 32190588,
+       "ttfbMs": 136.62,
+       "throughputMBps": 69.222
+      },
+      "medianTtfbMs": 111.56,
+      "worstTtfbMs": 186.15,
+      "failures": 0
+     },
+     "seeksWallMs": 1867.5,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 96571765,
+      "ttfbMs": 135.04,
+      "bytes": 225334121,
+      "durationMs": 4388,
+      "meanMBps": 52.983,
+      "p05MBps": 35.793,
+      "timeToBufferMs": 815,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 4388.5,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "518f4aeb3bdec36905cd82df6113512a9a4919a4fb9c031b789ba4df0034648c"
+      },
+      {
+       "start": 159952943,
+       "bytes": 2000000,
+       "sha256": "cb37e4294880844c4a5d3db895c0ac91a2331fb5bae255f5920184bb8f88d7b6"
+      },
+      {
+       "start": 319905886,
+       "bytes": 2000000,
+       "sha256": "80c39132e3e0dcd3646f6e170c128794169c97e70eca1ebb1af581ed626ee43c"
+      }
+     ],
+     "integrityWallMs": 706.5,
+     "status": "ok",
+     "wallMs": 18678.7,
+     "cpuSeconds": null,
+     "deliveredBytes": 483455250,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "plain-medium",
+     "tier": "smoke",
+     "axes": [
+      "direct-video",
+      "no-archive",
+      "per-file-unique-stems"
+     ],
+     "expect": "serve",
+     "importMs": 657.1,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 65.05,
+      "ttfbMs": 65.13,
+      "bytes": 1048576,
+      "status": 200
+     },
+     "coldOpenWallMs": 113.1,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 207.58
+     },
+     "probeWallMs": 207.7,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 77.32,
+      "ttfbMs": 77.4,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "warmOpenWallMs": 141.6,
+     "sequential": {
+      "ttfbMs": 97.48,
+      "bytes": 256016384,
+      "durationMs": 2869.38,
+      "meanMBps": 92.361,
+      "p50MBps": 88.258,
+      "p05MBps": 27.883,
+      "maxMBps": 122.983,
+      "reliable": true
+     },
+     "sequentialWallMs": 2869.6,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 322.25,
+        "headerMs": 322.2,
+        "bytes": 8031275,
+        "throughputMBps": 40.979,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 373.52,
+        "headerMs": 373.46,
+        "bytes": 8007721,
+        "throughputMBps": 47.233,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 334.35,
+        "headerMs": 334.3,
+        "bytes": 8020050,
+        "throughputMBps": 36.944,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 278.89,
+        "headerMs": 278.82,
+        "bytes": 8032379,
+        "throughputMBps": 25.621,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 1070.84,
+        "headerMs": 1070.77,
+        "bytes": 8029135,
+        "throughputMBps": 103.888,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 272.81,
+       "throughputMBps": 37.591
+      },
+      "medianTtfbMs": 334.35,
+      "worstTtfbMs": 1070.84,
+      "failures": 0
+     },
+     "seeksWallMs": 3840,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 409.25,
+      "bytes": 4401949950,
+      "durationMs": 30001.83,
+      "meanMBps": 148.752,
+      "p05MBps": 82.905,
+      "timeToBufferMs": 1212,
+      "secondsBelowBitrate": 0.27,
+      "sustainable": true
+     },
+     "playbackWallMs": 30002.3,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 1966.9,
+     "status": "ok",
+     "wallMs": 39798.4,
+     "cpuSeconds": null,
+     "deliveredBytes": 4660030718,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "obfuscated-direct",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "obfuscated-names",
+      "extensionless"
+     ],
+     "expect": "serve",
+     "importMs": 890,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 62.81,
+      "ttfbMs": 63,
+      "bytes": 1048576,
+      "status": 200
+     },
+     "coldOpenWallMs": 179.2,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 120.59
+     },
+     "probeWallMs": 120.7,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 116.02,
+      "ttfbMs": 116.09,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "warmOpenWallMs": 139.8,
+     "sequential": {
+      "ttfbMs": 98.25,
+      "bytes": 256016384,
+      "durationMs": 2956.68,
+      "meanMBps": 89.566,
+      "p50MBps": 92.05,
+      "p05MBps": 53.614,
+      "maxMBps": 113.213,
+      "reliable": true
+     },
+     "sequentialWallMs": 2956.9,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 260.37,
+        "headerMs": 260.28,
+        "bytes": 8031275,
+        "throughputMBps": 36.204,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 374.78,
+        "headerMs": 374.7,
+        "bytes": 8007721,
+        "throughputMBps": 100.615,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 344.59,
+        "headerMs": 344.51,
+        "bytes": 8019946,
+        "throughputMBps": 82.947,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 366.23,
+        "headerMs": 366.17,
+        "bytes": 8032379,
+        "throughputMBps": 27.043,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 676.09,
+        "headerMs": 676.01,
+        "bytes": 8061903,
+        "throughputMBps": 76.284,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 323.55,
+       "throughputMBps": 41.642
+      },
+      "medianTtfbMs": 366.23,
+      "worstTtfbMs": 676.09,
+      "failures": 0
+     },
+     "seeksWallMs": 3339.5,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 306.52,
+      "bytes": 2917919998,
+      "durationMs": 30001.3,
+      "meanMBps": 98.264,
+      "p05MBps": 14.502,
+      "timeToBufferMs": 882,
+      "secondsBelowBitrate": 5.22,
+      "sustainable": true
+     },
+     "playbackWallMs": 30001.5,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 1259.1,
+     "status": "ok",
+     "wallMs": 38886.8,
+     "cpuSeconds": null,
+     "deliveredBytes": 3176000766,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "plain-large",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "no-archive"
+     ],
+     "expect": "serve",
+     "importMs": 876.2,
+     "target": {
+      "fileName": "1ca77039eefe6edc3e869fb905878.mkv",
+      "sizeBytes": 15076905867
+     },
+     "coldOpen": {
+      "headerMs": 63.95,
+      "ttfbMs": 64.03,
+      "bytes": 1048576,
+      "status": 200
+     },
+     "coldOpenWallMs": 220.5,
+     "probe": {
+      "totalBytes": 15076905867,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 61.68
+     },
+     "probeWallMs": 61.8,
+     "sizeBytes": 15076905867,
+     "warmOpen": {
+      "headerMs": 57.42,
+      "ttfbMs": 57.46,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "warmOpenWallMs": 74.5,
+     "sequential": {
+      "ttfbMs": 67.22,
+      "bytes": 256016384,
+      "durationMs": 2413.09,
+      "meanMBps": 109.135,
+      "p50MBps": 132.498,
+      "p05MBps": 64.622,
+      "maxMBps": 158.903,
+      "reliable": true
+     },
+     "sequentialWallMs": 2413.3,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 150769058,
+        "ttfbMs": 661.04,
+        "headerMs": 660.95,
+        "bytes": 8024670,
+        "throughputMBps": 80.011,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 3769226466,
+        "ttfbMs": 238.3,
+        "headerMs": 238.24,
+        "bytes": 8006430,
+        "throughputMBps": 49.908,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 7538452933,
+        "ttfbMs": 981.26,
+        "headerMs": 981.14,
+        "bytes": 8001031,
+        "throughputMBps": 14.192,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 11307679400,
+        "ttfbMs": 338.78,
+        "headerMs": 338.71,
+        "bytes": 8061272,
+        "throughputMBps": 19.383,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 14323060573,
+        "ttfbMs": 341.83,
+        "headerMs": 341.78,
+        "bytes": 8024227,
+        "throughputMBps": 40.823,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1507690586,
+       "ttfbMs": 1588.57,
+       "throughputMBps": 67.82
+      },
+      "medianTtfbMs": 341.83,
+      "worstTtfbMs": 981.26,
+      "failures": 0
+     },
+     "seeksWallMs": 5705.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 4523071760,
+      "ttfbMs": 375.2,
+      "bytes": 2067916528,
+      "durationMs": 30094.17,
+      "meanMBps": 69.582,
+      "p05MBps": 2.1,
+      "timeToBufferMs": 876,
+      "secondsBelowBitrate": 7.27,
+      "sustainable": true
+     },
+     "playbackWallMs": 30094.7,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "f9f305fa3fbc944f62df43ac8c3452bb25fd5d81f018ff874658b5004c8319d1"
+      },
+      {
+       "start": 7537452933,
+       "bytes": 2000000,
+       "sha256": "5551953b14d1450b51a7914a813f0ae27582f40aed6090f9a9a08742f3084e2d"
+      },
+      {
+       "start": 15074905867,
+       "bytes": 2000000,
+       "sha256": "98fdc11b40dbe71e4bf96844181a32f8573cd2b7058f16cf66702a1ff20aea6b"
+      }
+     ],
+     "integrityWallMs": 1235.3,
+     "status": "ok",
+     "wallMs": 40681.7,
+     "cpuSeconds": null,
+     "deliveredBytes": 2325997296,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "plain-season-pack",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "season-pack",
+      "file-selection"
+     ],
+     "expect": "serve",
+     "importMs": 590.6,
+     "target": {
+      "fileName": "Bosch.S01E01.2015.1080p.Amazon.WEB-DL.AVC.DDP.5.1-DBTV.mkv",
+      "sizeBytes": 2210528776
+     },
+     "coldOpen": {
+      "headerMs": 53.67,
+      "ttfbMs": 53.73,
+      "bytes": 1011712,
+      "status": 200
+     },
+     "coldOpenWallMs": 144.9,
+     "probe": {
+      "totalBytes": 2210528776,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 71.99
+     },
+     "probeWallMs": 72.2,
+     "sizeBytes": 2210528776,
+     "warmOpen": {
+      "headerMs": 80.49,
+      "ttfbMs": 80.56,
+      "bytes": 1011712,
+      "status": 200
+     },
+     "warmOpenWallMs": 136.3,
+     "sequential": {
+      "ttfbMs": 47.3,
+      "bytes": 256000000,
+      "durationMs": 3213.56,
+      "meanMBps": 80.852,
+      "p50MBps": 91.98,
+      "p05MBps": 65.179,
+      "maxMBps": 103.623,
+      "reliable": true
+     },
+     "sequentialWallMs": 3213.8,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 22105287,
+        "ttfbMs": 152.64,
+        "headerMs": 152.58,
+        "bytes": 8004409,
+        "throughputMBps": 98.651,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 552632194,
+        "ttfbMs": 379.09,
+        "headerMs": 379.02,
+        "bytes": 8003710,
+        "throughputMBps": 38.76,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 1105264388,
+        "ttfbMs": 225.68,
+        "headerMs": 225.6,
+        "bytes": 8024316,
+        "throughputMBps": 73.985,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 1657896582,
+        "ttfbMs": 216.96,
+        "headerMs": 216.9,
+        "bytes": 8003962,
+        "throughputMBps": 88.105,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 2100002337,
+        "ttfbMs": 179.37,
+        "headerMs": 179.31,
+        "bytes": 8008159,
+        "throughputMBps": 62.192,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 221052877,
+       "ttfbMs": 166.02,
+       "throughputMBps": 59.514
+      },
+      "medianTtfbMs": 216.96,
+      "worstTtfbMs": 379.09,
+      "failures": 0
+     },
+     "seeksWallMs": 2070.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 663158632,
+      "ttfbMs": 132.45,
+      "bytes": 1547370144,
+      "durationMs": 16443.78,
+      "meanMBps": 94.865,
+      "p05MBps": 64.431,
+      "timeToBufferMs": 509,
+      "secondsBelowBitrate": 0.27,
+      "sustainable": true
+     },
+     "playbackWallMs": 16444.1,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "c3d52b715e7f6ee76f5a1c103a31853d440f1e96341ff2170ca66646a105f452"
+      },
+      {
+       "start": 1104264388,
+       "bytes": 2000000,
+       "sha256": "9e6e73cef2032c61a18d91b1f4d869f69f33e473b43d21d1fb9f1c7d69c9f09e"
+      },
+      {
+       "start": 2208528776,
+       "bytes": 2000000,
+       "sha256": "01b4b848c553ad2ae59b7bab78a02762acfede9b41415de494e5907413a9881f"
+      }
+     ],
+     "integrityWallMs": 502.4,
+     "status": "ok",
+     "wallMs": 23174.7,
+     "cpuSeconds": null,
+     "deliveredBytes": 1805393568,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar4-rNN",
+     "tier": "core",
+     "axes": [
+      "rar4",
+      "stored",
+      "rar+rNN",
+      "letter-rollover"
+     ],
+     "expect": "serve",
+     "importMs": 2131.8,
+     "target": {
+      "fileName": "It's.Always.Sunny.in.Philadelphia.S07E12.The.High.School.Reunion.BluRay.1080p.Remux.AVC.DTSHD-MA.5.1-PtZ.mkv",
+      "sizeBytes": 5882124203
+     },
+     "coldOpen": {
+      "headerMs": 113.95,
+      "ttfbMs": 114.03,
+      "bytes": 1029974,
+      "status": 200
+     },
+     "coldOpenWallMs": 157.7,
+     "probe": {
+      "totalBytes": 5882124203,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 193.5
+     },
+     "probeWallMs": 193.6,
+     "sizeBytes": 5882124203,
+     "warmOpen": {
+      "headerMs": 126.56,
+      "ttfbMs": 126.62,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "warmOpenWallMs": 140.3,
+     "sequential": {
+      "ttfbMs": 169.25,
+      "bytes": 256004094,
+      "durationMs": 2702.82,
+      "meanMBps": 101.045,
+      "p50MBps": 94.257,
+      "p05MBps": 83.144,
+      "maxMBps": 120.231,
+      "reliable": true
+     },
+     "sequentialWallMs": 2703,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 58821242,
+        "ttfbMs": 124.87,
+        "headerMs": 124.82,
+        "bytes": 8029446,
+        "throughputMBps": 83.807,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1470531050,
+        "ttfbMs": 250.35,
+        "headerMs": 250.28,
+        "bytes": 8003076,
+        "throughputMBps": 123.659,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 2941062101,
+        "ttfbMs": 135.35,
+        "headerMs": 135.27,
+        "bytes": 8012977,
+        "throughputMBps": 24.898,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4411593152,
+        "ttfbMs": 200.53,
+        "headerMs": 200.39,
+        "bytes": 8006494,
+        "throughputMBps": 45.319,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 5588017992,
+        "ttfbMs": 104.15,
+        "headerMs": 104.07,
+        "bytes": 8025500,
+        "throughputMBps": 66.628,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 588212420,
+       "ttfbMs": 268.97,
+       "throughputMBps": 109.923
+      },
+      "medianTtfbMs": 135.35,
+      "worstTtfbMs": 250.35,
+      "failures": 0
+     },
+     "seeksWallMs": 1936.9,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1764637260,
+      "ttfbMs": 266.19,
+      "bytes": 2378170706,
+      "durationMs": 30005.33,
+      "meanMBps": 79.968,
+      "p05MBps": 23.812,
+      "timeToBufferMs": 843,
+      "secondsBelowBitrate": 1.15,
+      "sustainable": true
+     },
+     "playbackWallMs": 30006.5,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "652f1b7a97f8dee12621e5d2c483f33bff7c19d5c8f59fe8a9438bc6581e8c88"
+      },
+      {
+       "start": 2940062101,
+       "bytes": 2000000,
+       "sha256": "58b9cf1d866e3b51cdba10ae584acd95b302c53135d8e929e467214fb16154b9"
+      },
+      {
+       "start": 5880124203,
+       "bytes": 2000000,
+       "sha256": "c3c2d6e2dfb3d4ea8c46f74b8579349829e42c7fdbddc101f5bfe992550c4e07"
+      }
+     ],
+     "integrityWallMs": 768.6,
+     "status": "ok",
+     "wallMs": 38038.5,
+     "cpuSeconds": null,
+     "deliveredBytes": 2636220582,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-hdrenc-small",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "status": "failed",
+     "error": "import failed: Article with message-id SbVwZiPuDtFfMaMhFpIeNrFf-1737036699496@nyuu not found.",
+     "wallMs": 9361.2,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-hdrenc-large",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 4527.8,
+     "target": {
+      "fileName": "Ed%C3%A9n%20(2024)%20[BDRip%20x264%201080p%20AC3%205.1%20Castellano]%20(MATS%C2%AE).mkv",
+      "sizeBytes": 17174121367
+     },
+     "coldOpen": {
+      "headerMs": 128.81,
+      "ttfbMs": 129.1,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "coldOpenWallMs": 240,
+     "probe": {
+      "totalBytes": 17174121367,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 110.34
+     },
+     "probeWallMs": 110.5,
+     "sizeBytes": 17174121367,
+     "warmOpen": {
+      "headerMs": 107.48,
+      "ttfbMs": 107.59,
+      "bytes": 1048576,
+      "status": 200
+     },
+     "warmOpenWallMs": 144,
+     "sequential": {
+      "ttfbMs": 158.15,
+      "bytes": 256049152,
+      "durationMs": 3584.7,
+      "meanMBps": 74.725,
+      "p50MBps": 75.335,
+      "p05MBps": 60.258,
+      "maxMBps": 92.432,
+      "reliable": true
+     },
+     "sequentialWallMs": 3585.1,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 171741213,
+        "ttfbMs": 122.56,
+        "headerMs": 122.49,
+        "bytes": 8028160,
+        "throughputMBps": 29.308,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 4293530341,
+        "ttfbMs": 133.3,
+        "headerMs": 133.24,
+        "bytes": 8028160,
+        "throughputMBps": 51.037,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 8587060683,
+        "ttfbMs": 360.4,
+        "headerMs": 360.3,
+        "bytes": 8028160,
+        "throughputMBps": 46.996,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 12880591025,
+        "ttfbMs": 133.72,
+        "headerMs": 133.67,
+        "bytes": 8028160,
+        "throughputMBps": 44.025,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 16315415298,
+        "ttfbMs": 115.26,
+        "headerMs": 115.2,
+        "bytes": 8028160,
+        "throughputMBps": 71.246,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1717412136,
+       "ttfbMs": 231.38,
+       "throughputMBps": 64.945
+      },
+      "medianTtfbMs": 133.3,
+      "worstTtfbMs": 360.4,
+      "failures": 0
+     },
+     "seeksWallMs": 2117.8,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 5152236410,
+      "ttfbMs": 162.39,
+      "bytes": 2061860864,
+      "durationMs": 30000.94,
+      "meanMBps": 69.101,
+      "p05MBps": 28.879,
+      "timeToBufferMs": 750,
+      "secondsBelowBitrate": 1.2,
+      "sustainable": true
+     },
+     "playbackWallMs": 30001.1,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "ca5f5f5d72bc03c73ec554b87f09293056cc64f898d9ba0c6009c0f31cf92035"
+      },
+      {
+       "start": 8586060683,
+       "bytes": 2000000,
+       "sha256": "ed802261f0ff5ea16496bbf3e08828cab7d130093e0b0bd504b5e93ccf9fac78"
+      },
+      {
+       "start": 17172121367,
+       "bytes": 2000000,
+       "sha256": "2cf8c04c6895c85ab6c884ddaea22a03d619822747aa358a1e9d975709bcecc3"
+      }
+     ],
+     "integrityWallMs": 631.5,
+     "status": "ok",
+     "wallMs": 41358,
+     "cpuSeconds": null,
+     "deliveredBytes": 2319974400,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-large",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "import failed: Article with message-id 0d98530cfea9409f8dffdc22a94b396a@ngPost not found.",
+     "wallMs": 6436.3,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-maestras",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "import failed: Article with message-id 4c30d20d229f498ca1aa5e49bafec4b2@ngPost not found.",
+     "wallMs": 2852.1,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-satans",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "import failed: Article with message-id 849c252510294df2af955f53d2aae08c@ngPost not found.",
+     "wallMs": 3490.5,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "7z-split-bugonia",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 1750.6,
+     "target": {
+      "fileName": "Bugonia.2025.SPANiSH.MULTi.1080p.BluRay.x264-USENETHD.mkv",
+      "sizeBytes": 21169663096
+     },
+     "coldOpen": {
+      "headerMs": 92.24,
+      "ttfbMs": 92.39,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "coldOpenWallMs": 184.5,
+     "probe": {
+      "totalBytes": 21169663096,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 114.53
+     },
+     "probeWallMs": 114.7,
+     "sizeBytes": 21169663096,
+     "warmOpen": {
+      "headerMs": 127.4,
+      "ttfbMs": 127.53,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "warmOpenWallMs": 180.8,
+     "sequential": {
+      "ttfbMs": 106.06,
+      "bytes": 256049152,
+      "durationMs": 3695.65,
+      "meanMBps": 71.331,
+      "p50MBps": 68.656,
+      "p05MBps": 45.671,
+      "maxMBps": 99.309,
+      "reliable": true
+     },
+     "sequentialWallMs": 3696,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 211696630,
+        "ttfbMs": 102.79,
+        "headerMs": 102.69,
+        "bytes": 8028160,
+        "throughputMBps": 20.75,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 5292415774,
+        "ttfbMs": 136.19,
+        "headerMs": 136.13,
+        "bytes": 8028160,
+        "throughputMBps": 14.505,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 10584831548,
+        "ttfbMs": 127.49,
+        "headerMs": 127.41,
+        "bytes": 8028160,
+        "throughputMBps": 70.238,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 15877247322,
+        "ttfbMs": 252.87,
+        "headerMs": 252.78,
+        "bytes": 8028160,
+        "throughputMBps": 35.991,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 20111179941,
+        "ttfbMs": 132.15,
+        "headerMs": 132.07,
+        "bytes": 8028160,
+        "throughputMBps": 46.902,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 2116966309,
+       "ttfbMs": 200.77,
+       "throughputMBps": 48.074
+      },
+      "medianTtfbMs": 132.15,
+      "worstTtfbMs": 252.87,
+      "failures": 0
+     },
+     "seeksWallMs": 2568.6,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 6350898928,
+      "ttfbMs": 212.93,
+      "bytes": 2556362752,
+      "durationMs": 30110.06,
+      "meanMBps": 85.505,
+      "p05MBps": 13.208,
+      "timeToBufferMs": 2604,
+      "secondsBelowBitrate": 0.7,
+      "sustainable": true
+     },
+     "playbackWallMs": 30110.6,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "dc90fbf4517651e76aca1b4c57f43ec37a25a92bdc1fd9294e806c2228ca39aa"
+      },
+      {
+       "start": 10583831548,
+       "bytes": 2000000,
+       "sha256": "911ad58d080637c505d2d3a768a6bb31ea30f3c4ee925cdb7ecc5003d10e7c2d"
+      },
+      {
+       "start": 21167663096,
+       "bytes": 2000000,
+       "sha256": "3a59d97512411e4b8a542cbf88a7af356b2916175b792ec5e6c2bfe2aeff3b5b"
+      }
+     ],
+     "integrityWallMs": 761.7,
+     "status": "ok",
+     "wallMs": 39367.6,
+     "cpuSeconds": null,
+     "deliveredBytes": 2814443520,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "7z-split-tardes",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 1766.2,
+     "target": {
+      "fileName": "Tardes.De.Soledad.2024.SPANiSH.1080p.BluRay.x264-USENETHD.mkv",
+      "sizeBytes": 19222688752
+     },
+     "coldOpen": {
+      "headerMs": 113.78,
+      "ttfbMs": 113.84,
+      "bytes": 1048576,
+      "status": 200
+     },
+     "coldOpenWallMs": 178.4,
+     "probe": {
+      "totalBytes": 19222688752,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 117.55
+     },
+     "probeWallMs": 117.7,
+     "sizeBytes": 19222688752,
+     "warmOpen": {
+      "headerMs": 133.75,
+      "ttfbMs": 133.81,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "warmOpenWallMs": 186.2,
+     "sequential": {
+      "ttfbMs": 107.39,
+      "bytes": 256016384,
+      "durationMs": 4701.11,
+      "meanMBps": 55.732,
+      "p50MBps": 62.122,
+      "p05MBps": 36.033,
+      "maxMBps": 73.571,
+      "reliable": true
+     },
+     "sequentialWallMs": 4701.3,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 192226887,
+        "ttfbMs": 164.8,
+        "headerMs": 164.71,
+        "bytes": 8028160,
+        "throughputMBps": 37.5,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 4805672188,
+        "ttfbMs": 150.79,
+        "headerMs": 150.69,
+        "bytes": 8028160,
+        "throughputMBps": 27.998,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 9611344376,
+        "ttfbMs": 127.05,
+        "headerMs": 126.98,
+        "bytes": 8028160,
+        "throughputMBps": 63.072,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 14417016564,
+        "ttfbMs": 313.31,
+        "headerMs": 313.23,
+        "bytes": 8028160,
+        "throughputMBps": 53.749,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 18261554314,
+        "ttfbMs": 259.43,
+        "headerMs": 259.33,
+        "bytes": 8028160,
+        "throughputMBps": 101.145,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1922268875,
+       "ttfbMs": 267.23,
+       "throughputMBps": 58.118
+      },
+      "medianTtfbMs": 164.8,
+      "worstTtfbMs": 313.31,
+      "failures": 0
+     },
+     "seeksWallMs": 2278.6,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 5766806625,
+      "ttfbMs": 207.84,
+      "bytes": 2243624960,
+      "durationMs": 30001.42,
+      "meanMBps": 75.306,
+      "p05MBps": 27.703,
+      "timeToBufferMs": 1135,
+      "secondsBelowBitrate": 0.33,
+      "sustainable": true
+     },
+     "playbackWallMs": 30001.6,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "676926b1cace4d63b9055ee16516ed2e86ababef4e6b3807d5e2529fe33fa4da"
+      },
+      {
+       "start": 9610344376,
+       "bytes": 2000000,
+       "sha256": "3037000cc41414ff7c6fa8f1ae5b95ca1a797239cde68dca8394bc5ce9f152e5"
+      },
+      {
+       "start": 19220688752,
+       "bytes": 2000000,
+       "sha256": "441fa0ef78afac308dd1fee5b4c5bac65486f670997aed25a54daafcb8e3f024"
+      }
+     ],
+     "integrityWallMs": 1042.4,
+     "status": "ok",
+     "wallMs": 40272.4,
+     "cpuSeconds": null,
+     "deliveredBytes": 2501705728,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "damaged-partial",
+     "tier": "failure",
+     "axes": [
+      "direct-video",
+      "missing-articles"
+     ],
+     "expect": "serve",
+     "importMs": 546.8,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 61.71,
+      "ttfbMs": 61.98,
+      "bytes": 1015808,
+      "status": 200
+     },
+     "coldOpenWallMs": 77.6,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 128.85
+     },
+     "probeWallMs": 129,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 143.72,
+      "ttfbMs": 143.78,
+      "bytes": 1048576,
+      "status": 200
+     },
+     "warmOpenWallMs": 176,
+     "sequential": {
+      "error": "terminated"
+     },
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 801.8,
+        "headerMs": 801.74,
+        "bytes": 8031275,
+        "throughputMBps": 21.028,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 515.54,
+        "headerMs": 515.44,
+        "bytes": 8007721,
+        "throughputMBps": 41.848,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 406.01,
+        "headerMs": 405.94,
+        "bytes": 8020050,
+        "throughputMBps": 18.858,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 479.48,
+        "headerMs": 479.41,
+        "bytes": 8065147,
+        "throughputMBps": 18.659,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 690.57,
+        "headerMs": 690.49,
+        "bytes": 8061903,
+        "throughputMBps": 180.564,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 1788.77,
+       "throughputMBps": 18.647
+      },
+      "medianTtfbMs": 515.54,
+      "worstTtfbMs": 801.8,
+      "failures": 0
+     },
+     "seeksWallMs": 6589.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 290.73,
+      "bytes": 3928321278,
+      "durationMs": 30005.72,
+      "meanMBps": 132.2,
+      "p05MBps": 66.749,
+      "timeToBufferMs": 1090,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30006.9,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 1332.5,
+     "status": "ok",
+     "wallMs": 40709,
+     "cpuSeconds": null,
+     "deliveredBytes": 3930385662,
+     "cpuSecondsPerGB": null
+    }
+   ],
+   "prepareMs": 610.1,
+   "buildReused": true,
+   "buildStamp": "usenet-bench/nzbdav:0c7d8e2",
+   "startupMs": 1637.2,
+   "version": {
+    "version": "0c7d8e2"
+   },
+   "port": 62460,
+   "pids": [],
+   "idle": {
+    "samples": 0,
+    "cpuSeconds": 0,
+    "unavailable": true,
+    "source": "docker"
+   },
+   "resourcesMeasured": false,
+   "resourceSource": "docker",
+   "resources": {
+    "samples": 0,
+    "cpuSeconds": 0,
+    "unavailable": true,
+    "source": "docker"
+   },
+   "idleAfter": {
+    "samples": 0,
+    "cpuSeconds": 0,
+    "unavailable": true,
+    "source": "docker"
+   },
+   "status": "ok",
+   "finishedAt": "2026-09-05T14:25:23.758Z"
+  },
+  {
+   "app": "decypharr",
+   "displayName": "Decypharr",
+   "language": "Go",
+   "repo": "https://github.com/sirrobot01/decypharr",
+   "serving": "webdav",
+   "runtime": "docker",
+   "startedAt": "2026-09-05T14:25:38.766Z",
+   "items": [
+    {
+     "id": "rar4-small",
+     "tier": "smoke",
+     "axes": [
+      "rar4",
+      "stored",
+      "named-volumes",
+      "partNN"
+     ],
+     "expect": "serve",
+     "importMs": 2546.7,
+     "target": {
+      "fileName": "Father.Brown.2013.S02E05.HDTV.x264-TLAfather.brown.2013.s02e05.hdtv.x264-tla.mp4",
+      "sizeBytes": 321905886
+     },
+     "coldOpen": {
+      "headerMs": 279.46,
+      "ttfbMs": 279.65,
+      "bytes": 1016426,
+      "status": 200
+     },
+     "coldOpenWallMs": 294.9,
+     "probe": {
+      "totalBytes": 321905886,
+      "rangeSupported": true,
+      "contentType": "video/mp4",
+      "firstByteMs": 2.15
+     },
+     "probeWallMs": 2.3,
+     "sizeBytes": 321905886,
+     "warmOpen": {
+      "headerMs": 1.27,
+      "ttfbMs": 1.33,
+      "bytes": 1025642,
+      "status": 200
+     },
+     "warmOpenWallMs": 5.6,
+     "sequential": {
+      "ttfbMs": 1.74,
+      "bytes": 256016384,
+      "durationMs": 8019.41,
+      "meanMBps": 31.932,
+      "p50MBps": 33.885,
+      "p05MBps": 9.941,
+      "maxMBps": 57.846,
+      "reliable": true
+     },
+     "sequentialWallMs": 8019.7,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 3219058,
+        "ttfbMs": 3.89,
+        "headerMs": 3.77,
+        "bytes": 8005163,
+        "throughputMBps": 194.838,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 80476471,
+        "ttfbMs": 5.9,
+        "headerMs": 5.86,
+        "bytes": 8005162,
+        "throughputMBps": 210.546,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 160952943,
+        "ttfbMs": 5.07,
+        "headerMs": 5.03,
+        "bytes": 8011433,
+        "throughputMBps": 261.337,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 241429414,
+        "ttfbMs": 2.75,
+        "headerMs": 2.72,
+        "bytes": 8027562,
+        "throughputMBps": 281.696,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 305810591,
+        "ttfbMs": 511.74,
+        "headerMs": 511.53,
+        "bytes": 8005162,
+        "throughputMBps": 164.08,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 32190588,
+       "ttfbMs": 105.97,
+       "throughputMBps": 88.426
+      },
+      "medianTtfbMs": 5.07,
+      "worstTtfbMs": 511.74,
+      "failures": 0
+     },
+     "seeksWallMs": 913.8,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 96571765,
+      "ttfbMs": 4.18,
+      "bytes": 225334121,
+      "durationMs": 1160.26,
+      "meanMBps": 194.913,
+      "p05MBps": 160.215,
+      "timeToBufferMs": 250,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 1160.7,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "518f4aeb3bdec36905cd82df6113512a9a4919a4fb9c031b789ba4df0034648c"
+      },
+      {
+       "start": 159952943,
+       "bytes": 2000000,
+       "sha256": "cb37e4294880844c4a5d3db895c0ac91a2331fb5bae255f5920184bb8f88d7b6"
+      },
+      {
+       "start": 319905886,
+       "bytes": 2000000,
+       "sha256": "80c39132e3e0dcd3646f6e170c128794169c97e70eca1ebb1af581ed626ee43c"
+      }
+     ],
+     "integrityWallMs": 150.9,
+     "status": "ok",
+     "wallMs": 13094.7,
+     "cpuSeconds": null,
+     "deliveredBytes": 483392573,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "plain-medium",
+     "tier": "smoke",
+     "axes": [
+      "direct-video",
+      "no-archive",
+      "per-file-unique-stems"
+     ],
+     "expect": "serve",
+     "importMs": 3094.4,
+     "target": {
+      "fileName": "plain-medium.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 180.9,
+      "ttfbMs": 181.12,
+      "bytes": 1011609,
+      "status": 200
+     },
+     "coldOpenWallMs": 195.8,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 1.33
+     },
+     "probeWallMs": 1.4,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 1.24,
+      "ttfbMs": 1.28,
+      "bytes": 1045145,
+      "status": 200
+     },
+     "warmOpenWallMs": 8.2,
+     "sequential": {
+      "ttfbMs": 2.68,
+      "bytes": 256016384,
+      "durationMs": 2108.71,
+      "meanMBps": 121.564,
+      "p50MBps": 161.093,
+      "p05MBps": 146.702,
+      "maxMBps": 191.564,
+      "reliable": true
+     },
+     "sequentialWallMs": 2108.9,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 533.69,
+        "headerMs": 533.61,
+        "bytes": 8005143,
+        "throughputMBps": 235.709,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 347.51,
+        "headerMs": 347.44,
+        "bytes": 8028160,
+        "throughputMBps": 62.815,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 450.47,
+        "headerMs": 450.38,
+        "bytes": 8060928,
+        "throughputMBps": 37.93,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 228.88,
+        "headerMs": 228.78,
+        "bytes": 8005141,
+        "throughputMBps": 203.46,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 1247.68,
+        "headerMs": 1247.53,
+        "bytes": 8005142,
+        "throughputMBps": 155.643,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 544.88,
+       "throughputMBps": 17.452
+      },
+      "medianTtfbMs": 450.47,
+      "worstTtfbMs": 1247.68,
+      "failures": 0
+     },
+     "seeksWallMs": 4278.8,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 788.83,
+      "bytes": 1582333952,
+      "durationMs": 30180.98,
+      "meanMBps": 53.835,
+      "p05MBps": 9.286,
+      "timeToBufferMs": 1609,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30181.4,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 1441.4,
+     "status": "ok",
+     "wallMs": 41310.4,
+     "cpuSeconds": null,
+     "deliveredBytes": 1840407090,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "obfuscated-direct",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "obfuscated-names",
+      "extensionless"
+     ],
+     "expect": "serve",
+     "status": "failed",
+     "error": "import failed: failed to process nzb: failed to process NZB archives: no valid files found in NZB",
+     "wallMs": 1473.1,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "plain-large",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "no-archive"
+     ],
+     "expect": "serve",
+     "importMs": 12202.7,
+     "target": {
+      "fileName": "plain-large.mkv",
+      "sizeBytes": 15076905867
+     },
+     "coldOpen": {
+      "headerMs": 332.1,
+      "ttfbMs": 332.18,
+      "bytes": 1017880,
+      "status": 200
+     },
+     "coldOpenWallMs": 340.2,
+     "probe": {
+      "totalBytes": 15076905867,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 2.72
+     },
+     "probeWallMs": 2.9,
+     "sizeBytes": 15076905867,
+     "warmOpen": {
+      "headerMs": 1.42,
+      "ttfbMs": 1.46,
+      "bytes": 1025624,
+      "status": 200
+     },
+     "warmOpenWallMs": 8.4,
+     "sequential": {
+      "ttfbMs": 1.65,
+      "bytes": 256016384,
+      "durationMs": 9759.36,
+      "meanMBps": 26.237,
+      "p50MBps": 26.308,
+      "p05MBps": 5.49,
+      "maxMBps": 77.56,
+      "reliable": true
+     },
+     "sequentialWallMs": 9759.6,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 150769058,
+        "ttfbMs": 222.55,
+        "headerMs": 222.48,
+        "bytes": 8005139,
+        "throughputMBps": 225.038,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 3769226466,
+        "ttfbMs": 891.93,
+        "headerMs": 891.75,
+        "bytes": 8037906,
+        "throughputMBps": 164.125,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 7538452933,
+        "ttfbMs": 201.12,
+        "headerMs": 201.05,
+        "bytes": 8005139,
+        "throughputMBps": 219.319,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 11307679400,
+        "ttfbMs": 807.22,
+        "headerMs": 806.91,
+        "bytes": 8021470,
+        "throughputMBps": 159.275,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 14323060573,
+        "ttfbMs": 229.93,
+        "headerMs": 229.87,
+        "bytes": 8005139,
+        "throughputMBps": 199.385,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1507690586,
+       "ttfbMs": 339.3,
+       "throughputMBps": 209.123
+      },
+      "medianTtfbMs": 229.93,
+      "worstTtfbMs": 891.93,
+      "failures": 0
+     },
+     "seeksWallMs": 2942.3,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 4523071760,
+      "ttfbMs": 211.51,
+      "bytes": 2302738432,
+      "durationMs": 30047.07,
+      "meanMBps": 77.181,
+      "p05MBps": 13.845,
+      "timeToBufferMs": 540,
+      "secondsBelowBitrate": 2.75,
+      "sustainable": true
+     },
+     "playbackWallMs": 30047.4,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "f9f305fa3fbc944f62df43ac8c3452bb25fd5d81f018ff874658b5004c8319d1"
+      },
+      {
+       "start": 7537452933,
+       "bytes": 2000000,
+       "sha256": "5551953b14d1450b51a7914a813f0ae27582f40aed6090f9a9a08742f3084e2d"
+      },
+      {
+       "start": 15074905867,
+       "bytes": 2000000,
+       "sha256": "98fdc11b40dbe71e4bf96844181a32f8573cd2b7058f16cf66702a1ff20aea6b"
+      }
+     ],
+     "integrityWallMs": 853.7,
+     "status": "ok",
+     "wallMs": 56157.3,
+     "cpuSeconds": null,
+     "deliveredBytes": 2560798320,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "plain-season-pack",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "season-pack",
+      "file-selection"
+     ],
+     "expect": "serve",
+     "importMs": 6198,
+     "target": {
+      "fileName": "Bosch.S01E01.2015.1080p.Amazon.WEB-DL.AVC.DDP.5.1-DBTV.mkv",
+      "sizeBytes": 2210528776
+     },
+     "coldOpen": {
+      "headerMs": 304.12,
+      "ttfbMs": 304.24,
+      "bytes": 1017114,
+      "status": 200
+     },
+     "coldOpenWallMs": 312.3,
+     "probe": {
+      "totalBytes": 2210528776,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 5.56
+     },
+     "probeWallMs": 5.9,
+     "sizeBytes": 2210528776,
+     "warmOpen": {
+      "headerMs": 1.38,
+      "ttfbMs": 1.43,
+      "bytes": 1025626,
+      "status": 200
+     },
+     "warmOpenWallMs": 5.1,
+     "sequential": {
+      "ttfbMs": 6.51,
+      "bytes": 256049152,
+      "durationMs": 3891.44,
+      "meanMBps": 65.908,
+      "p50MBps": 80.102,
+      "p05MBps": 50.835,
+      "maxMBps": 86.508,
+      "reliable": true
+     },
+     "sequentialWallMs": 3891.6,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 22105287,
+        "ttfbMs": 1.53,
+        "headerMs": 1.47,
+        "bytes": 8005144,
+        "throughputMBps": 243.278,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 552632194,
+        "ttfbMs": 318.8,
+        "headerMs": 318.7,
+        "bytes": 8005143,
+        "throughputMBps": 180.678,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 1105264388,
+        "ttfbMs": 115.15,
+        "headerMs": 115.08,
+        "bytes": 8028160,
+        "throughputMBps": 30.183,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 1657896582,
+        "ttfbMs": 123.77,
+        "headerMs": 123.68,
+        "bytes": 8028160,
+        "throughputMBps": 5.152,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 2100002337,
+        "ttfbMs": 330.08,
+        "headerMs": 329.91,
+        "bytes": 8028160,
+        "throughputMBps": 57.832,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 221052877,
+       "ttfbMs": 3.79,
+       "throughputMBps": 237.737
+      },
+      "medianTtfbMs": 123.77,
+      "worstTtfbMs": 330.08,
+      "failures": 0
+     },
+     "seeksWallMs": 2967.3,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 663158632,
+      "ttfbMs": 141.57,
+      "bytes": 1547370144,
+      "durationMs": 23912.61,
+      "meanMBps": 65.095,
+      "p05MBps": 34.468,
+      "timeToBufferMs": 850,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 23913.1,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "c3d52b715e7f6ee76f5a1c103a31853d440f1e96341ff2170ca66646a105f452"
+      },
+      {
+       "start": 1104264388,
+       "bytes": 2000000,
+       "sha256": "9e6e73cef2032c61a18d91b1f4d869f69f33e473b43d21d1fb9f1c7d69c9f09e"
+      },
+      {
+       "start": 2208528776,
+       "bytes": 2000000,
+       "sha256": "01b4b848c553ad2ae59b7bab78a02762acfede9b41415de494e5907413a9881f"
+      }
+     ],
+     "integrityWallMs": 444.9,
+     "status": "ok",
+     "wallMs": 37738.4,
+     "cpuSeconds": null,
+     "deliveredBytes": 1805462036,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar4-rNN",
+     "tier": "core",
+     "axes": [
+      "rar4",
+      "stored",
+      "rar+rNN",
+      "letter-rollover"
+     ],
+     "expect": "serve",
+     "importMs": 3343.8,
+     "target": {
+      "fileName": "rar4-rNN.mkv",
+      "sizeBytes": 3636490397
+     },
+     "coldOpen": {
+      "headerMs": 199.52,
+      "ttfbMs": 199.83,
+      "bytes": 1019354,
+      "status": 200
+     },
+     "coldOpenWallMs": 215.2,
+     "probe": {
+      "totalBytes": 3636490397,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 1.44
+     },
+     "probeWallMs": 1.5,
+     "sizeBytes": 3636490397,
+     "warmOpen": {
+      "headerMs": 1.94,
+      "ttfbMs": 1.99,
+      "bytes": 1025626,
+      "status": 200
+     },
+     "warmOpenWallMs": 7,
+     "sequential": {
+      "ttfbMs": 3.97,
+      "bytes": 256016384,
+      "durationMs": 3832.51,
+      "meanMBps": 66.87,
+      "p50MBps": 70.407,
+      "p05MBps": 46.826,
+      "maxMBps": 84.168,
+      "reliable": true
+     },
+     "sequentialWallMs": 3833,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 36364903,
+        "ttfbMs": 103.42,
+        "headerMs": 103.31,
+        "bytes": 8028160,
+        "throughputMBps": 96.097,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 909122599,
+        "ttfbMs": 251.8,
+        "headerMs": 251.67,
+        "bytes": 8028160,
+        "throughputMBps": 87.721,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 1818245198,
+        "ttfbMs": 169.33,
+        "headerMs": 169.26,
+        "bytes": 8028160,
+        "throughputMBps": 114.123,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 2727367797,
+        "ttfbMs": 86.44,
+        "headerMs": 86.36,
+        "bytes": 8028160,
+        "throughputMBps": 46.785,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 3454665877,
+        "ttfbMs": 90.63,
+        "headerMs": 90.55,
+        "bytes": 8028160,
+        "throughputMBps": 41.246,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 363649039,
+       "ttfbMs": 150,
+       "throughputMBps": 70.636
+      },
+      "medianTtfbMs": 103.42,
+      "worstTtfbMs": 251.8,
+      "failures": 0
+     },
+     "seeksWallMs": 1577.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1090947119,
+      "ttfbMs": 147.54,
+      "bytes": 2545543278,
+      "durationMs": 28094.15,
+      "meanMBps": 91.086,
+      "p05MBps": 57.522,
+      "timeToBufferMs": 791,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 28094.7,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "652f1b7a97f8dee12621e5d2c483f33bff7c19d5c8f59fe8a9438bc6581e8c88"
+      },
+      {
+       "start": 1817245198,
+       "bytes": 2000000,
+       "sha256": "a46edfb96c6d78083dcc7db08c6b6e6b2e7888ef717441d2693f1e62de1839bb"
+      },
+      {
+       "start": 3634490397,
+       "bytes": 2000000,
+       "sha256": "c3c2d6e2dfb3d4ea8c46f74b8579349829e42c7fdbddc101f5bfe992550c4e07"
+      }
+     ],
+     "integrityWallMs": 229.4,
+     "status": "ok",
+     "wallMs": 37302,
+     "cpuSeconds": null,
+     "deliveredBytes": 2803604642,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-hdrenc-small",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "status": "failed",
+     "error": "import failed: failed to process nzb: failed to process NZB archives: all files were skipped due to size or extension restrictions(error file extension not allowed)",
+     "wallMs": 3142.5,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-hdrenc-large",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 7224.2,
+     "target": {
+      "fileName": "rar-hdrenc-large.mkv",
+      "sizeBytes": 17174121367
+     },
+     "coldOpen": {
+      "headerMs": 328.09,
+      "ttfbMs": 328.21,
+      "bytes": 1015256,
+      "status": 200
+     },
+     "coldOpenWallMs": 335.3,
+     "probe": {
+      "totalBytes": 17174121367,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 5.4
+     },
+     "probeWallMs": 5.5,
+     "sizeBytes": 17174121367,
+     "warmOpen": {
+      "headerMs": 3.28,
+      "ttfbMs": 3.33,
+      "bytes": 1025624,
+      "status": 200
+     },
+     "warmOpenWallMs": 9.3,
+     "sequential": {
+      "ttfbMs": 4.46,
+      "bytes": 256016384,
+      "durationMs": 3830.05,
+      "meanMBps": 66.922,
+      "p50MBps": 67.868,
+      "p05MBps": 26.306,
+      "maxMBps": 78.317,
+      "reliable": true
+     },
+     "sequentialWallMs": 3830.3,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 171741213,
+        "ttfbMs": 2.05,
+        "headerMs": 1.98,
+        "bytes": 8021471,
+        "throughputMBps": 246.448,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 4293530341,
+        "ttfbMs": 389.05,
+        "headerMs": 388.88,
+        "bytes": 8028160,
+        "throughputMBps": 41.287,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 8587060683,
+        "ttfbMs": 280.03,
+        "headerMs": 279.95,
+        "bytes": 8028160,
+        "throughputMBps": 18.111,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 12880591025,
+        "ttfbMs": 144.55,
+        "headerMs": 144.47,
+        "bytes": 8028160,
+        "throughputMBps": 33.006,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 16315415298,
+        "ttfbMs": 134.68,
+        "headerMs": 134.6,
+        "bytes": 8060928,
+        "throughputMBps": 38.354,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1717412136,
+       "ttfbMs": 120.8,
+       "throughputMBps": 15.737
+      },
+      "medianTtfbMs": 144.55,
+      "worstTtfbMs": 389.05,
+      "failures": 0
+     },
+     "seeksWallMs": 2705.3,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 5152236410,
+      "ttfbMs": 123.8,
+      "bytes": 1319141376,
+      "durationMs": 32600.91,
+      "meanMBps": 40.618,
+      "p05MBps": 4.398,
+      "timeToBufferMs": 1746,
+      "secondsBelowBitrate": 6.83,
+      "sustainable": true
+     },
+     "playbackWallMs": 32601.3,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "ca5f5f5d72bc03c73ec554b87f09293056cc64f898d9ba0c6009c0f31cf92035"
+      },
+      {
+       "start": 8586060683,
+       "bytes": 2000000,
+       "sha256": "ed802261f0ff5ea16496bbf3e08828cab7d130093e0b0bd504b5e93ccf9fac78"
+      },
+      {
+       "start": 17172121367,
+       "bytes": 2000000,
+       "sha256": "2cf8c04c6895c85ab6c884ddaea22a03d619822747aa358a1e9d975709bcecc3"
+      }
+     ],
+     "integrityWallMs": 733.1,
+     "status": "ok",
+     "wallMs": 47444.4,
+     "cpuSeconds": null,
+     "deliveredBytes": 1577198640,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-large",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "POST http://127.0.0.1:64872/sabnzbd/api?mode=addfile&output=json&category=bench&cat=bench&action=none -> 500: {\n  \"status\": false,\n  \"error\": \"Failed to add rar-partNN-large.nzb: usenet parse failed: failed to stat segment XEQWzFs0v7WfZnBBzUxZ.part01.rar \\u003cd3ce1d85f18444998817c8c9f5e4c3fb@ngPost\\u003e: all providers failed: NNTP ARTICLE_NOT_FOUND (code 430): No Such Article\"\n}\n",
+     "wallMs": 1350.5,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-maestras",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "POST http://127.0.0.1:64872/sabnzbd/api?mode=addfile&output=json&category=bench&cat=bench&action=none -> 500: {\n  \"status\": false,\n  \"error\": \"Failed to add rar-partNN-maestras.nzb: usenet parse failed: failed to stat segment Su7pfShZJ0uazNFfv70sB3.part01.rar \\u003cbf4a33b4f2cd47d2829c3c5688da9667@ngPost\\u003e: all providers failed: NNTP ARTICLE_NOT_FOUND (code 430): No Such Article\"\n}\n",
+     "wallMs": 1359.5,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-satans",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "POST http://127.0.0.1:64872/sabnzbd/api?mode=addfile&output=json&category=bench&cat=bench&action=none -> 500: {\n  \"status\": false,\n  \"error\": \"Failed to add rar-partNN-satans.nzb: usenet parse failed: failed to stat segment rEN8svtCcJjJ74Q4qpvJf1K8A.part01.rar \\u003c4b2b3480fd6543efb4f7bba8e7ccc3b7@ngPost\\u003e: all providers failed: NNTP ARTICLE_NOT_FOUND (code 430): No Such Article\"\n}\n",
+     "wallMs": 1273.2,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "7z-split-bugonia",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "status": "failed",
+     "error": "import failed: failed to process nzb: content verification failed: head of \"7z-split-bugonia.mkv\" matches no media container signature: usenet file content is corrupt",
+     "wallMs": 6220,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "7z-split-tardes",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "status": "failed",
+     "error": "import failed: failed to process nzb: content verification failed: head of \"7z-split-tardes.mkv\" matches no media container signature: usenet file content is corrupt",
+     "wallMs": 5192.3,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "damaged-partial",
+     "tier": "failure",
+     "axes": [
+      "direct-video",
+      "missing-articles"
+     ],
+     "expect": "serve",
+     "importMs": 2095.4,
+     "target": {
+      "fileName": "damaged-partial.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 508.1,
+      "ttfbMs": 508.2,
+      "bytes": 1032217,
+      "status": 200
+     },
+     "coldOpenWallMs": 513.6,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 3.01
+     },
+     "probeWallMs": 3.2,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 1.49,
+      "ttfbMs": 1.57,
+      "bytes": 1025625,
+      "status": 200
+     },
+     "warmOpenWallMs": 5.3,
+     "sequential": {
+      "error": "terminated"
+     },
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 6.36,
+        "headerMs": 6.2,
+        "bytes": 8005143,
+        "throughputMBps": 152.947,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 780.21,
+        "headerMs": 780.12,
+        "bytes": 8028160,
+        "throughputMBps": 146.967,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 856.22,
+        "headerMs": 856.13,
+        "bytes": 8028160,
+        "throughputMBps": 20.214,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 523.76,
+        "headerMs": 523.68,
+        "bytes": 8005141,
+        "throughputMBps": 210.831,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 1946.18,
+        "headerMs": 1946.02,
+        "bytes": 8005142,
+        "throughputMBps": 148.037,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 1965.14,
+       "throughputMBps": 3.49
+      },
+      "medianTtfbMs": 780.21,
+      "worstTtfbMs": 1946.18,
+      "failures": 0
+     },
+     "seeksWallMs": 8975.1,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 906.65,
+      "bytes": 1603305472,
+      "durationMs": 30090.03,
+      "meanMBps": 54.939,
+      "p05MBps": 8.799,
+      "timeToBufferMs": 1859,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30090.5,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 1392.4,
+     "status": "ok",
+     "wallMs": 49341,
+     "cpuSeconds": null,
+     "deliveredBytes": 1605363314,
+     "cpuSecondsPerGB": null
+    }
+   ],
+   "prepareMs": 579.6,
+   "buildReused": true,
+   "buildStamp": "usenet-bench/decypharr:0dd1cbb",
+   "startupMs": 1030.7,
+   "version": {
+    "version": "v2.5",
+    "commit": "0dd1cbb"
+   },
+   "port": 64872,
+   "pids": [],
+   "idle": {
+    "samples": 0,
+    "cpuSeconds": 0,
+    "unavailable": true,
+    "source": "docker"
+   },
+   "resourcesMeasured": false,
+   "resourceSource": "docker",
+   "resources": {
+    "samples": 0,
+    "cpuSeconds": 0,
+    "unavailable": true,
+    "source": "docker"
+   },
+   "idleAfter": {
+    "samples": 0,
+    "cpuSeconds": 0,
+    "unavailable": true,
+    "source": "docker"
+   },
+   "status": "ok",
+   "finishedAt": "2026-09-05T14:31:33.114Z"
+  },
+  {
+   "app": "stremthru",
+   "displayName": "StremThru (newz)",
+   "language": "Go",
+   "repo": "https://github.com/MunifTanjim/stremthru",
+   "serving": "http-range",
+   "runtime": "source",
+   "startedAt": "2026-09-05T14:31:48.117Z",
+   "items": [
+    {
+     "id": "rar4-small",
+     "tier": "smoke",
+     "axes": [
+      "rar4",
+      "stored",
+      "named-volumes",
+      "partNN"
+     ],
+     "expect": "serve",
+     "importMs": 3446.9,
+     "target": {
+      "fileName": "father.brown.2013.s02e05.hdtv.x264-tla.mp4",
+      "sizeBytes": 321905886
+     },
+     "coldOpen": {
+      "headerMs": 43.16,
+      "ttfbMs": 43.22,
+      "bytes": 1007317,
+      "status": 206
+     },
+     "coldOpenWallMs": 44.5,
+     "probe": {
+      "totalBytes": 321905886,
+      "rangeSupported": true,
+      "contentType": "video/mp4",
+      "firstByteMs": 21.4
+     },
+     "probeWallMs": 21.5,
+     "sizeBytes": 321905886,
+     "warmOpen": {
+      "headerMs": 15.56,
+      "ttfbMs": 15.61,
+      "bytes": 1011413,
+      "status": 206
+     },
+     "warmOpenWallMs": 16.6,
+     "sequential": {
+      "ttfbMs": 17.32,
+      "bytes": 256020181,
+      "durationMs": 13645.77,
+      "meanMBps": 18.786,
+      "p50MBps": 20.598,
+      "p05MBps": 7.422,
+      "maxMBps": 36.613,
+      "reliable": true
+     },
+     "sequentialWallMs": 13646.2,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 3219058,
+        "ttfbMs": 58.52,
+        "headerMs": 58.48,
+        "bytes": 8027855,
+        "throughputMBps": 900.948,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 80476471,
+        "ttfbMs": 31.92,
+        "headerMs": 31.89,
+        "bytes": 8002550,
+        "throughputMBps": 1020.652,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 160952943,
+        "ttfbMs": 27.32,
+        "headerMs": 27.29,
+        "bytes": 8003277,
+        "throughputMBps": 721.907,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 241429414,
+        "ttfbMs": 31.42,
+        "headerMs": 31.36,
+        "bytes": 8003278,
+        "throughputMBps": 952.743,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 305810591,
+        "ttfbMs": 205.33,
+        "headerMs": 205.27,
+        "bytes": 8015566,
+        "throughputMBps": 18.296,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 32190588,
+       "ttfbMs": 33.13,
+       "throughputMBps": 985.623
+      },
+      "medianTtfbMs": 31.92,
+      "worstTtfbMs": 205.33,
+      "failures": 0
+     },
+     "seeksWallMs": 870.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 96571765,
+      "ttfbMs": 30.28,
+      "bytes": 225334121,
+      "durationMs": 2238.15,
+      "meanMBps": 102.059,
+      "p05MBps": 22.777,
+      "timeToBufferMs": 305,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 2238.6,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "518f4aeb3bdec36905cd82df6113512a9a4919a4fb9c031b789ba4df0034648c"
+      },
+      {
+       "start": 159952943,
+       "bytes": 2000000,
+       "sha256": "cb37e4294880844c4a5d3db895c0ac91a2331fb5bae255f5920184bb8f88d7b6"
+      },
+      {
+       "start": 319905886,
+       "bytes": 2000000,
+       "sha256": "80c39132e3e0dcd3646f6e170c128794169c97e70eca1ebb1af581ed626ee43c"
+      }
+     ],
+     "integrityWallMs": 150,
+     "status": "ok",
+     "wallMs": 20434.8,
+     "cpuSeconds": 5.93,
+     "rssPeakBytes": 613335040,
+     "rssMeanBytes": 448533845,
+     "cpuShape": {
+      "intervals": 20,
+      "maxCores": 1.21,
+      "p95Cores": 1.21,
+      "medianCores": 0.24,
+      "busyFraction": 0.1
+     },
+     "deliveredBytes": 483373032,
+     "cpuSecondsPerGB": 13.17
+    },
+    {
+     "id": "plain-medium",
+     "tier": "smoke",
+     "axes": [
+      "direct-video",
+      "no-archive",
+      "per-file-unique-stems"
+     ],
+     "expect": "serve",
+     "importMs": 835.4,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6818028645
+     },
+     "coldOpen": {
+      "headerMs": 17.68,
+      "ttfbMs": 17.78,
+      "bytes": 1032140,
+      "status": 206
+     },
+     "coldOpenWallMs": 19.8,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 12.27
+     },
+     "probeWallMs": 12.4,
+     "sizeBytes": 6818028645,
+     "warmOpen": {
+      "headerMs": 9.58,
+      "ttfbMs": 9.63,
+      "bytes": 1032140,
+      "status": 206
+     },
+     "warmOpenWallMs": 10.6,
+     "sequential": {
+      "ttfbMs": 11.92,
+      "bytes": 256049152,
+      "durationMs": 2220.39,
+      "meanMBps": 115.94,
+      "p50MBps": 130.715,
+      "p05MBps": 121.625,
+      "maxMBps": 135.268,
+      "reliable": true
+     },
+     "sequentialWallMs": 2220.6,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 68180286,
+        "ttfbMs": 18.43,
+        "headerMs": 18.29,
+        "bytes": 8028160,
+        "throughputMBps": 580.242,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1704507161,
+        "ttfbMs": 287.6,
+        "headerMs": 287.41,
+        "bytes": 8028056,
+        "throughputMBps": 31.426,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3409014322,
+        "ttfbMs": 252.72,
+        "headerMs": 252.57,
+        "bytes": 8028160,
+        "throughputMBps": 15.35,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 5113521483,
+        "ttfbMs": 312.18,
+        "headerMs": 312.04,
+        "bytes": 8028160,
+        "throughputMBps": 20.695,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6477127212,
+        "ttfbMs": 921.42,
+        "headerMs": 921.26,
+        "bytes": 8028160,
+        "throughputMBps": 20.478,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 681802864,
+       "ttfbMs": 496.02,
+       "throughputMBps": 26.109
+      },
+      "medianTtfbMs": 287.6,
+      "worstTtfbMs": 921.42,
+      "failures": 0
+     },
+     "seeksWallMs": 4170.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 2045408593,
+      "ttfbMs": 324.04,
+      "bytes": 2924904448,
+      "durationMs": 30465.4,
+      "meanMBps": 97.04,
+      "p05MBps": 22.12,
+      "timeToBufferMs": 990,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30465.6,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3408014322,
+       "bytes": 2000000,
+       "sha256": "44c2e44fa185cf6e8fbeb0e8eefbbf082e3f28f1487322a7448f40925673c8d0"
+      },
+      {
+       "start": 6816028645,
+       "error": "HTTP 416 for http://127.0.0.1:50339/v0/store/newz/stream/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdHJlbXRocnUiLCJzdWIiOiJiZW5jaCIsImV4cCI6MTc4ODY2MTkzNCwiZGF0YSI6eyJlbmNfbGluayI6Im9NUFlPbGNXTzhnOUxIMCt0MDRGOUxiNUNIYVJHeHBicEN5bUJMRUprKys2bEFwcGNGbHhPcFVHZFljOUlrT1d0RFN6czk3a0l0MW53M3I0NkdvSFVaMmRlT1lUSzk3SFdtY3ZjOGNKdVExeHJzZFUySmNQbjE0V0FiNldTWmoySWpCMlpMRDgwWldRSU91VHNGd1R1R2RnWGFBVDFWUG9MbnBFUngwdmJ2bGo4NlJFMXRoNWdTOVU4ZmM2RmVFVzF3OEJPbDh4TFYvNi9QRjVSMU1VcDdXZ3NXV3FnRmhaOHdEOE5NRUh4RlNFV0NBbyIsImVuY19mb3JtYXQiOiJBRVMtR0NNLTI1NiJ9fQ.mAhgBHD7BXg5Fdnu3net-MWa_yn-mTny6cKF1MGrtHI/Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv: invalid range: failed to overlap\n"
+      }
+     ],
+     "integrityWallMs": 79.2,
+     "status": "ok",
+     "wallMs": 37814.1,
+     "cpuSeconds": 17.95,
+     "rssPeakBytes": 884457472,
+     "rssMeanBytes": 783668278,
+     "cpuShape": {
+      "intervals": 37,
+      "maxCores": 0.61,
+      "p95Cores": 0.59,
+      "medianCores": 0.49,
+      "busyFraction": 0.89
+     },
+     "deliveredBytes": 3183017880,
+     "cpuSecondsPerGB": 6.06
+    },
+    {
+     "id": "obfuscated-direct",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "obfuscated-names",
+      "extensionless"
+     ],
+     "expect": "serve",
+     "importMs": 104.8,
+     "target": {
+      "fileName": "1)",
+      "sizeBytes": 6818028645
+     },
+     "coldOpen": {
+      "headerMs": 9.91,
+      "ttfbMs": 9.96,
+      "bytes": 1015808,
+      "status": 206
+     },
+     "coldOpenWallMs": 10.8,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "application/octet-stream",
+      "firstByteMs": 14.36
+     },
+     "probeWallMs": 14.5,
+     "sizeBytes": 6818028645,
+     "warmOpen": {
+      "headerMs": 10.98,
+      "ttfbMs": 11.14,
+      "bytes": 1039812,
+      "status": 206
+     },
+     "warmOpenWallMs": 16.9,
+     "sequential": {
+      "ttfbMs": 16.07,
+      "bytes": 256016384,
+      "durationMs": 112.07,
+      "meanMBps": 2666.982,
+      "p50MBps": null,
+      "p05MBps": null,
+      "maxMBps": null,
+      "reliable": false,
+      "unreliableReason": "only 256 MB in 0.1s"
+     },
+     "sequentialWallMs": 112.2,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 68180286,
+        "ttfbMs": 9.29,
+        "headerMs": 8.94,
+        "bytes": 8028160,
+        "throughputMBps": 822.024,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1704507161,
+        "ttfbMs": 13.67,
+        "headerMs": 13.63,
+        "bytes": 8028160,
+        "throughputMBps": 1864.846,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3409014322,
+        "ttfbMs": 13.12,
+        "headerMs": 13.02,
+        "bytes": 8060928,
+        "throughputMBps": 837.756,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 5113521483,
+        "ttfbMs": 14.5,
+        "headerMs": 14.22,
+        "bytes": 8052164,
+        "throughputMBps": 1106.744,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6477127212,
+        "ttfbMs": 8.58,
+        "headerMs": 8.55,
+        "bytes": 8060928,
+        "throughputMBps": 766.956,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 681802864,
+       "ttfbMs": 14.41,
+       "throughputMBps": 1412.307
+      },
+      "medianTtfbMs": 13.12,
+      "worstTtfbMs": 14.5,
+      "failures": 0
+     },
+     "seeksWallMs": 121.5,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 2045408593,
+      "ttfbMs": 22.39,
+      "bytes": 4563585548,
+      "durationMs": 14404.43,
+      "meanMBps": 317.311,
+      "p05MBps": 31.796,
+      "timeToBufferMs": 250,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 14406.7,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3408014322,
+       "bytes": 2000000,
+       "sha256": "44c2e44fa185cf6e8fbeb0e8eefbbf082e3f28f1487322a7448f40925673c8d0"
+      },
+      {
+       "start": 6816028645,
+       "error": "HTTP 416 for http://127.0.0.1:50339/v0/store/newz/stream/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdHJlbXRocnUiLCJzdWIiOiJiZW5jaCIsImV4cCI6MTc4ODY2MTk3MiwiZGF0YSI6eyJlbmNfbGluayI6InIvSWhvRnBYV1hlWHBIUXdqb3RGYjJJTkZ6QUlWN3UrRCtISWpHajNxdjRvUWVKdkQ3NHRGZkdiRHF5RHpHUzc5M0NjZ1J1VU9SaXVsRnJhL2VsUnNOdHdDSlRLa1hDaEJ3NlJpNU03d2QrTVEyYU91M081UnFHSCsyWUdkbDREOERxdjAyWDJpclhzbEg3aVFteVVwTHRURVZVOUJRQmF6ejdCSWV5TkhyN3VjNE9IQThvejdLM1JnazVPYzlidUpsNlpJZVNDbVBoanRIck1oRi9jOGQydllycml3QlI1WFpIWnU1cTk1M25NZDdneiIsImVuY19mb3JtYXQiOiJBRVMtR0NNLTI1NiJ9fQ.UB90CxlmhKg3XBf6RJJfqqT6T_bYq5LKSvcP1IdxDzA/1): invalid range: failed to overlap\n"
+      }
+     ],
+     "integrityWallMs": 65.3,
+     "status": "ok",
+     "wallMs": 14852.8,
+     "cpuSeconds": 9.92,
+     "rssPeakBytes": 957480960,
+     "rssMeanBytes": 786125073,
+     "cpuShape": {
+      "intervals": 14,
+      "maxCores": 1.64,
+      "p95Cores": 1.64,
+      "medianCores": 0.51,
+      "busyFraction": 0.07
+     },
+     "deliveredBytes": 4821657552,
+     "cpuSecondsPerGB": 2.21
+    },
+    {
+     "id": "plain-large",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "no-archive"
+     ],
+     "expect": "serve",
+     "importMs": 636.9,
+     "target": {
+      "fileName": "1ca77039eefe6edc3e869fb905878.mkv",
+      "sizeBytes": 15550201521
+     },
+     "coldOpen": {
+      "headerMs": 38.01,
+      "ttfbMs": 38.12,
+      "bytes": 1048264,
+      "status": 206
+     },
+     "coldOpenWallMs": 41.1,
+     "probe": {
+      "totalBytes": 15076905867,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 20.31
+     },
+     "probeWallMs": 20.4,
+     "sizeBytes": 15550201521,
+     "warmOpen": {
+      "headerMs": 15.27,
+      "ttfbMs": 15.3,
+      "bytes": 1048264,
+      "status": 206
+     },
+     "warmOpenWallMs": 15.8,
+     "sequential": {
+      "ttfbMs": 14.06,
+      "bytes": 256049152,
+      "durationMs": 3429.77,
+      "meanMBps": 74.962,
+      "p50MBps": 73.963,
+      "p05MBps": 51.073,
+      "maxMBps": 79.66,
+      "reliable": true
+     },
+     "sequentialWallMs": 3430,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 155502015,
+        "ttfbMs": 38.86,
+        "headerMs": 38.69,
+        "bytes": 8060408,
+        "throughputMBps": 780.682,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 3887550380,
+        "ttfbMs": 140.12,
+        "headerMs": 140.05,
+        "bytes": 8028160,
+        "throughputMBps": 32.902,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 7775100760,
+        "ttfbMs": 265.55,
+        "headerMs": 265.39,
+        "bytes": 8060928,
+        "throughputMBps": 35.132,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 11662651140,
+        "ttfbMs": 212.52,
+        "headerMs": 212.41,
+        "bytes": 8060928,
+        "throughputMBps": 27.979,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 14772691444,
+        "ttfbMs": 254.31,
+        "headerMs": 254.19,
+        "bytes": 8028160,
+        "throughputMBps": 35.068,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1555020152,
+       "ttfbMs": 222.82,
+       "throughputMBps": 31.621
+      },
+      "medianTtfbMs": 212.52,
+      "worstTtfbMs": 265.55,
+      "failures": 0
+     },
+     "seeksWallMs": 2390.8,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 4665060456,
+      "ttfbMs": 259.74,
+      "bytes": 2366603264,
+      "durationMs": 30001.31,
+      "meanMBps": 79.572,
+      "p05MBps": 19.892,
+      "timeToBufferMs": 1385,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30001.6,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "f9f305fa3fbc944f62df43ac8c3452bb25fd5d81f018ff874658b5004c8319d1"
+      },
+      {
+       "start": 7774100760,
+       "bytes": 2000000,
+       "sha256": "b5adcb0c8ab51e4fecf19c8f70ac47251422a2347e71c2829b12df0f4c467ae5"
+      },
+      {
+       "start": 15548201521,
+       "error": "HTTP 416 for http://127.0.0.1:50339/v0/store/newz/stream/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdHJlbXRocnUiLCJzdWIiOiJiZW5jaCIsImV4cCI6MTc4ODY2MTk4NywiZGF0YSI6eyJlbmNfbGluayI6Img2U3ROaXRwY2d2bmNjRTNiVzlHMG1uSFRMcVNsT1Z3TjZ1d3doVGJUL0xSNktJZXpWZUdINkxwV1Bya243c1l0bGYrYkY5V1JwNUFqc1JaMVZlM0lFRVJ2c3NEQWxNa3Z0a0FQbUN4RmJ0WERrT0xkYU41NTJoVldNSDJic2lFSm81dVlmTHZhYnB1N0crejVZT1JHZzNHQmYwMGUrZWE0elkvc0x4eE0vbEorSWhia2JVZzJTYWIxNUo2cENQeEhFT01Sdz09IiwiZW5jX2Zvcm1hdCI6IkFFUy1HQ00tMjU2In19.ixJCn5LTVqMbXxlG3uvXUpKqGYZX2uq_MxcB-9KTg14/1ca77039eefe6edc3e869fb905878.mkv: invalid range: failed to overlap\n"
+      }
+     ],
+     "integrityWallMs": 281.4,
+     "status": "ok",
+     "wallMs": 36818.1,
+     "cpuSeconds": 15.72,
+     "rssPeakBytes": 807829504,
+     "rssMeanBytes": 699741980,
+     "cpuShape": {
+      "intervals": 35,
+      "maxCores": 0.53,
+      "p95Cores": 0.51,
+      "medianCores": 0.44,
+      "busyFraction": 1
+     },
+     "deliveredBytes": 2624748944,
+     "cpuSecondsPerGB": 6.43
+    },
+    {
+     "id": "plain-season-pack",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "season-pack",
+      "file-selection"
+     ],
+     "expect": "serve",
+     "importMs": 1042,
+     "target": {
+      "fileName": "Bosch.S01E01.2015.1080p.Amazon.WEB-DL.AVC.DDP.5.1-DBTV.mkv",
+      "sizeBytes": 2280882941
+     },
+     "coldOpen": {
+      "headerMs": 76.06,
+      "ttfbMs": 76.1,
+      "bytes": 1015808,
+      "status": 206
+     },
+     "coldOpenWallMs": 252,
+     "probe": {
+      "totalBytes": 2210528776,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 61.46
+     },
+     "probeWallMs": 61.6,
+     "sizeBytes": 2280882941,
+     "warmOpen": {
+      "headerMs": 40.56,
+      "ttfbMs": 40.59,
+      "bytes": 1048267,
+      "status": 206
+     },
+     "warmOpenWallMs": 41,
+     "sequential": {
+      "ttfbMs": 39.18,
+      "bytes": 256049152,
+      "durationMs": 7203.43,
+      "meanMBps": 35.74,
+      "p50MBps": 37.096,
+      "p05MBps": 11.389,
+      "maxMBps": 52.979,
+      "reliable": true
+     },
+     "sequentialWallMs": 7203.5,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 22808829,
+        "ttfbMs": 41.18,
+        "headerMs": 41.15,
+        "bytes": 8060824,
+        "throughputMBps": 1212.511,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 570220735,
+        "ttfbMs": 208.28,
+        "headerMs": 208.2,
+        "bytes": 8028160,
+        "throughputMBps": 26.322,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 1140441470,
+        "ttfbMs": 238.4,
+        "headerMs": 238.25,
+        "bytes": 8060928,
+        "throughputMBps": 21.697,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 1710662205,
+        "ttfbMs": 211.04,
+        "headerMs": 210.87,
+        "bytes": 8028160,
+        "throughputMBps": 20.403,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 2166838793,
+        "ttfbMs": 654.62,
+        "headerMs": 654.48,
+        "bytes": 8028160,
+        "throughputMBps": 0.771,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 228088294,
+       "ttfbMs": 71.85,
+       "throughputMBps": 1518.249
+      },
+      "medianTtfbMs": 211.04,
+      "worstTtfbMs": 654.62,
+      "failures": 0
+     },
+     "seeksWallMs": 12923.1,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 684264882,
+      "ttfbMs": 204.09,
+      "bytes": 793100236,
+      "durationMs": 30103.38,
+      "meanMBps": 26.526,
+      "p05MBps": 2.354,
+      "timeToBufferMs": 12755,
+      "secondsBelowBitrate": 14.67,
+      "sustainable": true
+     },
+     "playbackWallMs": 30103.6,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "c3d52b715e7f6ee76f5a1c103a31853d440f1e96341ff2170ca66646a105f452"
+      },
+      {
+       "start": 1139441470,
+       "bytes": 2000000,
+       "sha256": "37c37d351e415f102ea70f38f25ce8116d101700fa0c7df4e5d9dbbbaa338ada"
+      },
+      {
+       "start": 2278882941,
+       "error": "HTTP 416 for http://127.0.0.1:50339/v0/store/newz/stream/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdHJlbXRocnUiLCJzdWIiOiJiZW5jaCIsImV4cCI6MTc4ODY2MjAyNCwiZGF0YSI6eyJlbmNfbGluayI6InQvdC8wdlRsc053aTB3TU5HWERvb3E1TXRhOVd0SDRlU1ErVzEyZEFaZUNLUVVRdEtMMVBLbkQ5VHhvT1FQY0dzczdPTWZ4MzBwbHl0L3ZHTVZMK2FQM2gxWTZBaXNGV1dKa3owNkszMXo4LzN3cHVGWCtqWU5JSklFdG8yY3kyYzR1WExhVEF3VFhXTElaU3gvamJtNllSNHRQcjBKWldoSnNpa0hPbmRUWHBIbWF0dGdRck83dktHTEpZaER0Z2FGMHppVnJtaHJJWHpiNG5lZ0VTdTQwRWludnZrMnVpck04WWV5UDlxaG9wUGFsQyIsImVuY19mb3JtYXQiOiJBRVMtR0NNLTI1NiJ9fQ.ZR08BDFhZqcP3Il21zzICt0NqWqieynFYdUAtl1AvQk/Bosch.S01E01.2015.1080p.Amazon.WEB-DL.AVC.DDP.5.1-DBTV.mkv: invalid range: failed to overlap\n"
+      }
+     ],
+     "integrityWallMs": 146.2,
+     "status": "ok",
+     "wallMs": 51773.2,
+     "cpuSeconds": 9.25,
+     "rssPeakBytes": 684556288,
+     "rssMeanBytes": 579402201,
+     "cpuShape": {
+      "intervals": 51,
+      "maxCores": 0.39,
+      "p95Cores": 0.33,
+      "medianCores": 0.18,
+      "busyFraction": 0.59
+     },
+     "deliveredBytes": 1051213463,
+     "cpuSecondsPerGB": 9.45
+    },
+    {
+     "id": "rar4-rNN",
+     "tier": "core",
+     "axes": [
+      "rar4",
+      "stored",
+      "rar+rNN",
+      "letter-rollover"
+     ],
+     "expect": "serve",
+     "importMs": 5326.3,
+     "target": {
+      "fileName": "It's.Always.Sunny.in.Philadelphia.S07E12.The.High.School.Reunion.BluRay.1080p.Remux.AVC.DTSHD-MA.5.1-PtZ.mkv",
+      "sizeBytes": 5882124203
+     },
+     "coldOpen": {
+      "headerMs": 240.35,
+      "ttfbMs": 240.4,
+      "bytes": 1007307,
+      "status": 206
+     },
+     "coldOpenWallMs": 241.2,
+     "probe": {
+      "totalBytes": 5882124203,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 212.36
+     },
+     "probeWallMs": 212.4,
+     "sizeBytes": 5882124203,
+     "warmOpen": {
+      "headerMs": 218.09,
+      "ttfbMs": 218.15,
+      "bytes": 1035979,
+      "status": 206
+     },
+     "warmOpenWallMs": 218.7,
+     "sequential": {
+      "ttfbMs": 225.26,
+      "bytes": 256020171,
+      "durationMs": 11344.36,
+      "meanMBps": 23.025,
+      "p50MBps": 33.923,
+      "p05MBps": 4.92,
+      "maxMBps": 43.164,
+      "reliable": true
+     },
+     "sequentialWallMs": 11344.5,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 58821242,
+        "ttfbMs": 337.46,
+        "headerMs": 337.41,
+        "bytes": 8048324,
+        "throughputMBps": 924.856,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1470531050,
+        "ttfbMs": 489.56,
+        "headerMs": 489.46,
+        "bytes": 8003266,
+        "throughputMBps": 22.906,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 2941062101,
+        "ttfbMs": 483.18,
+        "headerMs": 483.12,
+        "bytes": 8003266,
+        "throughputMBps": 19.205,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4411593152,
+        "ttfbMs": 483.49,
+        "headerMs": 483.38,
+        "bytes": 8011458,
+        "throughputMBps": 26.243,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 5588017992,
+        "ttfbMs": 299.33,
+        "headerMs": 299.29,
+        "bytes": 8007363,
+        "throughputMBps": 20.442,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 588212420,
+       "ttfbMs": 428.11,
+       "throughputMBps": 30.938
+      },
+      "medianTtfbMs": 483.18,
+      "worstTtfbMs": 489.56,
+      "failures": 0
+     },
+     "seeksWallMs": 4252.4,
+     "playback": {
+      "error": "terminated"
+     },
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "652f1b7a97f8dee12621e5d2c483f33bff7c19d5c8f59fe8a9438bc6581e8c88"
+      },
+      {
+       "start": 2940062101,
+       "bytes": 2000000,
+       "sha256": "58b9cf1d866e3b51cdba10ae584acd95b302c53135d8e929e467214fb16154b9"
+      },
+      {
+       "start": 5880124203,
+       "bytes": 2000000,
+       "sha256": "c3c2d6e2dfb3d4ea8c46f74b8579349829e42c7fdbddc101f5bfe992550c4e07"
+      }
+     ],
+     "integrityWallMs": 1586.9,
+     "status": "ok",
+     "wallMs": 35095.9,
+     "cpuSeconds": 20.61,
+     "rssPeakBytes": 788856832,
+     "rssMeanBytes": 709990341,
+     "cpuShape": {
+      "intervals": 34,
+      "maxCores": 3.03,
+      "p95Cores": 2.12,
+      "medianCores": 0.28,
+      "busyFraction": 0.21
+     },
+     "deliveredBytes": 258063457,
+     "cpuSecondsPerGB": 85.75
+    },
+    {
+     "id": "rar-hdrenc-small",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "status": "failed",
+     "error": "newz status failed",
+     "wallMs": 25890.6,
+     "cpuSeconds": 4.39,
+     "rssPeakBytes": 742178816,
+     "rssMeanBytes": 682999808,
+     "cpuShape": {
+      "intervals": 25,
+      "maxCores": 0.21,
+      "p95Cores": 0.19,
+      "medianCores": 0.1,
+      "busyFraction": 0.56
+     },
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-hdrenc-large",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 27852.3,
+     "target": {
+      "fileName": "Ed\u00e9n (2024) [BDRip x264 1080p AC3 5.1 Castellano] (MATS\u00ae).mkv",
+      "sizeBytes": 17174121367
+     },
+     "coldOpen": {
+      "headerMs": 191.16,
+      "ttfbMs": 191.2,
+      "bytes": 1003208,
+      "status": 206
+     },
+     "coldOpenWallMs": 193,
+     "probe": {
+      "totalBytes": 17174121367,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 189.92
+     },
+     "probeWallMs": 190,
+     "sizeBytes": 17174121367,
+     "warmOpen": {
+      "headerMs": 191.59,
+      "ttfbMs": 191.64,
+      "bytes": 1011400,
+      "status": 206
+     },
+     "warmOpenWallMs": 193.1,
+     "sequential": {
+      "ttfbMs": 201.05,
+      "bytes": 256003784,
+      "durationMs": 7734.79,
+      "meanMBps": 33.981,
+      "p50MBps": 31.765,
+      "p05MBps": 1.18,
+      "maxMBps": 90.566,
+      "reliable": true
+     },
+     "sequentialWallMs": 7735,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 171741213,
+        "ttfbMs": 228.73,
+        "headerMs": 228.58,
+        "bytes": 8007360,
+        "throughputMBps": 533.794,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 4293530341,
+        "ttfbMs": 405.49,
+        "headerMs": 405.44,
+        "bytes": 8007359,
+        "throughputMBps": 23.843,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 8587060683,
+        "ttfbMs": 446.92,
+        "headerMs": 446.89,
+        "bytes": 8003264,
+        "throughputMBps": 25.826,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 12880591025,
+        "ttfbMs": 441.39,
+        "headerMs": 441.33,
+        "bytes": 8003263,
+        "throughputMBps": 23.311,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 16315415298,
+        "ttfbMs": 421.95,
+        "headerMs": 421.92,
+        "bytes": 8052416,
+        "throughputMBps": 17.97,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1717412136,
+       "ttfbMs": 459.7,
+       "throughputMBps": 23.01
+      },
+      "medianTtfbMs": 421.95,
+      "worstTtfbMs": 446.92,
+      "failures": 0
+     },
+     "seeksWallMs": 4204.8,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 5152236410,
+      "ttfbMs": 751.77,
+      "bytes": 800775871,
+      "durationMs": 30016.48,
+      "meanMBps": 27.363,
+      "p05MBps": 1.452,
+      "timeToBufferMs": 1865,
+      "secondsBelowBitrate": 13.4,
+      "sustainable": true
+     },
+     "playbackWallMs": 30017,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "ca5f5f5d72bc03c73ec554b87f09293056cc64f898d9ba0c6009c0f31cf92035"
+      },
+      {
+       "start": 8586060683,
+       "bytes": 2000000,
+       "sha256": "ed802261f0ff5ea16496bbf3e08828cab7d130093e0b0bd504b5e93ccf9fac78"
+      },
+      {
+       "start": 17172121367,
+       "bytes": 2000000,
+       "sha256": "2cf8c04c6895c85ab6c884ddaea22a03d619822747aa358a1e9d975709bcecc3"
+      }
+     ],
+     "integrityWallMs": 1476,
+     "status": "ok",
+     "wallMs": 71861.3,
+     "cpuSeconds": 27.25,
+     "rssPeakBytes": 901464064,
+     "rssMeanBytes": 763103460,
+     "cpuShape": {
+      "intervals": 71,
+      "maxCores": 3.46,
+      "p95Cores": 1.44,
+      "medianCores": 0.25,
+      "busyFraction": 0.11
+     },
+     "deliveredBytes": 1058794263,
+     "cpuSecondsPerGB": 27.63
+    },
+    {
+     "id": "rar-partNN-large",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "newz status failed",
+     "wallMs": 24768.4,
+     "cpuSeconds": 0.61,
+     "rssPeakBytes": 900055040,
+     "rssMeanBytes": 868998485,
+     "cpuShape": {
+      "intervals": 23,
+      "maxCores": 0.06,
+      "p95Cores": 0.06,
+      "medianCores": 0.02,
+      "busyFraction": 0.13
+     },
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-maestras",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "newz status failed",
+     "wallMs": 8844.8,
+     "cpuSeconds": 0.16,
+     "rssPeakBytes": 869548032,
+     "rssMeanBytes": 868885390,
+     "cpuShape": {
+      "intervals": 8,
+      "maxCores": 0.03,
+      "p95Cores": 0.03,
+      "medianCores": 0.02,
+      "busyFraction": 0.5
+     },
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-satans",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "newz status failed",
+     "wallMs": 6770,
+     "cpuSeconds": 0.11,
+     "rssPeakBytes": 870416384,
+     "rssMeanBytes": 870385957,
+     "cpuShape": {
+      "intervals": 6,
+      "maxCores": 0.02,
+      "p95Cores": 0.02,
+      "medianCores": 0.01,
+      "busyFraction": 0.67
+     },
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "7z-split-bugonia",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 8217.7,
+     "target": {
+      "fileName": "Bugonia.2025.SPANiSH.MULTi.1080p.BluRay.x264-USENETHD.mkv",
+      "sizeBytes": 21169663096
+     },
+     "coldOpen": {
+      "headerMs": 733.11,
+      "ttfbMs": 733.37,
+      "bytes": 1015808,
+      "status": 206
+     },
+     "coldOpenWallMs": 746,
+     "probe": {
+      "totalBytes": 21169663096,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 58.98
+     },
+     "probeWallMs": 59.1,
+     "sizeBytes": 21169663096,
+     "warmOpen": {
+      "headerMs": 51.2,
+      "ttfbMs": 51.24,
+      "bytes": 1015808,
+      "status": 206
+     },
+     "warmOpenWallMs": 55.8,
+     "sequential": {
+      "ttfbMs": 179.7,
+      "bytes": 218923008,
+      "durationMs": 30182.88,
+      "meanMBps": 7.297,
+      "p50MBps": 7.444,
+      "p05MBps": 4.794,
+      "maxMBps": 9.095,
+      "reliable": true
+     },
+     "sequentialWallMs": 30183.6,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 211696630,
+        "ttfbMs": 126.43,
+        "headerMs": 126.37,
+        "bytes": 8028160,
+        "throughputMBps": 161.666,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 5292415774,
+        "ttfbMs": 163.91,
+        "headerMs": 163.82,
+        "bytes": 8028160,
+        "throughputMBps": 8.499,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 10584831548,
+        "ttfbMs": 232.61,
+        "headerMs": 232.5,
+        "bytes": 8028160,
+        "throughputMBps": 8.127,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 15877247322,
+        "ttfbMs": 217.05,
+        "headerMs": 216.98,
+        "bytes": 8028160,
+        "throughputMBps": 8.876,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 20111179941,
+        "ttfbMs": 241.72,
+        "headerMs": 241.61,
+        "bytes": 8028160,
+        "throughputMBps": 6.077,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 2116966309,
+       "ttfbMs": 420.47,
+       "throughputMBps": 7.216
+      },
+      "medianTtfbMs": 217.05,
+      "worstTtfbMs": 241.72,
+      "failures": 0
+     },
+     "seeksWallMs": 6723.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 6350898928,
+      "ttfbMs": 257.74,
+      "bytes": 240549888,
+      "durationMs": 30106.28,
+      "meanMBps": 8.059,
+      "p05MBps": 7.152,
+      "timeToBufferMs": 7652,
+      "secondsBelowBitrate": 4.06,
+      "sustainable": true
+     },
+     "playbackWallMs": 30106.8,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "dc90fbf4517651e76aca1b4c57f43ec37a25a92bdc1fd9294e806c2228ca39aa"
+      },
+      {
+       "start": 10583831548,
+       "bytes": 2000000,
+       "sha256": "911ad58d080637c505d2d3a768a6bb31ea30f3c4ee925cdb7ecc5003d10e7c2d"
+      },
+      {
+       "start": 21167663096,
+       "bytes": 2000000,
+       "sha256": "3a59d97512411e4b8a542cbf88a7af356b2916175b792ec5e6c2bfe2aeff3b5b"
+      }
+     ],
+     "integrityWallMs": 973.3,
+     "status": "ok",
+     "wallMs": 77065.8,
+     "cpuSeconds": 25.87,
+     "rssPeakBytes": 874479616,
+     "rssMeanBytes": 710734090,
+     "cpuShape": {
+      "intervals": 76,
+      "maxCores": 0.57,
+      "p95Cores": 0.48,
+      "medianCores": 0.36,
+      "busyFraction": 0.86
+     },
+     "deliveredBytes": 461504512,
+     "cpuSecondsPerGB": 60.19
+    },
+    {
+     "id": "7z-split-tardes",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 4370,
+     "target": {
+      "fileName": "Tardes.De.Soledad.2024.SPANiSH.1080p.BluRay.x264-USENETHD.mkv",
+      "sizeBytes": 19222688752
+     },
+     "coldOpen": {
+      "headerMs": 58.94,
+      "ttfbMs": 59,
+      "bytes": 1048576,
+      "status": 206
+     },
+     "coldOpenWallMs": 66.9,
+     "probe": {
+      "totalBytes": 19222688752,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 48.62
+     },
+     "probeWallMs": 48.7,
+     "sizeBytes": 19222688752,
+     "warmOpen": {
+      "headerMs": 47.29,
+      "ttfbMs": 47.34,
+      "bytes": 1015808,
+      "status": 206
+     },
+     "warmOpenWallMs": 54.1,
+     "sequential": {
+      "ttfbMs": 48.94,
+      "bytes": 211517440,
+      "durationMs": 30017.84,
+      "meanMBps": 7.058,
+      "p50MBps": 7.287,
+      "p05MBps": 3.947,
+      "maxMBps": 9.16,
+      "reliable": true
+     },
+     "sequentialWallMs": 30018.5,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 192226887,
+        "ttfbMs": 125.46,
+        "headerMs": 125.41,
+        "bytes": 8028160,
+        "throughputMBps": 152.115,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 4805672188,
+        "ttfbMs": 399.19,
+        "headerMs": 399.01,
+        "bytes": 8028160,
+        "throughputMBps": 7.884,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 9611344376,
+        "ttfbMs": 297.48,
+        "headerMs": 297.4,
+        "bytes": 8028160,
+        "throughputMBps": 7.893,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 14417016564,
+        "ttfbMs": 248.82,
+        "headerMs": 248.64,
+        "bytes": 8028160,
+        "throughputMBps": 8.006,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 18261554314,
+        "ttfbMs": 432.2,
+        "headerMs": 432,
+        "bytes": 8028160,
+        "throughputMBps": 8.416,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1922268875,
+       "ttfbMs": 417.31,
+       "throughputMBps": 7.801
+      },
+      "medianTtfbMs": 297.48,
+      "worstTtfbMs": 432.2,
+      "failures": 0
+     },
+     "seeksWallMs": 6995.6,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 5766806625,
+      "ttfbMs": 267.48,
+      "bytes": 206766080,
+      "durationMs": 30012.02,
+      "meanMBps": 6.951,
+      "p05MBps": 5.307,
+      "timeToBufferMs": 4659,
+      "secondsBelowBitrate": 2.77,
+      "sustainable": true
+     },
+     "playbackWallMs": 30012.8,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "676926b1cace4d63b9055ee16516ed2e86ababef4e6b3807d5e2529fe33fa4da"
+      },
+      {
+       "start": 9610344376,
+       "bytes": 2000000,
+       "sha256": "3037000cc41414ff7c6fa8f1ae5b95ca1a797239cde68dca8394bc5ce9f152e5"
+      },
+      {
+       "start": 19220688752,
+       "bytes": 2000000,
+       "sha256": "441fa0ef78afac308dd1fee5b4c5bac65486f670997aed25a54daafcb8e3f024"
+      }
+     ],
+     "integrityWallMs": 1050.8,
+     "status": "ok",
+     "wallMs": 72617.6,
+     "cpuSeconds": 24.23,
+     "rssPeakBytes": 544374784,
+     "rssMeanBytes": 529454795,
+     "cpuShape": {
+      "intervals": 72,
+      "maxCores": 0.62,
+      "p95Cores": 0.46,
+      "medianCores": 0.35,
+      "busyFraction": 0.89
+     },
+     "deliveredBytes": 420347904,
+     "cpuSecondsPerGB": 61.89
+    },
+    {
+     "id": "damaged-partial",
+     "tier": "failure",
+     "axes": [
+      "direct-video",
+      "missing-articles"
+     ],
+     "expect": "serve",
+     "importMs": 629.7,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6818028645
+     },
+     "coldOpen": {
+      "headerMs": 20.76,
+      "ttfbMs": 20.95,
+      "bytes": 1048267,
+      "status": 206
+     },
+     "coldOpenWallMs": 22.8,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 10.48
+     },
+     "probeWallMs": 10.7,
+     "sizeBytes": 6818028645,
+     "warmOpen": {
+      "headerMs": 8.52,
+      "ttfbMs": 8.56,
+      "bytes": 1048267,
+      "status": 206
+     },
+     "warmOpenWallMs": 9.2,
+     "sequential": {
+      "error": "terminated"
+     },
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 68180286,
+        "ttfbMs": 19.22,
+        "headerMs": 18.94,
+        "bytes": 8060612,
+        "throughputMBps": 746.621,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1704507161,
+        "ttfbMs": 704.15,
+        "headerMs": 703.97,
+        "bytes": 8060928,
+        "throughputMBps": 11.982,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3409014322,
+        "ttfbMs": 529.7,
+        "headerMs": 529.54,
+        "bytes": 8028160,
+        "throughputMBps": 19.044,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 5113521483,
+        "ttfbMs": 621,
+        "headerMs": 620.86,
+        "bytes": 8028160,
+        "throughputMBps": 15.55,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6477127212,
+        "ttfbMs": 381.65,
+        "headerMs": 381.53,
+        "bytes": 8028160,
+        "throughputMBps": 10.72,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 681802864,
+       "ttfbMs": 317.61,
+       "throughputMBps": 16.163
+      },
+      "medianTtfbMs": 529.7,
+      "worstTtfbMs": 704.15,
+      "failures": 0
+     },
+     "seeksWallMs": 5441.1,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 2045408593,
+      "ttfbMs": 785.43,
+      "bytes": 2006351872,
+      "durationMs": 31010.86,
+      "meanMBps": 66.38,
+      "p05MBps": 10.491,
+      "timeToBufferMs": 1583,
+      "secondsBelowBitrate": 0.54,
+      "sustainable": true
+     },
+     "playbackWallMs": 31011.3,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3408014322,
+       "bytes": 2000000,
+       "sha256": "44c2e44fa185cf6e8fbeb0e8eefbbf082e3f28f1487322a7448f40925673c8d0"
+      },
+      {
+       "start": 6816028645,
+       "error": "HTTP 416 for http://127.0.0.1:50339/v0/store/newz/stream/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdHJlbXRocnUiLCJzdWIiOiJiZW5jaCIsImV4cCI6MTc4ODY2MjM5OCwiZGF0YSI6eyJlbmNfbGluayI6ImNVelN3Ly9xTVlFMjEzL1hEOU9lTXpOTU1kVUpQdUpYbStacmNFcUh4WlE4c09SUkZoUHJEbm56NHRGcXlWVlVvYXdGNFRNbDFPelFKTFdVRENBZ3YzL3h3bDF4dXZBMHNSOENCSVNjRW5EcVFlNWtPQ29PaWc2Tm4vZ2hvMDRKMUkyZmROTjgvc0ZjS1NUUHd2eHdnZTlBUkVqOTlGUzd6a1Q1YUNLeEt5Ny9VcTJmV2JSU1lma29OaUFuTFc0S05BbTg2OUZnMTF4aTBXOHhlVG10MFoxYzNlcFN0eFlLUjBZNTlRMEhUcjVxVngvbiIsImVuY19mb3JtYXQiOiJBRVMtR0NNLTI1NiJ9fQ.yrcigAzI8yMkJ0DVQtS7mC53dtYu2-dLx3hB_2tEZkg/Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv: invalid range: failed to overlap\n"
+      }
+     ],
+     "integrityWallMs": 59.2,
+     "status": "ok",
+     "wallMs": 39110.9,
+     "cpuSeconds": 13.07,
+     "rssPeakBytes": 840056832,
+     "rssMeanBytes": 754599148,
+     "cpuShape": {
+      "intervals": 38,
+      "maxCores": 0.53,
+      "p95Cores": 0.51,
+      "medianCores": 0.36,
+      "busyFraction": 0.82
+     },
+     "deliveredBytes": 2008448406,
+     "cpuSecondsPerGB": 6.99
+    }
+   ],
+   "prepareMs": 15.8,
+   "buildReused": true,
+   "buildStamp": "stremthru@73bf362",
+   "startupMs": 558.7,
+   "version": {
+    "version": "73bf362"
+   },
+   "port": 50339,
+   "pids": [
+    9541
+   ],
+   "idle": {
+    "samples": 10,
+    "cpuSeconds": 0.12,
+    "rssPeakBytes": 133791744,
+    "rssMedianBytes": 77201408,
+    "rssMeanBytes": 82806374,
+    "maxProcesses": 1
+   },
+   "resourcesMeasured": true,
+   "resourceSource": "host",
+   "resources": {
+    "samples": 524,
+    "cpuSeconds": 175.07,
+    "rssPeakBytes": 957480960,
+    "rssMedianBytes": 702103552,
+    "rssMeanBytes": 689763242,
+    "maxProcesses": 1
+   },
+   "idleAfter": {
+    "samples": 45,
+    "cpuSeconds": 175.38,
+    "rssPeakBytes": 739000320,
+    "rssMedianBytes": 717553664,
+    "rssMeanBytes": 718029892,
+    "maxProcesses": 1
+   },
+   "status": "ok",
+   "finishedAt": "2026-09-05T14:41:22.687Z"
+  },
+  {
+   "app": "infinidysk",
+   "displayName": "InfiniDysk",
+   "language": "C# (.NET 10)",
+   "repo": "https://github.com/infinidysk/infinidysk",
+   "serving": "webdav",
+   "runtime": "docker",
+   "startedAt": "2026-09-05T14:41:37.698Z",
+   "items": [
+    {
+     "id": "rar4-small",
+     "tier": "smoke",
+     "axes": [
+      "rar4",
+      "stored",
+      "named-volumes",
+      "partNN"
+     ],
+     "expect": "serve",
+     "importMs": 24498.7,
+     "target": {
+      "fileName": "rar4-small.mp4",
+      "sizeBytes": 321905886
+     },
+     "coldOpen": {
+      "headerMs": 77.17,
+      "ttfbMs": 77.24,
+      "bytes": 1006459,
+      "status": 206
+     },
+     "coldOpenWallMs": 241.1,
+     "probe": {
+      "totalBytes": 321905886,
+      "rangeSupported": true,
+      "contentType": "video/mp4",
+      "firstByteMs": 119.58
+     },
+     "probeWallMs": 119.8,
+     "sizeBytes": 321905886,
+     "warmOpen": {
+      "headerMs": 48.68,
+      "ttfbMs": 48.77,
+      "bytes": 1030011,
+      "status": 206
+     },
+     "warmOpenWallMs": 176.5,
+     "sequential": {
+      "ttfbMs": 76.55,
+      "bytes": 256026291,
+      "durationMs": 12410.44,
+      "meanMBps": 20.758,
+      "p50MBps": 30.835,
+      "p05MBps": 1.824,
+      "maxMBps": 63.937,
+      "reliable": true
+     },
+     "sequentialWallMs": 12410.7,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 3219058,
+        "ttfbMs": 50.91,
+        "headerMs": 50.82,
+        "bytes": 8007945,
+        "throughputMBps": 34.921,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 80476471,
+        "ttfbMs": 64.08,
+        "headerMs": 64.02,
+        "bytes": 8017938,
+        "throughputMBps": 36.874,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 160952943,
+        "ttfbMs": 47.58,
+        "headerMs": 47.52,
+        "bytes": 8047503,
+        "throughputMBps": 26.152,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 241429414,
+        "ttfbMs": 49.68,
+        "headerMs": 49.62,
+        "bytes": 8027917,
+        "throughputMBps": 32.473,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 305810591,
+        "ttfbMs": 59.12,
+        "headerMs": 59.06,
+        "bytes": 8029154,
+        "throughputMBps": 17.653,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 32190588,
+       "ttfbMs": 225.75,
+       "throughputMBps": 75.211
+      },
+      "medianTtfbMs": 50.91,
+      "worstTtfbMs": 64.08,
+      "failures": 0
+     },
+     "seeksWallMs": 2060.7,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 96571765,
+      "ttfbMs": 4.94,
+      "bytes": 225334121,
+      "durationMs": 3442.09,
+      "meanMBps": 65.558,
+      "p05MBps": 40.294,
+      "timeToBufferMs": 548,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 3442.4,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "518f4aeb3bdec36905cd82df6113512a9a4919a4fb9c031b789ba4df0034648c"
+      },
+      {
+       "start": 159952943,
+       "bytes": 2000000,
+       "sha256": "cb37e4294880844c4a5d3db895c0ac91a2331fb5bae255f5920184bb8f88d7b6"
+      },
+      {
+       "start": 319905886,
+       "bytes": 2000000,
+       "sha256": "80c39132e3e0dcd3646f6e170c128794169c97e70eca1ebb1af581ed626ee43c"
+      }
+     ],
+     "integrityWallMs": 1086.5,
+     "status": "ok",
+     "wallMs": 44036.5,
+     "cpuSeconds": null,
+     "deliveredBytes": 483396882,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "plain-medium",
+     "tier": "smoke",
+     "axes": [
+      "direct-video",
+      "no-archive",
+      "per-file-unique-stems"
+     ],
+     "expect": "serve",
+     "importMs": 1092.2,
+     "target": {
+      "fileName": "plain-medium.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 61.76,
+      "ttfbMs": 61.8,
+      "bytes": 1010454,
+      "status": 206
+     },
+     "coldOpenWallMs": 139.2,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 1369.89
+     },
+     "probeWallMs": 1370,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 81.28,
+      "ttfbMs": 81.34,
+      "bytes": 1016364,
+      "status": 206
+     },
+     "warmOpenWallMs": 144.1,
+     "sequential": {
+      "ttfbMs": 730.86,
+      "bytes": 256016384,
+      "durationMs": 8461.28,
+      "meanMBps": 33.118,
+      "p50MBps": 8.733,
+      "p05MBps": 2.711,
+      "maxMBps": 91.654,
+      "reliable": true
+     },
+     "sequentialWallMs": 8461.5,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 415.54,
+        "headerMs": 415.41,
+        "bytes": 8031275,
+        "throughputMBps": 6.634,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 359.16,
+        "headerMs": 359.09,
+        "bytes": 8007721,
+        "throughputMBps": 10.122,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 1139.1,
+        "headerMs": 1138.98,
+        "bytes": 8052818,
+        "throughputMBps": 3.032,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 718.09,
+        "headerMs": 718.01,
+        "bytes": 8032379,
+        "throughputMBps": 1.48,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 1208.52,
+        "headerMs": 1208.41,
+        "bytes": 8029135,
+        "throughputMBps": 5.938,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 223.89,
+       "throughputMBps": 25.171
+      },
+      "medianTtfbMs": 718.09,
+      "worstTtfbMs": 1208.52,
+      "failures": 0
+     },
+     "seeksWallMs": 15821.8,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 256.77,
+      "bytes": 1913842942,
+      "durationMs": 30357.33,
+      "meanMBps": 63.582,
+      "p05MBps": 1.603,
+      "timeToBufferMs": 3212,
+      "secondsBelowBitrate": 6.33,
+      "sustainable": true
+     },
+     "playbackWallMs": 30357.7,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 2908.8,
+     "status": "ok",
+     "wallMs": 60295.5,
+     "cpuSeconds": null,
+     "deliveredBytes": 2171886144,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "obfuscated-direct",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "obfuscated-names",
+      "extensionless"
+     ],
+     "expect": "serve",
+     "importMs": 1207.7,
+     "target": {
+      "fileName": "obfuscated-direct.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 66.69,
+      "ttfbMs": 66.72,
+      "bytes": 1024285,
+      "status": 206
+     },
+     "coldOpenWallMs": 165.4,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 1035.99
+     },
+     "probeWallMs": 1036.1,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 374.28,
+      "ttfbMs": 374.36,
+      "bytes": 1011446,
+      "status": 206
+     },
+     "warmOpenWallMs": 458.4,
+     "sequential": {
+      "ttfbMs": 211.83,
+      "bytes": 256049152,
+      "durationMs": 10322.19,
+      "meanMBps": 25.325,
+      "p50MBps": 16.09,
+      "p05MBps": 1.646,
+      "maxMBps": 77.658,
+      "reliable": true
+     },
+     "sequentialWallMs": 10322.4,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 352.27,
+        "headerMs": 352.13,
+        "bytes": 8031275,
+        "throughputMBps": 7.647,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 736.12,
+        "headerMs": 735.96,
+        "bytes": 8007721,
+        "throughputMBps": 2.485,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 651.79,
+        "headerMs": 651.67,
+        "bytes": 8020050,
+        "throughputMBps": 11.834,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 485.51,
+        "headerMs": 485.44,
+        "bytes": 8032379,
+        "throughputMBps": 10.913,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 1607.13,
+        "headerMs": 1606.99,
+        "bytes": 8029135,
+        "throughputMBps": 10.594,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 1206.68,
+       "throughputMBps": 10.019
+      },
+      "medianTtfbMs": 651.79,
+      "worstTtfbMs": 1607.13,
+      "failures": 0
+     },
+     "seeksWallMs": 12285.1,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 150.32,
+      "bytes": 2855267582,
+      "durationMs": 30000.68,
+      "meanMBps": 95.653,
+      "p05MBps": 3.372,
+      "timeToBufferMs": 5147,
+      "secondsBelowBitrate": 2.83,
+      "sustainable": true
+     },
+     "playbackWallMs": 30000.8,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 1271,
+     "status": "ok",
+     "wallMs": 56747.1,
+     "cpuSeconds": null,
+     "deliveredBytes": 3113352465,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "plain-large",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "no-archive"
+     ],
+     "expect": "serve",
+     "importMs": 1081.9,
+     "target": {
+      "fileName": "plain-large.mkv",
+      "sizeBytes": 15076905867
+     },
+     "coldOpen": {
+      "headerMs": 84.35,
+      "ttfbMs": 84.42,
+      "bytes": 1019677,
+      "status": 206
+     },
+     "coldOpenWallMs": 127.7,
+     "probe": {
+      "totalBytes": 15076905867,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 59.53
+     },
+     "probeWallMs": 59.7,
+     "sizeBytes": 15076905867,
+     "warmOpen": {
+      "headerMs": 45.88,
+      "ttfbMs": 45.94,
+      "bytes": 1013645,
+      "status": 206
+     },
+     "warmOpenWallMs": 82.9,
+     "sequential": {
+      "ttfbMs": 3760.1,
+      "bytes": 256049152,
+      "durationMs": 13049.79,
+      "meanMBps": 27.563,
+      "p50MBps": 34.5,
+      "p05MBps": 0.357,
+      "maxMBps": 152.526,
+      "reliable": true
+     },
+     "sequentialWallMs": 13050,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 150769058,
+        "ttfbMs": 611.06,
+        "headerMs": 610.97,
+        "bytes": 8024670,
+        "throughputMBps": 15.095,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 3769226466,
+        "ttfbMs": 347.92,
+        "headerMs": 347.82,
+        "bytes": 8006430,
+        "throughputMBps": 7.898,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 7538452933,
+        "ttfbMs": 230.38,
+        "headerMs": 230.29,
+        "bytes": 8017467,
+        "throughputMBps": 7.84,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 11307679400,
+        "ttfbMs": 1970.3,
+        "headerMs": 1970.23,
+        "bytes": 8028504,
+        "throughputMBps": 11.789,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 14323060573,
+        "ttfbMs": 1186.66,
+        "headerMs": 1186.54,
+        "bytes": 8024227,
+        "throughputMBps": 6.449,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1507690586,
+       "ttfbMs": 568.97,
+       "throughputMBps": 4.028
+      },
+      "medianTtfbMs": 611.06,
+      "worstTtfbMs": 1970.3,
+      "failures": 0
+     },
+     "seeksWallMs": 11401.4,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 4523071760,
+      "ttfbMs": 239.07,
+      "bytes": 2276288240,
+      "durationMs": 30000.93,
+      "meanMBps": 76.483,
+      "p05MBps": 11.134,
+      "timeToBufferMs": 3498,
+      "secondsBelowBitrate": 0.97,
+      "sustainable": true
+     },
+     "playbackWallMs": 30001.2,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "f9f305fa3fbc944f62df43ac8c3452bb25fd5d81f018ff874658b5004c8319d1"
+      },
+      {
+       "start": 7537452933,
+       "bytes": 2000000,
+       "sha256": "5551953b14d1450b51a7914a813f0ae27582f40aed6090f9a9a08742f3084e2d"
+      },
+      {
+       "start": 15074905867,
+       "bytes": 2000000,
+       "sha256": "98fdc11b40dbe71e4bf96844181a32f8573cd2b7058f16cf66702a1ff20aea6b"
+      }
+     ],
+     "integrityWallMs": 855.2,
+     "status": "ok",
+     "wallMs": 56660.1,
+     "cpuSeconds": null,
+     "deliveredBytes": 2534370714,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "plain-season-pack",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "season-pack",
+      "file-selection"
+     ],
+     "expect": "serve",
+     "importMs": 2435.1,
+     "target": {
+      "fileName": "Bosch.S01E01.2015.1080p.Amazon.WEB-DL.AVC.DDP.5.1-DBTV.mkv",
+      "sizeBytes": 2210528776
+     },
+     "coldOpen": {
+      "headerMs": 50.16,
+      "ttfbMs": 50.21,
+      "bytes": 1011712,
+      "status": 206
+     },
+     "coldOpenWallMs": 200.9,
+     "probe": {
+      "totalBytes": 2210528776,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 133.03
+     },
+     "probeWallMs": 133.2,
+     "sizeBytes": 2210528776,
+     "warmOpen": {
+      "headerMs": 66.02,
+      "ttfbMs": 66.07,
+      "bytes": 1011712,
+      "status": 206
+     },
+     "warmOpenWallMs": 157.5,
+     "sequential": {
+      "ttfbMs": 131.07,
+      "bytes": 256016384,
+      "durationMs": 3580.01,
+      "meanMBps": 74.23,
+      "p50MBps": 77.607,
+      "p05MBps": 30.692,
+      "maxMBps": 106.961,
+      "reliable": true
+     },
+     "sequentialWallMs": 3580.4,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 22105287,
+        "ttfbMs": 8.23,
+        "headerMs": 8.15,
+        "bytes": 8028160,
+        "throughputMBps": 237.459,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 552632194,
+        "ttfbMs": 149.33,
+        "headerMs": 149.29,
+        "bytes": 8003710,
+        "throughputMBps": 20.581,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 1105264388,
+        "ttfbMs": 162.31,
+        "headerMs": 162.27,
+        "bytes": 8057084,
+        "throughputMBps": 20.054,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 1657896582,
+        "ttfbMs": 103.48,
+        "headerMs": 103.42,
+        "bytes": 8012154,
+        "throughputMBps": 22.22,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 2100002337,
+        "ttfbMs": 124.62,
+        "headerMs": 124.48,
+        "bytes": 8008159,
+        "throughputMBps": 10.832,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 221052877,
+       "ttfbMs": 66.06,
+       "throughputMBps": 34.227
+      },
+      "medianTtfbMs": 124.62,
+      "worstTtfbMs": 162.31,
+      "failures": 0
+     },
+     "seeksWallMs": 2773.5,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 663158632,
+      "ttfbMs": 112.41,
+      "bytes": 1547370144,
+      "durationMs": 11933.56,
+      "meanMBps": 130.899,
+      "p05MBps": 81.082,
+      "timeToBufferMs": 800,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 11933.9,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "c3d52b715e7f6ee76f5a1c103a31853d440f1e96341ff2170ca66646a105f452"
+      },
+      {
+       "start": 1104264388,
+       "bytes": 2000000,
+       "sha256": "9e6e73cef2032c61a18d91b1f4d869f69f33e473b43d21d1fb9f1c7d69c9f09e"
+      },
+      {
+       "start": 2208528776,
+       "bytes": 2000000,
+       "sha256": "01b4b848c553ad2ae59b7bab78a02762acfede9b41415de494e5907413a9881f"
+      }
+     ],
+     "integrityWallMs": 946.1,
+     "status": "ok",
+     "wallMs": 22160.5,
+     "cpuSeconds": null,
+     "deliveredBytes": 1805409952,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar4-rNN",
+     "tier": "core",
+     "axes": [
+      "rar4",
+      "stored",
+      "rar+rNN",
+      "letter-rollover"
+     ],
+     "expect": "serve",
+     "importMs": 3190.5,
+     "target": {
+      "fileName": "rar4-rNN.mkv",
+      "sizeBytes": 5882124203
+     },
+     "coldOpen": {
+      "headerMs": 53.02,
+      "ttfbMs": 53.09,
+      "bytes": 1029974,
+      "status": 206
+     },
+     "coldOpenWallMs": 116.3,
+     "probe": {
+      "totalBytes": 5882124203,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 75.5
+     },
+     "probeWallMs": 75.6,
+     "sizeBytes": 5882124203,
+     "warmOpen": {
+      "headerMs": 95.98,
+      "ttfbMs": 96.03,
+      "bytes": 1019822,
+      "status": 206
+     },
+     "warmOpenWallMs": 233.2,
+     "sequential": {
+      "ttfbMs": 129.15,
+      "bytes": 256016382,
+      "durationMs": 4902.88,
+      "meanMBps": 53.63,
+      "p50MBps": 52.157,
+      "p05MBps": 7.735,
+      "maxMBps": 94.764,
+      "reliable": true
+     },
+     "sequentialWallMs": 4903.1,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 58821242,
+        "ttfbMs": 101.85,
+        "headerMs": 101.79,
+        "bytes": 8017158,
+        "throughputMBps": 10.476,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1470531050,
+        "ttfbMs": 81.89,
+        "headerMs": 81.78,
+        "bytes": 8031748,
+        "throughputMBps": 7.826,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 2941062101,
+        "ttfbMs": 787.66,
+        "headerMs": 787.46,
+        "bytes": 8031409,
+        "throughputMBps": 7.784,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4411593152,
+        "ttfbMs": 195,
+        "headerMs": 194.79,
+        "bytes": 8057694,
+        "throughputMBps": 13.921,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 5588017992,
+        "ttfbMs": 54.49,
+        "headerMs": 54.39,
+        "bytes": 8007068,
+        "throughputMBps": 29.975,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 588212420,
+       "ttfbMs": 96.54,
+       "throughputMBps": 25.381
+      },
+      "medianTtfbMs": 101.85,
+      "worstTtfbMs": 787.66,
+      "failures": 0
+     },
+     "seeksWallMs": 5302.6,
+     "playback": {
+      "error": "terminated"
+     },
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "652f1b7a97f8dee12621e5d2c483f33bff7c19d5c8f59fe8a9438bc6581e8c88"
+      },
+      {
+       "start": 2940062101,
+       "bytes": 2000000,
+       "sha256": "58b9cf1d866e3b51cdba10ae584acd95b302c53135d8e929e467214fb16154b9"
+      },
+      {
+       "start": 5880124203,
+       "bytes": 2000000,
+       "sha256": "c3c2d6e2dfb3d4ea8c46f74b8579349829e42c7fdbddc101f5bfe992550c4e07"
+      }
+     ],
+     "integrityWallMs": 881.8,
+     "status": "ok",
+     "wallMs": 21759.1,
+     "cpuSeconds": null,
+     "deliveredBytes": 258066178,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-hdrenc-small",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "status": "failed",
+     "error": "import failed: Article with message-id SbVwZiPuDtFfMaMhFpIeNrFf-1737036699496@nyuu not found.",
+     "wallMs": 4264.8,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-hdrenc-large",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 5446.6,
+     "target": {
+      "fileName": "rar-hdrenc-large.mkv",
+      "sizeBytes": 17174121367
+     },
+     "coldOpen": {
+      "headerMs": 581.04,
+      "ttfbMs": 581.14,
+      "bytes": 1015493,
+      "status": 206
+     },
+     "coldOpenWallMs": 588.9,
+     "probe": {
+      "totalBytes": 17174121367,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 257.9
+     },
+     "probeWallMs": 258,
+     "sizeBytes": 17174121367,
+     "warmOpen": {
+      "headerMs": 312.04,
+      "ttfbMs": 312.13,
+      "bytes": 1015493,
+      "status": 206
+     },
+     "warmOpenWallMs": 322.9,
+     "sequential": {
+      "ttfbMs": 269.29,
+      "bytes": 256016384,
+      "durationMs": 3712.99,
+      "meanMBps": 74.343,
+      "p50MBps": 52.754,
+      "p05MBps": 10.632,
+      "maxMBps": 147.52,
+      "reliable": true
+     },
+     "sequentialWallMs": 3713.2,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 171741213,
+        "ttfbMs": 82.55,
+        "headerMs": 82.49,
+        "bytes": 8028160,
+        "throughputMBps": 24.681,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 4293530341,
+        "ttfbMs": 116.93,
+        "headerMs": 116.86,
+        "bytes": 8028160,
+        "throughputMBps": 13.065,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 8587060683,
+        "ttfbMs": 259.93,
+        "headerMs": 259.85,
+        "bytes": 8060928,
+        "throughputMBps": 10.782,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 12880591025,
+        "ttfbMs": 217.16,
+        "headerMs": 216.98,
+        "bytes": 8028160,
+        "throughputMBps": 20.3,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 16315415298,
+        "ttfbMs": 135.7,
+        "headerMs": 135.62,
+        "bytes": 8028160,
+        "throughputMBps": 16.065,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1717412136,
+       "ttfbMs": 92.97,
+       "throughputMBps": 13.812
+      },
+      "medianTtfbMs": 135.7,
+      "worstTtfbMs": 259.93,
+      "failures": 0
+     },
+     "seeksWallMs": 4069.9,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 5152236410,
+      "ttfbMs": 79.67,
+      "bytes": 3030024192,
+      "durationMs": 30053.7,
+      "meanMBps": 101.088,
+      "p05MBps": 34.108,
+      "timeToBufferMs": 1084,
+      "secondsBelowBitrate": 1.4,
+      "sustainable": true
+     },
+     "playbackWallMs": 30054,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "ca5f5f5d72bc03c73ec554b87f09293056cc64f898d9ba0c6009c0f31cf92035"
+      },
+      {
+       "start": 8586060683,
+       "bytes": 2000000,
+       "sha256": "ed802261f0ff5ea16496bbf3e08828cab7d130093e0b0bd504b5e93ccf9fac78"
+      },
+      {
+       "start": 17172121367,
+       "bytes": 2000000,
+       "sha256": "2cf8c04c6895c85ab6c884ddaea22a03d619822747aa358a1e9d975709bcecc3"
+      }
+     ],
+     "integrityWallMs": 989.2,
+     "status": "ok",
+     "wallMs": 45442.8,
+     "cpuSeconds": null,
+     "deliveredBytes": 3288071562,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-large",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "import failed: Missing articles: 1 important file(s) have missing segments across all providers (e.g. XEQWzFs0v7WfZnBBzUxZ.part04.rar). NZB is likely DMCA'd or expired.",
+     "wallMs": 1358.7,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-maestras",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "import failed: Missing articles: 1 important file(s) have missing segments across all providers (e.g. Su7pfShZJ0uazNFfv70sB3.part04.rar). NZB is likely DMCA'd or expired.",
+     "wallMs": 1310.1,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-satans",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "import failed: Missing articles: 1 important file(s) have missing segments across all providers (e.g. rEN8svtCcJjJ74Q4qpvJf1K8A.part01.rar). NZB is likely DMCA'd or expired.",
+     "wallMs": 2298.9,
+     "cpuSeconds": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "7z-split-bugonia",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 16142.5,
+     "target": {
+      "fileName": "7z-split-bugonia.mkv",
+      "sizeBytes": 21169663096
+     },
+     "coldOpen": {
+      "headerMs": 126.31,
+      "ttfbMs": 126.37,
+      "bytes": 1015808,
+      "status": 206
+     },
+     "coldOpenWallMs": 134.1,
+     "probe": {
+      "totalBytes": 21169663096,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 274.84
+     },
+     "probeWallMs": 275,
+     "sizeBytes": 21169663096,
+     "warmOpen": {
+      "headerMs": 311.35,
+      "ttfbMs": 311.42,
+      "bytes": 1015808,
+      "status": 206
+     },
+     "warmOpenWallMs": 319.2,
+     "sequential": {
+      "ttfbMs": 410.86,
+      "bytes": 256016384,
+      "durationMs": 3462.81,
+      "meanMBps": 83.886,
+      "p50MBps": 79.729,
+      "p05MBps": 34.839,
+      "maxMBps": 126.627,
+      "reliable": true
+     },
+     "sequentialWallMs": 3463,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 211696630,
+        "ttfbMs": 97.22,
+        "headerMs": 97.17,
+        "bytes": 8028160,
+        "throughputMBps": 13.459,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 5292415774,
+        "ttfbMs": 133.17,
+        "headerMs": 133.11,
+        "bytes": 8028160,
+        "throughputMBps": 21.392,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 10584831548,
+        "ttfbMs": 53.74,
+        "headerMs": 53.66,
+        "bytes": 8028160,
+        "throughputMBps": 16.297,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 15877247322,
+        "ttfbMs": 136.95,
+        "headerMs": 136.87,
+        "bytes": 8028160,
+        "throughputMBps": 28.064,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 20111179941,
+        "ttfbMs": 138.52,
+        "headerMs": 138.45,
+        "bytes": 8028160,
+        "throughputMBps": 11.886,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 2116966309,
+       "ttfbMs": 117.6,
+       "throughputMBps": 26.988
+      },
+      "medianTtfbMs": 133.17,
+      "worstTtfbMs": 138.52,
+      "failures": 0
+     },
+     "seeksWallMs": 3400.9,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 6350898928,
+      "ttfbMs": 127.94,
+      "bytes": 3555328000,
+      "durationMs": 30000.83,
+      "meanMBps": 119.015,
+      "p05MBps": 43.708,
+      "timeToBufferMs": 1047,
+      "secondsBelowBitrate": 1.47,
+      "sustainable": true
+     },
+     "playbackWallMs": 30001.1,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "dc90fbf4517651e76aca1b4c57f43ec37a25a92bdc1fd9294e806c2228ca39aa"
+      },
+      {
+       "start": 10583831548,
+       "bytes": 2000000,
+       "sha256": "911ad58d080637c505d2d3a768a6bb31ea30f3c4ee925cdb7ecc5003d10e7c2d"
+      },
+      {
+       "start": 21167663096,
+       "bytes": 2000000,
+       "sha256": "3a59d97512411e4b8a542cbf88a7af356b2916175b792ec5e6c2bfe2aeff3b5b"
+      }
+     ],
+     "integrityWallMs": 767.9,
+     "status": "ok",
+     "wallMs": 54503.8,
+     "cpuSeconds": null,
+     "deliveredBytes": 3813376000,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "7z-split-tardes",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 9432,
+     "target": {
+      "fileName": "7z-split-tardes.mkv",
+      "sizeBytes": 19222688752
+     },
+     "coldOpen": {
+      "headerMs": 132.8,
+      "ttfbMs": 132.87,
+      "bytes": 1015808,
+      "status": 206
+     },
+     "coldOpenWallMs": 139.6,
+     "probe": {
+      "totalBytes": 19222688752,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 359.44
+     },
+     "probeWallMs": 359.6,
+     "sizeBytes": 19222688752,
+     "warmOpen": {
+      "headerMs": 265.52,
+      "ttfbMs": 265.64,
+      "bytes": 1015808,
+      "status": 206
+     },
+     "warmOpenWallMs": 271.3,
+     "sequential": {
+      "ttfbMs": 450.07,
+      "bytes": 256016384,
+      "durationMs": 3373.32,
+      "meanMBps": 87.58,
+      "p50MBps": 80.977,
+      "p05MBps": 29.189,
+      "maxMBps": 119.696,
+      "reliable": true
+     },
+     "sequentialWallMs": 3373.6,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 192226887,
+        "ttfbMs": 65.07,
+        "headerMs": 64.98,
+        "bytes": 8028160,
+        "throughputMBps": 6.225,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 4805672188,
+        "ttfbMs": 85.99,
+        "headerMs": 85.93,
+        "bytes": 8028160,
+        "throughputMBps": 20.019,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 9611344376,
+        "ttfbMs": 82.02,
+        "headerMs": 81.95,
+        "bytes": 8028160,
+        "throughputMBps": 18.446,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 14417016564,
+        "ttfbMs": 110.28,
+        "headerMs": 110.21,
+        "bytes": 8028160,
+        "throughputMBps": 24.701,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 18261554314,
+        "ttfbMs": 213.8,
+        "headerMs": 213.73,
+        "bytes": 8028160,
+        "throughputMBps": 14.806,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1922268875,
+       "ttfbMs": 403.51,
+       "throughputMBps": 25.686
+      },
+      "medianTtfbMs": 85.99,
+      "worstTtfbMs": 213.8,
+      "failures": 0
+     },
+     "seeksWallMs": 4266.8,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 5766806625,
+      "ttfbMs": 121.01,
+      "bytes": 3408461824,
+      "durationMs": 30042.1,
+      "meanMBps": 113.915,
+      "p05MBps": 50.67,
+      "timeToBufferMs": 907,
+      "secondsBelowBitrate": 0.48,
+      "sustainable": true
+     },
+     "playbackWallMs": 30042.4,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "676926b1cace4d63b9055ee16516ed2e86ababef4e6b3807d5e2529fe33fa4da"
+      },
+      {
+       "start": 9610344376,
+       "bytes": 2000000,
+       "sha256": "3037000cc41414ff7c6fa8f1ae5b95ca1a797239cde68dca8394bc5ce9f152e5"
+      },
+      {
+       "start": 19220688752,
+       "bytes": 2000000,
+       "sha256": "441fa0ef78afac308dd1fee5b4c5bac65486f670997aed25a54daafcb8e3f024"
+      }
+     ],
+     "integrityWallMs": 710.2,
+     "status": "ok",
+     "wallMs": 48595.5,
+     "cpuSeconds": null,
+     "deliveredBytes": 3666509824,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "damaged-partial",
+     "tier": "failure",
+     "axes": [
+      "direct-video",
+      "missing-articles"
+     ],
+     "expect": "serve",
+     "importMs": 1448.8,
+     "target": {
+      "fileName": "damaged-partial.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 75.2,
+      "ttfbMs": 75.26,
+      "bytes": 1036137,
+      "status": 206
+     },
+     "coldOpenWallMs": 219.7,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 1205.41
+     },
+     "probeWallMs": 1205.6,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 288.47,
+      "ttfbMs": 288.6,
+      "bytes": 1008536,
+      "status": 206
+     },
+     "warmOpenWallMs": 353.1,
+     "sequential": {
+      "ttfbMs": 159.9,
+      "bytes": 256016384,
+      "durationMs": 9111.09,
+      "meanMBps": 28.601,
+      "p50MBps": 18.072,
+      "p05MBps": 4.558,
+      "maxMBps": 68.313,
+      "reliable": true
+     },
+     "sequentialWallMs": 9111.3,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 338.97,
+        "headerMs": 338.9,
+        "bytes": 8031275,
+        "throughputMBps": 7.551,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 582.81,
+        "headerMs": 582.74,
+        "bytes": 8007721,
+        "throughputMBps": 9.834,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 849.8,
+        "headerMs": 849.73,
+        "bytes": 8020050,
+        "throughputMBps": 7.311,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 2589.98,
+        "headerMs": 2589.89,
+        "bytes": 8065147,
+        "throughputMBps": 2.523,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 521.28,
+        "headerMs": 521.2,
+        "bytes": 8029135,
+        "throughputMBps": 4.667,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 160.05,
+       "throughputMBps": 4.002
+      },
+      "medianTtfbMs": 582.81,
+      "worstTtfbMs": 2589.98,
+      "failures": 0
+     },
+     "seeksWallMs": 14941.2,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 619.46,
+      "bytes": 2018700542,
+      "durationMs": 31508.67,
+      "meanMBps": 65.353,
+      "p05MBps": 1.975,
+      "timeToBufferMs": 13854,
+      "secondsBelowBitrate": 13.01,
+      "sustainable": true
+     },
+     "playbackWallMs": 31509.1,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 1838.7,
+     "status": "ok",
+     "wallMs": 60627.5,
+     "cpuSeconds": null,
+     "deliveredBytes": 2276761599,
+     "cpuSecondsPerGB": null
+    }
+   ],
+   "prepareMs": 632.2,
+   "buildReused": true,
+   "buildStamp": "usenet-bench/infinidysk:2043c96",
+   "startupMs": 6323.4,
+   "version": {
+    "version": "dev"
+   },
+   "port": 53351,
+   "pids": [],
+   "idle": {
+    "samples": 0,
+    "cpuSeconds": 0,
+    "unavailable": true,
+    "source": "docker"
+   },
+   "resourcesMeasured": false,
+   "resourceSource": "docker",
+   "resources": {
+    "samples": 0,
+    "cpuSeconds": 0,
+    "unavailable": true,
+    "source": "docker"
+   },
+   "idleAfter": {
+    "samples": 0,
+    "cpuSeconds": 0,
+    "unavailable": true,
+    "source": "docker"
+   },
+   "status": "ok",
+   "finishedAt": "2026-09-05T14:50:35.150Z"
+  },
+  {
+   "app": "aiostreams",
+   "displayName": "AIOStreams",
+   "language": "TypeScript",
+   "repo": "https://github.com/Viren070/AIOStreams",
+   "serving": "http-range",
+   "runtime": "source",
+   "startedAt": "2026-09-05T14:50:50.157Z",
+   "items": [
+    {
+     "id": "rar4-small",
+     "tier": "smoke",
+     "axes": [
+      "rar4",
+      "stored",
+      "named-volumes",
+      "partNN"
+     ],
+     "expect": "serve",
+     "importMs": 1341.4,
+     "target": {
+      "fileName": "father.brown.2013.s02e05.hdtv.x264-tla.mp4",
+      "sizeBytes": 321905886
+     },
+     "coldOpen": {
+      "headerMs": 205.34,
+      "ttfbMs": 205.5,
+      "bytes": 1048576,
+      "status": 206
+     },
+     "coldOpenWallMs": 445,
+     "probe": {
+      "totalBytes": 321905886,
+      "rangeSupported": true,
+      "contentType": "video/mp4",
+      "firstByteMs": 6.61
+     },
+     "probeWallMs": 6.9,
+     "sizeBytes": 321905886,
+     "warmOpen": {
+      "headerMs": 3.54,
+      "ttfbMs": 3.67,
+      "bytes": 1022024,
+      "status": 206
+     },
+     "warmOpenWallMs": 6.2,
+     "sequential": {
+      "ttfbMs": 5.64,
+      "bytes": 256048944,
+      "durationMs": 4899.46,
+      "meanMBps": 52.321,
+      "p50MBps": 54.772,
+      "p05MBps": 18.945,
+      "maxMBps": 80.496,
+      "reliable": true
+     },
+     "sequentialWallMs": 4899.7,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 3219058,
+        "ttfbMs": 12.86,
+        "headerMs": 12.8,
+        "bytes": 8060928,
+        "throughputMBps": 683.373,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 80476471,
+        "ttfbMs": 9.26,
+        "headerMs": 9.2,
+        "bytes": 8060928,
+        "throughputMBps": 962.719,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 160952943,
+        "ttfbMs": 3.13,
+        "headerMs": 3.1,
+        "bytes": 8060928,
+        "throughputMBps": 960.783,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 241429414,
+        "ttfbMs": 4.82,
+        "headerMs": 4.74,
+        "bytes": 8060928,
+        "throughputMBps": 2273.994,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 305810591,
+        "ttfbMs": 91.5,
+        "headerMs": 91.47,
+        "bytes": 8060928,
+        "throughputMBps": 12.81,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 32190588,
+       "ttfbMs": 11.69,
+       "throughputMBps": 650.239
+      },
+      "medianTtfbMs": 9.26,
+      "worstTtfbMs": 91.5,
+      "failures": 0
+     },
+     "seeksWallMs": 807.5,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 96571765,
+      "ttfbMs": 4.67,
+      "bytes": 225334121,
+      "durationMs": 693.26,
+      "meanMBps": 327.242,
+      "p05MBps": null,
+      "timeToBufferMs": 289,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 693.4,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "518f4aeb3bdec36905cd82df6113512a9a4919a4fb9c031b789ba4df0034648c"
+      },
+      {
+       "start": 159952943,
+       "bytes": 2000000,
+       "sha256": "cb37e4294880844c4a5d3db895c0ac91a2331fb5bae255f5920184bb8f88d7b6"
+      },
+      {
+       "start": 319905886,
+       "bytes": 2000000,
+       "sha256": "80c39132e3e0dcd3646f6e170c128794169c97e70eca1ebb1af581ed626ee43c"
+      }
+     ],
+     "integrityWallMs": 17.6,
+     "status": "ok",
+     "wallMs": 8217.9,
+     "cpuSeconds": 4.97,
+     "rssPeakBytes": 374964224,
+     "rssMeanBytes": 306943317,
+     "cpuShape": {
+      "intervals": 8,
+      "maxCores": 0.61,
+      "p95Cores": 0.61,
+      "medianCores": 0.55,
+      "busyFraction": 0.88
+     },
+     "deliveredBytes": 483453665,
+     "cpuSecondsPerGB": 11.04
+    },
+    {
+     "id": "plain-medium",
+     "tier": "smoke",
+     "axes": [
+      "direct-video",
+      "no-archive",
+      "per-file-unique-stems"
+     ],
+     "expect": "serve",
+     "importMs": 533.6,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 315.11,
+      "ttfbMs": 315.17,
+      "bytes": 1055361,
+      "status": 206
+     },
+     "coldOpenWallMs": 316.3,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 2.64
+     },
+     "probeWallMs": 2.8,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 2.18,
+      "ttfbMs": 2.21,
+      "bytes": 1047637,
+      "status": 206
+     },
+     "warmOpenWallMs": 2.9,
+     "sequential": {
+      "ttfbMs": 2.97,
+      "bytes": 256049152,
+      "durationMs": 2670.1,
+      "meanMBps": 96.002,
+      "p50MBps": 67.609,
+      "p05MBps": 48.913,
+      "maxMBps": 127.403,
+      "reliable": true
+     },
+     "sequentialWallMs": 2670.2,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 7.59,
+        "headerMs": 7.56,
+        "bytes": 8031275,
+        "throughputMBps": 1284.918,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 531,
+        "headerMs": 530.89,
+        "bytes": 8004133,
+        "throughputMBps": 22.09,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 493.02,
+        "headerMs": 492.88,
+        "bytes": 8059190,
+        "throughputMBps": 42.05,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 270.07,
+        "headerMs": 269.95,
+        "bytes": 8063483,
+        "throughputMBps": 35.425,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 279.1,
+        "headerMs": 278.97,
+        "bytes": 8061695,
+        "throughputMBps": 36.818,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 1491.31,
+       "throughputMBps": 22.606
+      },
+      "medianTtfbMs": 279.1,
+      "worstTtfbMs": 531,
+      "failures": 0
+     },
+     "seeksWallMs": 4434.8,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 361.51,
+      "bytes": 4573064446,
+      "durationMs": 30104.82,
+      "meanMBps": 153.751,
+      "p05MBps": 27.246,
+      "timeToBufferMs": 1791,
+      "secondsBelowBitrate": 0.55,
+      "sustainable": true
+     },
+     "playbackWallMs": 30105.3,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 235.9,
+     "status": "ok",
+     "wallMs": 38302,
+     "cpuSeconds": 25.4,
+     "rssPeakBytes": 698974208,
+     "rssMeanBytes": 612110552,
+     "cpuShape": {
+      "intervals": 37,
+      "maxCores": 1.01,
+      "p95Cores": 0.93,
+      "medianCores": 0.7,
+      "busyFraction": 0.86
+     },
+     "deliveredBytes": 4831216596,
+     "cpuSecondsPerGB": 5.65
+    },
+    {
+     "id": "obfuscated-direct",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "obfuscated-names",
+      "extensionless"
+     ],
+     "expect": "serve",
+     "importMs": 537.3,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 5.67,
+      "ttfbMs": 5.79,
+      "bytes": 1047845,
+      "status": 206
+     },
+     "coldOpenWallMs": 7.1,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 3.27
+     },
+     "probeWallMs": 3.4,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 1.43,
+      "ttfbMs": 1.46,
+      "bytes": 1047845,
+      "status": 206
+     },
+     "warmOpenWallMs": 2.2,
+     "sequential": {
+      "ttfbMs": 3.18,
+      "bytes": 256049152,
+      "durationMs": 3786.02,
+      "meanMBps": 67.687,
+      "p50MBps": 58.009,
+      "p05MBps": 26.629,
+      "maxMBps": 108.297,
+      "reliable": true
+     },
+     "sequentialWallMs": 3787.1,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 6.79,
+        "headerMs": 6.73,
+        "bytes": 8062639,
+        "throughputMBps": 523.813,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 8.73,
+        "headerMs": 8.49,
+        "bytes": 8014925,
+        "throughputMBps": 33.524,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 5.17,
+        "headerMs": 5.1,
+        "bytes": 8020050,
+        "throughputMBps": 23.065,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 4.91,
+        "headerMs": 4.86,
+        "bytes": 8065147,
+        "throughputMBps": 20.181,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 6.8,
+        "headerMs": 6.7,
+        "bytes": 8061903,
+        "throughputMBps": 564.46,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 10.64,
+       "throughputMBps": 18.809
+      },
+      "medianTtfbMs": 6.79,
+      "worstTtfbMs": 8.73,
+      "failures": 0
+     },
+     "seeksWallMs": 1486.7,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 5.8,
+      "bytes": 4594035966,
+      "durationMs": 30007.23,
+      "meanMBps": 153.127,
+      "p05MBps": 21.669,
+      "timeToBufferMs": 1249,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30007.6,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 1189.6,
+     "status": "ok",
+     "wallMs": 37021,
+     "cpuSeconds": 24.02,
+     "rssPeakBytes": 673054720,
+     "rssMeanBytes": 595428214,
+     "cpuShape": {
+      "intervals": 36,
+      "maxCores": 0.96,
+      "p95Cores": 0.88,
+      "medianCores": 0.67,
+      "busyFraction": 0.94
+     },
+     "deliveredBytes": 4852180808,
+     "cpuSecondsPerGB": 5.32
+    },
+    {
+     "id": "plain-large",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "no-archive"
+     ],
+     "expect": "serve",
+     "importMs": 804.2,
+     "target": {
+      "fileName": "1ca77039eefe6edc3e869fb905878.mkv",
+      "sizeBytes": 15076905867
+     },
+     "coldOpen": {
+      "headerMs": 518.73,
+      "ttfbMs": 518.86,
+      "bytes": 1047890,
+      "status": 206
+     },
+     "coldOpenWallMs": 520.7,
+     "probe": {
+      "totalBytes": 15076905867,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 5.41
+     },
+     "probeWallMs": 5.7,
+     "sizeBytes": 15076905867,
+     "warmOpen": {
+      "headerMs": 3.7,
+      "ttfbMs": 3.78,
+      "bytes": 1006358,
+      "status": 206
+     },
+     "warmOpenWallMs": 5.6,
+     "sequential": {
+      "ttfbMs": 4.63,
+      "bytes": 256049152,
+      "durationMs": 3687.81,
+      "meanMBps": 69.519,
+      "p50MBps": 58.625,
+      "p05MBps": 12.929,
+      "maxMBps": 140.161,
+      "reliable": true
+     },
+     "sequentialWallMs": 3688.1,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 150769058,
+        "ttfbMs": 4.37,
+        "headerMs": 4.32,
+        "bytes": 8024670,
+        "throughputMBps": 1307.713,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 3769226466,
+        "ttfbMs": 159.84,
+        "headerMs": 159.72,
+        "bytes": 8006430,
+        "throughputMBps": 27.835,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 7538452933,
+        "ttfbMs": 224.49,
+        "headerMs": 224.37,
+        "bytes": 8017259,
+        "throughputMBps": 29.108,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 11307679400,
+        "ttfbMs": 175.89,
+        "headerMs": 175.77,
+        "bytes": 8028296,
+        "throughputMBps": 18.344,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 14323060573,
+        "ttfbMs": 164.49,
+        "headerMs": 164.32,
+        "bytes": 8024019,
+        "throughputMBps": 25.56,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1507690586,
+       "ttfbMs": 170.22,
+       "throughputMBps": 37.592
+      },
+      "medianTtfbMs": 164.49,
+      "worstTtfbMs": 224.49,
+      "failures": 0
+     },
+     "seeksWallMs": 2434.5,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 4523071760,
+      "ttfbMs": 162.34,
+      "bytes": 4039665392,
+      "durationMs": 30070.16,
+      "meanMBps": 135.071,
+      "p05MBps": 35.342,
+      "timeToBufferMs": 1429,
+      "secondsBelowBitrate": 0.01,
+      "sustainable": true
+     },
+     "playbackWallMs": 30070.9,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "f9f305fa3fbc944f62df43ac8c3452bb25fd5d81f018ff874658b5004c8319d1"
+      },
+      {
+       "start": 7537452933,
+       "bytes": 2000000,
+       "sha256": "5551953b14d1450b51a7914a813f0ae27582f40aed6090f9a9a08742f3084e2d"
+      },
+      {
+       "start": 15074905867,
+       "bytes": 2000000,
+       "sha256": "98fdc11b40dbe71e4bf96844181a32f8573cd2b7058f16cf66702a1ff20aea6b"
+      }
+     ],
+     "integrityWallMs": 295.5,
+     "status": "ok",
+     "wallMs": 37825.2,
+     "cpuSeconds": 16.02,
+     "rssPeakBytes": 627146752,
+     "rssMeanBytes": 476015562,
+     "cpuShape": {
+      "intervals": 37,
+      "maxCores": 0.73,
+      "p95Cores": 0.6,
+      "medianCores": 0.42,
+      "busyFraction": 0.92
+     },
+     "deliveredBytes": 4297768792,
+     "cpuSecondsPerGB": 4
+    },
+    {
+     "id": "plain-season-pack",
+     "tier": "core",
+     "axes": [
+      "direct-video",
+      "season-pack",
+      "file-selection"
+     ],
+     "expect": "serve",
+     "importMs": 317.9,
+     "target": {
+      "fileName": "Bosch.S01E01.2015.1080p.Amazon.WEB-DL.AVC.DDP.5.1-DBTV.mkv",
+      "sizeBytes": 2210528776
+     },
+     "coldOpen": {
+      "headerMs": 146.33,
+      "ttfbMs": 146.4,
+      "bytes": 1044272,
+      "status": 206
+     },
+     "coldOpenWallMs": 295.2,
+     "probe": {
+      "totalBytes": 2210528776,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 4.88
+     },
+     "probeWallMs": 5.3,
+     "sizeBytes": 2210528776,
+     "warmOpen": {
+      "headerMs": 5.34,
+      "ttfbMs": 5.43,
+      "bytes": 1044272,
+      "status": 206
+     },
+     "warmOpenWallMs": 8.5,
+     "sequential": {
+      "ttfbMs": 2.79,
+      "bytes": 256036864,
+      "durationMs": 4129.09,
+      "meanMBps": 62.05,
+      "p50MBps": 63.909,
+      "p05MBps": 25.012,
+      "maxMBps": 107.45,
+      "reliable": true
+     },
+     "sequentialWallMs": 4129.4,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 22105287,
+        "ttfbMs": 9.81,
+        "headerMs": 9.76,
+        "bytes": 8000313,
+        "throughputMBps": 1233.855,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 552632194,
+        "ttfbMs": 118.35,
+        "headerMs": 118.29,
+        "bytes": 8044670,
+        "throughputMBps": 19.906,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 1105264388,
+        "ttfbMs": 128.65,
+        "headerMs": 128.57,
+        "bytes": 8056876,
+        "throughputMBps": 22.547,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 1657896582,
+        "ttfbMs": 132.02,
+        "headerMs": 131.88,
+        "bytes": 8012154,
+        "throughputMBps": 17.947,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 2100002337,
+        "ttfbMs": 131.57,
+        "headerMs": 131.42,
+        "bytes": 8045023,
+        "throughputMBps": 26.164,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 221052877,
+       "ttfbMs": 9.72,
+       "throughputMBps": 345.039
+      },
+      "medianTtfbMs": 128.65,
+      "worstTtfbMs": 132.02,
+      "failures": 0
+     },
+     "seeksWallMs": 2075.9,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 663158632,
+      "ttfbMs": 80.53,
+      "bytes": 1547370144,
+      "durationMs": 16421.96,
+      "meanMBps": 94.69,
+      "p05MBps": 64.376,
+      "timeToBufferMs": 898,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 16422.3,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "c3d52b715e7f6ee76f5a1c103a31853d440f1e96341ff2170ca66646a105f452"
+      },
+      {
+       "start": 1104264388,
+       "bytes": 2000000,
+       "sha256": "9e6e73cef2032c61a18d91b1f4d869f69f33e473b43d21d1fb9f1c7d69c9f09e"
+      },
+      {
+       "start": 2208528776,
+       "bytes": 2000000,
+       "sha256": "01b4b848c553ad2ae59b7bab78a02762acfede9b41415de494e5907413a9881f"
+      }
+     ],
+     "integrityWallMs": 33.4,
+     "status": "ok",
+     "wallMs": 23287.8,
+     "cpuSeconds": 9.21,
+     "rssPeakBytes": 437141504,
+     "rssMeanBytes": 378508867,
+     "cpuShape": {
+      "intervals": 22,
+      "maxCores": 0.53,
+      "p95Cores": 0.52,
+      "medianCores": 0.43,
+      "busyFraction": 0.86
+     },
+     "deliveredBytes": 1805495552,
+     "cpuSecondsPerGB": 5.48
+    },
+    {
+     "id": "rar4-rNN",
+     "tier": "core",
+     "axes": [
+      "rar4",
+      "stored",
+      "rar+rNN",
+      "letter-rollover"
+     ],
+     "expect": "serve",
+     "importMs": 1821,
+     "target": {
+      "fileName": "It's.Always.Sunny.in.Philadelphia.S07E12.The.High.School.Reunion.BluRay.1080p.Remux.AVC.DTSHD-MA.5.1-PtZ.mkv",
+      "sizeBytes": 5882124203
+     },
+     "coldOpen": {
+      "headerMs": 94.54,
+      "ttfbMs": 94.71,
+      "bytes": 1048368,
+      "status": 206
+     },
+     "coldOpenWallMs": 142.5,
+     "probe": {
+      "totalBytes": 5882124203,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 5.94
+     },
+     "probeWallMs": 6.1,
+     "sizeBytes": 5882124203,
+     "warmOpen": {
+      "headerMs": 3.75,
+      "ttfbMs": 3.89,
+      "bytes": 1047533,
+      "status": 206
+     },
+     "warmOpenWallMs": 6.4,
+     "sequential": {
+      "ttfbMs": 4.97,
+      "bytes": 256048944,
+      "durationMs": 3815.14,
+      "meanMBps": 67.201,
+      "p50MBps": 83.516,
+      "p05MBps": 22.301,
+      "maxMBps": 95.274,
+      "reliable": true
+     },
+     "sequentialWallMs": 3815.4,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 58821242,
+        "ttfbMs": 5.21,
+        "headerMs": 5.14,
+        "bytes": 8060928,
+        "throughputMBps": 1510.539,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1470531050,
+        "ttfbMs": 108.56,
+        "headerMs": 108.51,
+        "bytes": 8052216,
+        "throughputMBps": 11.444,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 2941062101,
+        "ttfbMs": 92.91,
+        "headerMs": 92.77,
+        "bytes": 8060720,
+        "throughputMBps": 15.172,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4411593152,
+        "ttfbMs": 281.83,
+        "headerMs": 281.65,
+        "bytes": 8051342,
+        "throughputMBps": 17.124,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 5588017992,
+        "ttfbMs": 133.88,
+        "headerMs": 133.79,
+        "bytes": 8060928,
+        "throughputMBps": 16.928,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 588212420,
+       "ttfbMs": 139.3,
+       "throughputMBps": 24.434
+      },
+      "medianTtfbMs": 108.56,
+      "worstTtfbMs": 281.83,
+      "failures": 0
+     },
+     "seeksWallMs": 3278.9,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1764637260,
+      "ttfbMs": 165.04,
+      "bytes": 3156264340,
+      "durationMs": 30014.42,
+      "meanMBps": 105.74,
+      "p05MBps": 44.085,
+      "timeToBufferMs": 1664,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30014.7,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "652f1b7a97f8dee12621e5d2c483f33bff7c19d5c8f59fe8a9438bc6581e8c88"
+      },
+      {
+       "start": 2940062101,
+       "bytes": 2000000,
+       "sha256": "58b9cf1d866e3b51cdba10ae584acd95b302c53135d8e929e467214fb16154b9"
+      },
+      {
+       "start": 5880124203,
+       "bytes": 2000000,
+       "sha256": "c3c2d6e2dfb3d4ea8c46f74b8579349829e42c7fdbddc101f5bfe992550c4e07"
+      }
+     ],
+     "integrityWallMs": 617.8,
+     "status": "ok",
+     "wallMs": 39702.8,
+     "cpuSeconds": 19.54,
+     "rssPeakBytes": 486457344,
+     "rssMeanBytes": 432201728,
+     "cpuShape": {
+      "intervals": 39,
+      "maxCores": 0.68,
+      "p95Cores": 0.66,
+      "medianCores": 0.5,
+      "busyFraction": 0.87
+     },
+     "deliveredBytes": 3414409185,
+     "cpuSecondsPerGB": 6.14
+    },
+    {
+     "id": "rar-hdrenc-small",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "status": "failed",
+     "error": "import failed: Archive incomplete: volumes missing from the post [incomplete_archive]",
+     "wallMs": 2577.4,
+     "cpuSeconds": 0.75,
+     "rssPeakBytes": 399966208,
+     "rssMeanBytes": 399777792,
+     "cpuShape": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-hdrenc-large",
+     "tier": "core",
+     "axes": [
+      "rar5",
+      "encrypted-headers",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 1097,
+     "target": {
+      "fileName": "Ed\u00e9n (2024) [BDRip x264 1080p AC3 5.1 Castellano] (MATS\u00ae).mkv",
+      "sizeBytes": 17174121367
+     },
+     "coldOpen": {
+      "headerMs": 133.48,
+      "ttfbMs": 133.54,
+      "bytes": 1048576,
+      "status": 206
+     },
+     "coldOpenWallMs": 310.6,
+     "probe": {
+      "totalBytes": 17174121367,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 2.66
+     },
+     "probeWallMs": 2.7,
+     "sizeBytes": 17174121367,
+     "warmOpen": {
+      "headerMs": 0.92,
+      "ttfbMs": 0.94,
+      "bytes": 1036744,
+      "status": 206
+     },
+     "warmOpenWallMs": 1.5,
+     "sequential": {
+      "ttfbMs": 2.43,
+      "bytes": 256049152,
+      "durationMs": 3365.8,
+      "meanMBps": 76.129,
+      "p50MBps": 87.82,
+      "p05MBps": 19.591,
+      "maxMBps": 120.72,
+      "reliable": true
+     },
+     "sequentialWallMs": 3366,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 171741213,
+        "ttfbMs": 6.78,
+        "headerMs": 6.73,
+        "bytes": 8060928,
+        "throughputMBps": 401.408,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 4293530341,
+        "ttfbMs": 157.77,
+        "headerMs": 157.72,
+        "bytes": 8060928,
+        "throughputMBps": 16.164,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 8587060683,
+        "ttfbMs": 149.47,
+        "headerMs": 149.4,
+        "bytes": 8060720,
+        "throughputMBps": 24.915,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 12880591025,
+        "ttfbMs": 108.67,
+        "headerMs": 108.51,
+        "bytes": 8060720,
+        "throughputMBps": 21.973,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 16315415298,
+        "ttfbMs": 121.25,
+        "headerMs": 121.1,
+        "bytes": 8060928,
+        "throughputMBps": 15.949,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1717412136,
+       "ttfbMs": 119.59,
+       "throughputMBps": 15.833
+      },
+      "medianTtfbMs": 121.25,
+      "worstTtfbMs": 157.77,
+      "failures": 0
+     },
+     "seeksWallMs": 2888,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 5152236410,
+      "ttfbMs": 137.59,
+      "bytes": 2588082176,
+      "durationMs": 30020.14,
+      "meanMBps": 86.608,
+      "p05MBps": 35.57,
+      "timeToBufferMs": 1783,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30020.3,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "ca5f5f5d72bc03c73ec554b87f09293056cc64f898d9ba0c6009c0f31cf92035"
+      },
+      {
+       "start": 8586060683,
+       "bytes": 2000000,
+       "sha256": "ed802261f0ff5ea16496bbf3e08828cab7d130093e0b0bd504b5e93ccf9fac78"
+      },
+      {
+       "start": 17172121367,
+       "bytes": 2000000,
+       "sha256": "2cf8c04c6895c85ab6c884ddaea22a03d619822747aa358a1e9d975709bcecc3"
+      }
+     ],
+     "integrityWallMs": 776.8,
+     "status": "ok",
+     "wallMs": 38463.1,
+     "cpuSeconds": 19.88,
+     "rssPeakBytes": 455360512,
+     "rssMeanBytes": 437126800,
+     "cpuShape": {
+      "intervals": 38,
+      "maxCores": 0.74,
+      "p95Cores": 0.67,
+      "medianCores": 0.56,
+      "busyFraction": 0.84
+     },
+     "deliveredBytes": 2846216648,
+     "cpuSecondsPerGB": 7.5
+    },
+    {
+     "id": "rar-partNN-large",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "import failed: Missing on providers: 8/8 sampled segments unavailable (incomplete or removed) [missing_on_providers]",
+     "wallMs": 1614.7,
+     "cpuSeconds": 0.24,
+     "rssPeakBytes": 459210752,
+     "rssMeanBytes": 459210752,
+     "cpuShape": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-maestras",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "import failed: Missing on providers: 16/16 sampled segments unavailable (incomplete or removed) [missing_on_providers]",
+     "wallMs": 4934.7,
+     "cpuSeconds": 0.16,
+     "rssPeakBytes": 341803008,
+     "rssMeanBytes": 336756736,
+     "cpuShape": {
+      "intervals": 4,
+      "maxCores": 0.04,
+      "p95Cores": 0.04,
+      "medianCores": 0.03,
+      "busyFraction": 0.75
+     },
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "rar-partNN-satans",
+     "tier": "failure",
+     "axes": [
+      "rar",
+      "partNN",
+      "password-in-nzb"
+     ],
+     "expect": "reject",
+     "status": "failed",
+     "error": "import failed: Missing on providers: 2/21 files unavailable (incomplete or removed) [missing_on_providers]",
+     "wallMs": 3871.3,
+     "cpuSeconds": 0.13,
+     "rssPeakBytes": 345407488,
+     "rssMeanBytes": 344023040,
+     "cpuShape": null,
+     "deliveredBytes": 0,
+     "cpuSecondsPerGB": null
+    },
+    {
+     "id": "7z-split-bugonia",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 1092,
+     "target": {
+      "fileName": "Bugonia.2025.SPANiSH.MULTi.1080p.BluRay.x264-USENETHD.mkv",
+      "sizeBytes": 21169663096
+     },
+     "coldOpen": {
+      "headerMs": 23,
+      "ttfbMs": 23.04,
+      "bytes": 1048576,
+      "status": 206
+     },
+     "coldOpenWallMs": 329.4,
+     "probe": {
+      "totalBytes": 21169663096,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 5.56
+     },
+     "probeWallMs": 5.8,
+     "sizeBytes": 21169663096,
+     "warmOpen": {
+      "headerMs": 5.51,
+      "ttfbMs": 5.59,
+      "bytes": 1047842,
+      "status": 206
+     },
+     "warmOpenWallMs": 6.7,
+     "sequential": {
+      "ttfbMs": 6.83,
+      "bytes": 256048944,
+      "durationMs": 5746.31,
+      "meanMBps": 44.612,
+      "p50MBps": 40.96,
+      "p05MBps": 13.316,
+      "maxMBps": 106.009,
+      "reliable": true
+     },
+     "sequentialWallMs": 5746.5,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 211696630,
+        "ttfbMs": 6.51,
+        "headerMs": 6.46,
+        "bytes": 8060928,
+        "throughputMBps": 650.486,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 5292415774,
+        "ttfbMs": 197.93,
+        "headerMs": 197.8,
+        "bytes": 8060720,
+        "throughputMBps": 20.389,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 10584831548,
+        "ttfbMs": 103.01,
+        "headerMs": 102.93,
+        "bytes": 8060928,
+        "throughputMBps": 22.59,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 15877247322,
+        "ttfbMs": 156.39,
+        "headerMs": 156.24,
+        "bytes": 8060928,
+        "throughputMBps": 14.123,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 20111179941,
+        "ttfbMs": 112.22,
+        "headerMs": 112.15,
+        "bytes": 8060720,
+        "throughputMBps": 16.678,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 2116966309,
+       "ttfbMs": 177.69,
+       "throughputMBps": 18.522
+      },
+      "medianTtfbMs": 112.22,
+      "worstTtfbMs": 197.93,
+      "failures": 0
+     },
+     "seeksWallMs": 3008.2,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 6350898928,
+      "ttfbMs": 110.45,
+      "bytes": 2149777408,
+      "durationMs": 30069.73,
+      "meanMBps": 71.757,
+      "p05MBps": 22.665,
+      "timeToBufferMs": 1502,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30069.9,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "dc90fbf4517651e76aca1b4c57f43ec37a25a92bdc1fd9294e806c2228ca39aa"
+      },
+      {
+       "start": 10583831548,
+       "bytes": 2000000,
+       "sha256": "911ad58d080637c505d2d3a768a6bb31ea30f3c4ee925cdb7ecc5003d10e7c2d"
+      },
+      {
+       "start": 21167663096,
+       "bytes": 2000000,
+       "sha256": "3a59d97512411e4b8a542cbf88a7af356b2916175b792ec5e6c2bfe2aeff3b5b"
+      }
+     ],
+     "integrityWallMs": 757.9,
+     "status": "ok",
+     "wallMs": 41016.7,
+     "cpuSeconds": 17.95,
+     "rssPeakBytes": 525008896,
+     "rssMeanBytes": 489553520,
+     "cpuShape": {
+      "intervals": 40,
+      "maxCores": 0.68,
+      "p95Cores": 0.66,
+      "medianCores": 0.48,
+      "busyFraction": 0.78
+     },
+     "deliveredBytes": 2407922770,
+     "cpuSecondsPerGB": 8
+    },
+    {
+     "id": "7z-split-tardes",
+     "tier": "core",
+     "axes": [
+      "7z",
+      "split-7z.NNN",
+      "password-in-nzb"
+     ],
+     "expect": "serve",
+     "importMs": 595.3,
+     "target": {
+      "fileName": "Tardes.De.Soledad.2024.SPANiSH.1080p.BluRay.x264-USENETHD.mkv",
+      "sizeBytes": 19222688752
+     },
+     "coldOpen": {
+      "headerMs": 19.8,
+      "ttfbMs": 19.84,
+      "bytes": 1048368,
+      "status": 206
+     },
+     "coldOpenWallMs": 134.5,
+     "probe": {
+      "totalBytes": 19222688752,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 2.52
+     },
+     "probeWallMs": 2.6,
+     "sizeBytes": 19222688752,
+     "warmOpen": {
+      "headerMs": 0.99,
+      "ttfbMs": 1.03,
+      "bytes": 1005158,
+      "status": 206
+     },
+     "warmOpenWallMs": 1.6,
+     "sequential": {
+      "ttfbMs": 2.42,
+      "bytes": 256048944,
+      "durationMs": 6325.65,
+      "meanMBps": 40.493,
+      "p50MBps": 58.551,
+      "p05MBps": 4.073,
+      "maxMBps": 104.048,
+      "reliable": true
+     },
+     "sequentialWallMs": 6325.8,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 192226887,
+        "ttfbMs": 9.39,
+        "headerMs": 9.3,
+        "bytes": 8060928,
+        "throughputMBps": 598.227,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 4805672188,
+        "ttfbMs": 147.71,
+        "headerMs": 147.65,
+        "bytes": 8060720,
+        "throughputMBps": 12.41,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 9611344376,
+        "ttfbMs": 164.02,
+        "headerMs": 163.93,
+        "bytes": 8060928,
+        "throughputMBps": 17.67,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 14417016564,
+        "ttfbMs": 113.55,
+        "headerMs": 113.44,
+        "bytes": 8060720,
+        "throughputMBps": 7.609,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 18261554314,
+        "ttfbMs": 234.91,
+        "headerMs": 234.79,
+        "bytes": 8060928,
+        "throughputMBps": 21.97,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 1922268875,
+       "ttfbMs": 172.9,
+       "throughputMBps": 13.063
+      },
+      "medianTtfbMs": 147.71,
+      "worstTtfbMs": 234.91,
+      "failures": 0
+     },
+     "seeksWallMs": 4006.1,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 5766806625,
+      "ttfbMs": 142.94,
+      "bytes": 3030581248,
+      "durationMs": 30011.15,
+      "meanMBps": 101.465,
+      "p05MBps": 80.331,
+      "timeToBufferMs": 1339,
+      "secondsBelowBitrate": 0,
+      "sustainable": true
+     },
+     "playbackWallMs": 30011.4,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "676926b1cace4d63b9055ee16516ed2e86ababef4e6b3807d5e2529fe33fa4da"
+      },
+      {
+       "start": 9610344376,
+       "bytes": 2000000,
+       "sha256": "3037000cc41414ff7c6fa8f1ae5b95ca1a797239cde68dca8394bc5ce9f152e5"
+      },
+      {
+       "start": 19220688752,
+       "bytes": 2000000,
+       "sha256": "441fa0ef78afac308dd1fee5b4c5bac65486f670997aed25a54daafcb8e3f024"
+      }
+     ],
+     "integrityWallMs": 728.2,
+     "status": "ok",
+     "wallMs": 41805.6,
+     "cpuSeconds": 21.31,
+     "rssPeakBytes": 477921280,
+     "rssMeanBytes": 424348721,
+     "cpuShape": {
+      "intervals": 41,
+      "maxCores": 0.78,
+      "p95Cores": 0.69,
+      "medianCores": 0.57,
+      "busyFraction": 0.85
+     },
+     "deliveredBytes": 3288683718,
+     "cpuSecondsPerGB": 6.96
+    },
+    {
+     "id": "damaged-partial",
+     "tier": "failure",
+     "axes": [
+      "direct-video",
+      "missing-articles"
+     ],
+     "expect": "serve",
+     "importMs": 546.7,
+     "target": {
+      "fileName": "Toy.Story.5.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-KyoGo.mkv",
+      "sizeBytes": 6608994141
+     },
+     "coldOpen": {
+      "headerMs": 167.12,
+      "ttfbMs": 167.19,
+      "bytes": 1055569,
+      "status": 206
+     },
+     "coldOpenWallMs": 169.4,
+     "probe": {
+      "totalBytes": 6608994141,
+      "rangeSupported": true,
+      "contentType": "video/x-matroska",
+      "firstByteMs": 4.57
+     },
+     "probeWallMs": 4.7,
+     "sizeBytes": 6608994141,
+     "warmOpen": {
+      "headerMs": 1.29,
+      "ttfbMs": 1.37,
+      "bytes": 1047845,
+      "status": 206
+     },
+     "warmOpenWallMs": 2.3,
+     "sequential": {
+      "ttfbMs": 1.61,
+      "bytes": 256049152,
+      "durationMs": 7816.65,
+      "meanMBps": 32.764,
+      "p50MBps": 39.876,
+      "p05MBps": 11.085,
+      "maxMBps": 65.488,
+      "reliable": true
+     },
+     "sequentialWallMs": 7816.9,
+     "seeks": {
+      "points": [
+       {
+        "fraction": 0.01,
+        "offset": 66089941,
+        "ttfbMs": 7.18,
+        "headerMs": 7.14,
+        "bytes": 8031275,
+        "throughputMBps": 742.577,
+        "status": 206
+       },
+       {
+        "fraction": 0.25,
+        "offset": 1652248535,
+        "ttfbMs": 412.59,
+        "headerMs": 412.55,
+        "bytes": 8027357,
+        "throughputMBps": 23.562,
+        "status": 206
+       },
+       {
+        "fraction": 0.5,
+        "offset": 3304497070,
+        "ttfbMs": 214.71,
+        "headerMs": 214.57,
+        "bytes": 8020050,
+        "throughputMBps": 23.516,
+        "status": 206
+       },
+       {
+        "fraction": 0.75,
+        "offset": 4956745605,
+        "ttfbMs": 239.14,
+        "headerMs": 238.99,
+        "bytes": 8064939,
+        "throughputMBps": 24.611,
+        "status": 206
+       },
+       {
+        "fraction": 0.95,
+        "offset": 6278544433,
+        "ttfbMs": 228.64,
+        "headerMs": 228.52,
+        "bytes": 8043387,
+        "throughputMBps": 18.512,
+        "status": 206
+       }
+      ],
+      "backward": {
+       "offset": 660899414,
+       "ttfbMs": 295.99,
+       "throughputMBps": 28.158
+      },
+      "medianTtfbMs": 228.64,
+      "worstTtfbMs": 412.59,
+      "failures": 0
+     },
+     "seeksWallMs": 3138.5,
+     "playback": {
+      "bitrateMbps": 25,
+      "requiredMBps": 3.125,
+      "startOffset": 1982698242,
+      "ttfbMs": 394.2,
+      "bytes": 4073942270,
+      "durationMs": 30026.09,
+      "meanMBps": 137.485,
+      "p05MBps": 30.357,
+      "timeToBufferMs": 3219,
+      "secondsBelowBitrate": 1.53,
+      "sustainable": true
+     },
+     "playbackWallMs": 30026.3,
+     "integrity": [
+      {
+       "start": 0,
+       "bytes": 2000000,
+       "sha256": "8e6c9a1e7b8b470b6296016fd07c41a27075594a7b4550944168c59d1758f0e2"
+      },
+      {
+       "start": 3303497070,
+       "bytes": 2000000,
+       "sha256": "2bd08a424a316ddc2bcc98be221ba7ca82d2f9568ec7214d6162f28f53a7a60f"
+      },
+      {
+       "start": 6606994141,
+       "bytes": 2000000,
+       "sha256": "d869d3c756dc57480095f1b9830a192d6ff1428ff142f40259116c794e6a2f89"
+      }
+     ],
+     "integrityWallMs": 553,
+     "status": "ok",
+     "wallMs": 42258,
+     "cpuSeconds": 25.06,
+     "rssPeakBytes": 621625344,
+     "rssMeanBytes": 542414555,
+     "cpuShape": {
+      "intervals": 41,
+      "maxCores": 0.88,
+      "p95Cores": 0.81,
+      "medianCores": 0.63,
+      "busyFraction": 0.85
+     },
+     "deliveredBytes": 4332094836,
+     "cpuSecondsPerGB": 6.21
+    }
+   ],
+   "prepareMs": 36.2,
+   "buildReused": true,
+   "buildStamp": "aiostreams@e694b6a",
+   "startupMs": 2928.8,
+   "version": {
+    "version": "2026.09.04.2319-nightly"
+   },
+   "port": 56394,
+   "pids": [
+    46820
+   ],
+   "idle": {
+    "samples": 10,
+    "cpuSeconds": 0.93,
+    "rssPeakBytes": 238125056,
+    "rssMedianBytes": 228327424,
+    "rssMeanBytes": 230363955,
+    "maxProcesses": 1
+   },
+   "resourcesMeasured": true,
+   "resourceSource": "host",
+   "resources": {
+    "samples": 361,
+    "cpuSeconds": 184.64,
+    "rssPeakBytes": 698974208,
+    "rssMedianBytes": 462077952,
+    "rssMeanBytes": 482488195,
+    "maxProcesses": 1
+   },
+   "idleAfter": {
+    "samples": 45,
+    "cpuSeconds": 188.51,
+    "rssPeakBytes": 572227584,
+    "rssMedianBytes": 230129664,
+    "rssMeanBytes": 263620745,
+    "maxProcesses": 1
+   },
+   "status": "ok",
+   "finishedAt": "2026-09-05T14:57:44.371Z"
+  }
+ ],
+ "finishedAt": "2026-09-05T14:57:44.374Z"
+}

--- a/internal/importer/parser/parser.go
+++ b/internal/importer/parser/parser.go
@@ -975,6 +975,35 @@ func (p *Parser) fetchAllFirstSegments(ctx context.Context, files []nzbparser.Nz
 	return cache, notFoundIDs, nil
 }
 
+// WarmFirstSegments fetches the first article of every file that ParseNzb
+// would fetch, into the head cache, and returns when they have all landed or
+// ctx ends. It exists so the fetch can overlap the fast-fail probe instead of
+// following it: on a healthy release the parse pass then finds every head
+// already cached. Errors are not reported; the parse pass diagnoses them.
+func (p *Parser) WarmFirstSegments(ctx context.Context, files []nzbparser.NzbFile) {
+	if ctx.Err() != nil || p.poolManager == nil || !p.poolManager.HasPool() {
+		return
+	}
+	cp, err := p.poolManager.GetPool()
+	if err != nil {
+		return
+	}
+	maxFetch := max(min(min(len(files), p.getConfig().TotalProviderConnections()), maxFetchGoroutines), 1)
+	warm := concpool.New().WithMaxGoroutines(maxFetch).WithContext(ctx)
+	for i := range files {
+		file := &files[i]
+		if len(file.Segments) == 0 || shouldSkipFirstSegmentFetch(file) {
+			continue
+		}
+		id := file.Segments[0].ID
+		warm.Go(func(ctx context.Context) error {
+			_, _ = p.fetchBodyWithRetry(ctx, cp, id)
+			return nil
+		})
+	}
+	_ = warm.Wait()
+}
+
 // fetchBodyWithRetry fetches one article, retrying transient failures. A
 // genuine article-not-found (430/423) is permanent and returned at once:
 // transient errors — connection exhaustion, timeouts, resets — must not be

--- a/internal/importer/parser/parser_warm_test.go
+++ b/internal/importer/parser/parser_warm_test.go
@@ -1,0 +1,67 @@
+package parser
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/nntppool/v4"
+	"github.com/javi11/nzbparser"
+)
+
+// Warming first segments while the fast-fail probe runs must leave the parse
+// pass nothing to fetch for those articles: one wire read per first segment,
+// not two.
+func TestWarmFirstSegmentsMakesParseServeHeadsFromCache(t *testing.T) {
+	content := bytes.Repeat([]byte("F"), 32768)
+	fp := fakepool.New()
+	fp.SetBehavior("vid-0", fakepool.SegmentBehavior{
+		Bytes: content[:16384],
+		YEnc:  nntppool.YEncMeta{FileName: "Real.Movie.2024.mkv", FileSize: 32768, Part: 1, PartBegin: 0, PartSize: 16384},
+	})
+	fp.SetBehavior("vid-1", fakepool.SegmentBehavior{
+		Bytes: content[16384:],
+		YEnc:  nntppool.YEncMeta{FileSize: 32768, Part: 2, PartBegin: 16384, PartSize: 16384},
+	})
+	nzb := &nzbparser.Nzb{Files: nzbparser.NzbFiles{
+		{Filename: "Real.Movie.2024.mkv", Segments: nzbparser.NzbSegments{
+			{Bytes: 16800, Number: 1, ID: "vid-0"},
+			{Bytes: 16800, Number: 2, ID: "vid-1"},
+		}},
+	}}
+
+	p := NewParser(newFakeFullPoolManager(fp), stormConfigGetter(4))
+
+	p.WarmFirstSegments(context.Background(), nzb.Files)
+	if got := fp.PerMessageCalls("vid-0"); got != 1 {
+		t.Fatalf("warm-up fetched vid-0 %d times, want 1", got)
+	}
+
+	parsed, err := p.ParseNzb(context.Background(), nzb, "release.nzb", nil, ParseOptions{})
+	if err != nil {
+		t.Fatalf("ParseNzb error = %v", err)
+	}
+	if len(parsed.Files) != 1 {
+		t.Fatalf("parsed %d files, want 1", len(parsed.Files))
+	}
+	if got := fp.PerMessageCalls("vid-0"); got != 1 {
+		t.Fatalf("parse refetched vid-0: %d calls total, want 1", got)
+	}
+}
+
+// A cancelled warm-up returns promptly and leaves the parse to fetch normally.
+func TestWarmFirstSegmentsHonoursCancel(t *testing.T) {
+	fp := fakepool.New()
+	fp.SetBehavior("vid-0", fakepool.SegmentBehavior{Bytes: []byte("x"), YEnc: nntppool.YEncMeta{FileSize: 1, PartSize: 1}})
+	nzb := &nzbparser.Nzb{Files: nzbparser.NzbFiles{
+		{Filename: "Real.Movie.2024.mkv", Segments: nzbparser.NzbSegments{{Bytes: 10, Number: 1, ID: "vid-0"}}},
+	}}
+	p := NewParser(newFakeFullPoolManager(fp), stormConfigGetter(4))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	p.WarmFirstSegments(ctx, nzb.Files)
+	if got := fp.PerMessageCalls("vid-0"); got != 0 {
+		t.Fatalf("cancelled warm-up still fetched vid-0 %d times", got)
+	}
+}

--- a/internal/importer/postprocessor/coordinator.go
+++ b/internal/importer/postprocessor/coordinator.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/javi11/altmount/internal/arrs"
+	"github.com/javi11/altmount/internal/arrs/model"
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/errors"
@@ -137,6 +138,8 @@ func (c *Coordinator) HandleSuccess(ctx context.Context, item *database.ImportQu
 			"path", resultingPath)
 	} else if arrsService == nil {
 		c.log.DebugContext(ctx, "ARR notification not sent", "path", resultingPath, "error", "ARRs disabled")
+	} else if !shouldWaitForMountPropagation(arrsService, item) {
+		c.log.DebugContext(ctx, "ARR notification not sent", "path", resultingPath, "error", "no ARR instance would be notified")
 	} else if err := c.waitForMountPropagation(ctx); err != nil {
 		return result, err
 	} else if err := c.notifyARRWith(ctx, arrsService, item, resultingPath); err != nil {
@@ -159,6 +162,25 @@ func (c *Coordinator) HandleSuccess(ctx context.Context, item *database.ImportQu
 // after HandleSuccess returns, so an unconditional wait here was a full
 // second added to every import's time to first byte.
 const mountPropagationDelay = 1 * time.Second
+
+// arrInstanceLister is the slice of *arrs.Service the wait decision needs.
+type arrInstanceLister interface {
+	GetAllInstances() []*model.ConfigInstance
+}
+
+// shouldWaitForMountPropagation reports whether an ARR will actually be
+// notified for this item, which is the only reason to pay the propagation
+// delay. The service object exists even with no ARR configured, so its
+// presence alone must not cost every import a second.
+func shouldWaitForMountPropagation(lister arrInstanceLister, item *database.ImportQueueItem) bool {
+	if lister == nil || item == nil || len(lister.GetAllInstances()) == 0 {
+		return false
+	}
+	if item.TargetPath != nil && *item.TargetPath != "" {
+		return true
+	}
+	return item.Category != nil && *item.Category != ""
+}
 
 func (c *Coordinator) waitForMountPropagation(ctx context.Context) error {
 	select {

--- a/internal/importer/postprocessor/coordinator_mount_wait_test.go
+++ b/internal/importer/postprocessor/coordinator_mount_wait_test.go
@@ -1,0 +1,38 @@
+package postprocessor
+
+import (
+	"testing"
+
+	"github.com/javi11/altmount/internal/arrs/model"
+	"github.com/javi11/altmount/internal/database"
+)
+
+type fakeInstanceLister struct{ instances []*model.ConfigInstance }
+
+func (f fakeInstanceLister) GetAllInstances() []*model.ConfigInstance { return f.instances }
+
+func TestShouldWaitForMountPropagation(t *testing.T) {
+	cat := "movies"
+	target := "/mnt/target/file.mkv"
+	one := []*model.ConfigInstance{{Name: "radarr"}}
+
+	tests := []struct {
+		name   string
+		lister arrInstanceLister
+		item   *database.ImportQueueItem
+		want   bool
+	}{
+		{"no arr service", nil, &database.ImportQueueItem{Category: &cat}, false},
+		{"arr service with no instances", fakeInstanceLister{}, &database.ImportQueueItem{Category: &cat}, false},
+		{"instances but item has no category or target", fakeInstanceLister{one}, &database.ImportQueueItem{}, false},
+		{"instances and category", fakeInstanceLister{one}, &database.ImportQueueItem{Category: &cat}, true},
+		{"instances and target path", fakeInstanceLister{one}, &database.ImportQueueItem{TargetPath: &target}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldWaitForMountPropagation(tt.lister, tt.item); got != tt.want {
+				t.Errorf("shouldWaitForMountPropagation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -875,10 +875,24 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 				"placeholders", gaps, "file_path", filePath)
 		}
 
-		// Pre-parse Stat check — runs before any Body fetches.
+		// Pre-parse Stat check. The first-segment fetch the parse pass needs
+		// runs alongside it: on a healthy release, the common case, that
+		// hides the shorter of the two behind the longer; on a failed check
+		// the warm-up is cancelled and its cost is a few early 430s.
 		proc.updateProgressWithStage(queueID, 0, "Checking segment availability")
+		warmCtx, cancelWarm := context.WithCancel(ctx)
+		warmDone := make(chan struct{})
+		go func() {
+			defer close(warmDone)
+			proc.parser.WarmFirstSegments(warmCtx, n.Files)
+		}()
 		var fastFailErr error
 		brokenIdx, missingIDs, degradedFiles, fastFailErr = proc.preParseFastFail(ctx, n, cfg, queueID, category, downloadID)
+		if fastFailErr != nil {
+			cancelWarm()
+		}
+		<-warmDone
+		cancelWarm()
 		if fastFailErr != nil {
 			// A deferral is not a failure: propagate it so the service parks
 			// the queue item pending the repair. Checked before the

--- a/internal/usenet/flight.go
+++ b/internal/usenet/flight.go
@@ -21,6 +21,7 @@ type articleBuf struct {
 	err     error
 	attempt int
 	leading bool
+	lead    int // bumped on every claimLead; identifies the current leader
 	refs    int
 	size    int64
 	notify  chan struct{} // closed and replaced on every state change
@@ -137,13 +138,28 @@ func (a *articleBuf) claimLead() bool {
 		return false
 	}
 	a.leading = true
+	a.lead++
 	return true
 }
 
-// releaseLead lets a follower take over after a leader gave up without
-// finishing (its reader was closed mid-article).
-func (a *articleBuf) releaseLead() {
+// leadGen identifies the current lead. A leader takes it right after
+// claimLead and passes it to releaseLead, so a release that arrives after
+// the lead has already moved on to another fetch is ignored.
+func (a *articleBuf) leadGen() int {
 	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.lead
+}
+
+// releaseLead lets a follower take over after the leader holding gen gave up
+// without finishing (its reader was closed mid-article). A stale gen is a
+// no-op: the lead has already been handed on.
+func (a *articleBuf) releaseLead(gen int) {
+	a.mu.Lock()
+	if !a.leading || a.lead != gen {
+		a.mu.Unlock()
+		return
+	}
 	a.leading = false
 	a.wakeLocked()
 	a.mu.Unlock()

--- a/internal/usenet/flight_test.go
+++ b/internal/usenet/flight_test.go
@@ -32,7 +32,7 @@ func TestArticleBufLeadAndWait(t *testing.T) {
 	if err := a.waitDone(timeoutCtx(t, 20*time.Millisecond)); !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("waitDone with a leader must block: %v", err)
 	}
-	a.releaseLead()
+	a.releaseLead(a.leadGen())
 	if err := a.waitDone(context.Background()); !errors.Is(err, errNoLeader) {
 		t.Fatalf("leaderless article must report errNoLeader: %v", err)
 	}
@@ -54,4 +54,28 @@ func timeoutCtx(t *testing.T, d time.Duration) context.Context {
 	ctx, cancel := context.WithTimeout(context.Background(), d)
 	t.Cleanup(cancel)
 	return ctx
+}
+
+// A release carrying a stale lead generation must not strip the lead from
+// the fetch that took over: a closed reader's late release would otherwise
+// leave the article leaderless with a fetch still running, and readers of
+// that fetch would wait forever.
+func TestReleaseLeadIgnoresStaleGeneration(t *testing.T) {
+	a := newArticleBuf(8)
+	if !a.claimLead() {
+		t.Fatal("first claim must win")
+	}
+	old := a.leadGen()
+	a.releaseLead(old)
+	if !a.claimLead() {
+		t.Fatal("second claim must win after release")
+	}
+	a.releaseLead(old)
+	if a.claimLead() {
+		t.Fatal("stale release must not clear the new leader")
+	}
+	a.releaseLead(a.leadGen())
+	if !a.claimLead() {
+		t.Fatal("current release must clear the lead")
+	}
 }

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -628,15 +628,24 @@ func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segmen
 	art := seg.attachShared(b.flights)
 	for {
 		if art.claimLead() {
+			fetchCtx, cancelFetch := b.fetchContext(ctx, art, keepOnClose)
 			// A fetch that may outlive its reader keeps the article in the
-			// flight map until it ends, so a reader arriving after the close
-			// joins it as a follower instead of fetching the article again.
+			// flight map for as long as it may still finish, so a reader
+			// arriving after the close joins it as a follower instead of
+			// fetching the article again. The pin is tied to fetchCtx, not to
+			// the fetch returning: a wire call that never comes back must not
+			// hold the lead forever, or every later reader of the article
+			// would wait on it for its whole context.
 			if keepOnClose && b.flights.acquire(seg.Id, seg.SegmentSize) == art {
-				defer b.flights.release(seg.Id, art)
+				context.AfterFunc(fetchCtx, func() {
+					if ctx.Err() != nil {
+						art.releaseLead()
+					}
+					b.flights.release(seg.Id, art)
+				})
 			} else if keepOnClose {
 				b.flights.release(seg.Id, art)
 			}
-			fetchCtx, cancelFetch := b.fetchContext(ctx, art, keepOnClose)
 			data, err := b.fetchWithRetry(fetchCtx, cp, seg, art)
 			cancelFetch()
 			switch {

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -628,6 +628,7 @@ func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segmen
 	art := seg.attachShared(b.flights)
 	for {
 		if art.claimLead() {
+			lead := art.leadGen()
 			fetchCtx, cancelFetch := b.fetchContext(ctx, art, keepOnClose)
 			// A fetch that may outlive its reader keeps the article in the
 			// flight map for as long as it may still finish, so a reader
@@ -636,15 +637,17 @@ func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segmen
 			// the fetch returning: a wire call that never comes back must not
 			// hold the lead forever, or every later reader of the article
 			// would wait on it for its whole context.
-			if keepOnClose && b.flights.acquire(seg.Id, seg.SegmentSize) == art {
-				context.AfterFunc(fetchCtx, func() {
-					if ctx.Err() != nil {
-						art.releaseLead()
-					}
-					b.flights.release(seg.Id, art)
-				})
-			} else if keepOnClose {
-				b.flights.release(seg.Id, art)
+			if keepOnClose {
+				if kept := b.flights.acquire(seg.Id, seg.SegmentSize); kept == art {
+					context.AfterFunc(fetchCtx, func() {
+						if ctx.Err() != nil {
+							art.releaseLead(lead)
+						}
+						b.flights.release(seg.Id, art)
+					})
+				} else {
+					b.flights.release(seg.Id, kept)
+				}
 			}
 			data, err := b.fetchWithRetry(fetchCtx, cp, seg, art)
 			cancelFetch()
@@ -656,7 +659,7 @@ func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segmen
 				return data, nil
 			case ctx.Err() != nil && !errors.Is(err, nntppool.ErrArticleNotFound):
 				// This reader is going away; let a follower take over.
-				art.releaseLead()
+				art.releaseLead(lead)
 				return nil, err
 			default:
 				// A definite answer (gone everywhere, or every attempt failed):

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -534,8 +534,38 @@ func (b *UsenetReader) GetBufferedOffset() int64 {
 	return b.rg.start + b.scheduledBytes
 }
 
-// downloadSegmentWithRetry attempts to download a segment with retry logic for pool unavailability
-func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segment) ([]byte, error) {
+// keepFetchCompletionTimeout bounds how long a fetch may run on after its
+// reader closed. One attempt window is enough: the article was already
+// arriving when the reader left.
+const keepFetchCompletionTimeout = 15 * time.Second
+
+// fetchContext returns the context a streaming fetch runs under. Without
+// keepOnClose it is ctx itself. With it, the fetch survives ctx being
+// cancelled once the article has started arriving: the pool would otherwise
+// abort the body (and, past its drain limit, close the connection), and the
+// next open of the same head would fetch the whole article again. An
+// article with no bytes yet is still cancelled with ctx.
+func (b *UsenetReader) fetchContext(ctx context.Context, art *articleBuf, keepOnClose bool) (context.Context, context.CancelFunc) {
+	if !keepOnClose || art == nil {
+		return ctx, func() {}
+	}
+	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), keepFetchCompletionTimeout)
+	go func() {
+		select {
+		case <-fetchCtx.Done():
+		case <-ctx.Done():
+			if art.published() == 0 {
+				cancel()
+			}
+		}
+	}()
+	return fetchCtx, cancel
+}
+
+// downloadSegmentWithRetry attempts to download a segment with retry logic for
+// pool unavailability. keepOnClose lets a started streaming fetch finish after
+// ctx is cancelled; see fetchContext.
+func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segment, keepOnClose bool) ([]byte, error) {
 	// Cache HIT: skip NNTP entirely
 	if b.segmentStore != nil {
 		if data, ok := b.segmentStore.Get(seg.Id); ok {
@@ -598,7 +628,17 @@ func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segmen
 	art := seg.attachShared(b.flights)
 	for {
 		if art.claimLead() {
-			data, err := b.fetchWithRetry(ctx, cp, seg, art)
+			// A fetch that may outlive its reader keeps the article in the
+			// flight map until it ends, so a reader arriving after the close
+			// joins it as a follower instead of fetching the article again.
+			if keepOnClose && b.flights.acquire(seg.Id, seg.SegmentSize) == art {
+				defer b.flights.release(seg.Id, art)
+			} else if keepOnClose {
+				b.flights.release(seg.Id, art)
+			}
+			fetchCtx, cancelFetch := b.fetchContext(ctx, art, keepOnClose)
+			data, err := b.fetchWithRetry(fetchCtx, cp, seg, art)
+			cancelFetch()
 			switch {
 			case err == nil:
 				if b.segmentStore != nil && data != nil {
@@ -831,6 +871,10 @@ func (b *UsenetReader) downloadManager(ctx context.Context) {
 		// Schedule next segment for download
 		idx := b.nextToDownload
 		b.nextToDownload++
+		// Demand-window articles are what a reopen of this position needs
+		// next, so they are worth finishing after a close; speculative
+		// read-ahead is not.
+		keepOnClose := b.priority && ahead < demandDepth
 		b.mu.Unlock()
 
 		seg, err := b.rg.GetSegment(idx)
@@ -896,7 +940,7 @@ func (b *UsenetReader) downloadManager(ctx context.Context) {
 				return
 			}
 
-			data, err := b.downloadSegmentWithRetry(taskCtx, s)
+			data, err := b.downloadSegmentWithRetry(taskCtx, s, keepOnClose)
 
 			if err != nil {
 				if errors.Is(err, nntppool.ErrArticleNotFound) {

--- a/internal/usenet/usenet_reader_flight_test.go
+++ b/internal/usenet/usenet_reader_flight_test.go
@@ -69,8 +69,9 @@ func TestTwoReadersShareOneDownload(t *testing.T) {
 	}
 }
 
-// A leader closed mid-article hands the download to a follower, which
-// completes it with exact bytes.
+// A leader closed mid-article keeps the demand-window fetch running to
+// completion, so a follower reads exact bytes from the shared buffer
+// without a second fetch.
 func TestFollowerTakesOverWhenLeaderCloses(t *testing.T) {
 	ctx := context.Background()
 	const segSize = 4096
@@ -105,8 +106,8 @@ func TestFollowerTakesOverWhenLeaderCloses(t *testing.T) {
 	if !bytes.Equal(got, segments.Payload(0, segSize)) {
 		t.Fatalf("follower got %d bytes, want exact payload", len(got))
 	}
-	if calls := fp.BodyStreamPriorityCalls(); calls != 2 {
-		t.Fatalf("stream fetches = %d, want 2 (leader aborted, follower refetched)", calls)
+	if calls := fp.BodyStreamPriorityCalls(); calls != 1 {
+		t.Fatalf("stream fetches = %d, want 1 (closed leader finished the article for the follower)", calls)
 	}
 }
 

--- a/internal/usenet/usenet_reader_keep_test.go
+++ b/internal/usenet/usenet_reader_keep_test.go
@@ -216,3 +216,57 @@ func TestLateReaderJoinsFinishingArticle(t *testing.T) {
 	}
 	_ = late.Close()
 }
+
+// A closed reader's kept fetch that never returns must not pin the article
+// in the flight map: a reader opened later for the same message-ID would
+// otherwise join a leader that can never finish and hang for its whole
+// context. Once the kept fetch's window ends the article is dropped from the
+// map and its lead released, so the late reader fetches for itself.
+func TestLateReaderNotPinnedByHungKeptFetch(t *testing.T) {
+	const segSize = 4096
+	hung := fakepool.New()
+	hung.SetBehavior(segments.MessageID(0), fakepool.SegmentBehavior{Bytes: segments.Payload(0, segSize)})
+	hung.BlockUntil(make(chan struct{})) // never released, ignores ctx
+
+	fm := newFlightMap()
+	mk := func(fp *fakepool.Client) *UsenetReader {
+		rg := buildEagerRange(context.Background(), t, 1, segSize)
+		getter := func() (pool.NntpClient, error) { return fp, nil }
+		ur, err := NewUsenetReader(context.Background(), getter, rg, 4, noopMetrics{}, "pin-test", nil, withFlightMap(fm))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return ur
+	}
+	first := mk(hung)
+	first.Start()
+	waitCalls(t, hung, 1)
+	// Close waits on the hung fetch; do not let that block the test.
+	go func() { _ = first.Close() }()
+
+	healthy := fakepool.New()
+	healthy.SetBehavior(segments.MessageID(0), fakepool.SegmentBehavior{Bytes: segments.Payload(0, segSize)})
+	late := mk(healthy)
+	late.Start()
+	defer func() { _ = late.Close() }()
+	buf := make([]byte, segSize)
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.ReadFull(late, buf)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("late reader: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("late reader hung behind a closed reader's fetch that never returns")
+	}
+	if !bytes.Equal(buf, segments.Payload(0, segSize)) {
+		t.Fatal("late reader got wrong bytes")
+	}
+	if got := healthy.BodyStreamPriorityCalls(); got != 1 {
+		t.Fatalf("late reader fetches = %d, want 1", got)
+	}
+}

--- a/internal/usenet/usenet_reader_keep_test.go
+++ b/internal/usenet/usenet_reader_keep_test.go
@@ -1,0 +1,218 @@
+package usenet
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/pool"
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/altmount/internal/testsupport/segments"
+)
+
+type syncStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newSyncStore() *syncStore { return &syncStore{m: map[string][]byte{}} }
+func (s *syncStore) Get(id string) ([]byte, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.m[id]
+	return v, ok
+}
+func (s *syncStore) Put(id string, data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[id] = data
+	return nil
+}
+func (s *syncStore) ids() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.m))
+	for k := range s.m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func newKeepReader(t *testing.T, fp *fakepool.Client, store SegmentStore, n, segSize, prefetch int) *UsenetReader {
+	t.Helper()
+	ctx := context.Background()
+	rg := buildEagerRange(ctx, t, n, segSize)
+	getter := func() (pool.NntpClient, error) { return fp, nil }
+	ur, err := NewUsenetReader(ctx, getter, rg, prefetch, noopMetrics{}, "keep-test", store, withFlightMap(newFlightMap()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ur
+}
+
+func waitCalls(t *testing.T, fp *fakepool.Client, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for fp.BodyStreamPriorityCalls() < want && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := fp.BodyStreamPriorityCalls(); got < want {
+		t.Fatalf("stream fetches = %d, want at least %d", got, want)
+	}
+}
+
+func waitStored(t *testing.T, store *syncStore, id string, want []byte) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got, ok := store.Get(id); ok {
+			if !bytes.Equal(got, want) {
+				t.Fatalf("stored %d bytes for %s, want exact payload", len(got), id)
+			}
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("article %s never reached the store", id)
+}
+
+// A reader closed while its demand-window article is mid-wire lets that
+// article finish and stores it, so the next open of the same head is a hit
+// rather than a second fetch (and the pool keeps its connection instead of
+// aborting a body).
+func TestClosedReaderFinishesStartedArticleIntoStore(t *testing.T) {
+	const segSize = 4096
+	fp := fakepool.New()
+	gate := make(chan struct{})
+	fp.SetBehavior(segments.MessageID(0), fakepool.SegmentBehavior{
+		Bytes: segments.Payload(0, segSize), ChunkSize: 1024, TailGate: gate,
+	})
+	store := newSyncStore()
+	ur := newKeepReader(t, fp, store, 1, segSize, 4)
+	ur.Start()
+	waitCalls(t, fp, 1)
+	time.Sleep(20 * time.Millisecond) // first chunk is written before the gate holds
+
+	closed := make(chan struct{})
+	go func() { _ = ur.Close(); close(closed) }()
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("Close must not wait for the in-flight article")
+	}
+	if _, ok := store.Get(segments.MessageID(0)); ok {
+		t.Fatal("article stored before its tail arrived")
+	}
+
+	close(gate)
+	waitStored(t, store, segments.MessageID(0), segments.Payload(0, segSize))
+	if got := fp.BodyStreamPriorityCalls(); got != 1 {
+		t.Fatalf("stream fetches = %d, want 1 (no refetch after close)", got)
+	}
+}
+
+// An article whose fetch has not delivered a byte yet is abandoned on close
+// as before: there is nothing to finish and no reason to hold a connection.
+func TestClosedReaderAbandonsArticleWithNoBytes(t *testing.T) {
+	const segSize = 4096
+	fp := fakepool.New()
+	fp.SetBehavior(segments.MessageID(0), fakepool.SegmentBehavior{
+		Bytes: segments.Payload(0, segSize), Latency: 300 * time.Millisecond,
+	})
+	store := newSyncStore()
+	ur := newKeepReader(t, fp, store, 1, segSize, 4)
+	ur.Start()
+	waitCalls(t, fp, 1)
+	_ = ur.Close()
+
+	time.Sleep(500 * time.Millisecond)
+	if _, ok := store.Get(segments.MessageID(0)); ok {
+		t.Fatal("an article with no bytes on the wire must not be completed after close")
+	}
+}
+
+// Speculative prefetch beyond the demand window is abandoned on close even
+// when bytes have started, so a seek does not keep the whole read-ahead
+// window downloading.
+func TestClosedReaderAbandonsSpeculativeArticles(t *testing.T) {
+	const n, segSize = 6, 4096
+	fp := fakepool.New()
+	gate := make(chan struct{})
+	for i := 0; i < n; i++ {
+		fp.SetBehavior(segments.MessageID(i), fakepool.SegmentBehavior{
+			Bytes: segments.Payload(i, segSize), ChunkSize: 1024, TailGate: gate,
+		})
+	}
+	store := newSyncStore()
+	ur := newKeepReader(t, fp, store, n, segSize, n)
+	ur.Start()
+	waitCalls(t, fp, int64(n))
+	time.Sleep(20 * time.Millisecond)
+	_ = ur.Close()
+	close(gate)
+
+	for i := 0; i < demandDepth; i++ {
+		waitStored(t, store, segments.MessageID(i), segments.Payload(i, segSize))
+	}
+	time.Sleep(100 * time.Millisecond)
+	if got := len(store.ids()); got != demandDepth {
+		t.Fatalf("stored %d articles after close, want only the %d demand-window ones: %v", got, demandDepth, store.ids())
+	}
+}
+
+// A reader opened while a closed reader's demand-window article is still
+// finishing joins that fetch as a follower instead of starting a second one,
+// and reads the exact bytes from the shared buffer.
+func TestLateReaderJoinsFinishingArticle(t *testing.T) {
+	const segSize = 4096
+	fp := fakepool.New()
+	gate := make(chan struct{})
+	fp.SetBehavior(segments.MessageID(0), fakepool.SegmentBehavior{
+		Bytes: segments.Payload(0, segSize), ChunkSize: 1024, TailGate: gate,
+	})
+	store := newSyncStore()
+	fm := newFlightMap()
+	mk := func() *UsenetReader {
+		rg := buildEagerRange(context.Background(), t, 1, segSize)
+		getter := func() (pool.NntpClient, error) { return fp, nil }
+		ur, err := NewUsenetReader(context.Background(), getter, rg, 4, noopMetrics{}, "late-test", store, withFlightMap(fm))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return ur
+	}
+	first := mk()
+	first.Start()
+	waitCalls(t, fp, 1)
+	time.Sleep(20 * time.Millisecond)
+	_ = first.Close()
+
+	late := mk()
+	late.Start()
+	buf := make([]byte, segSize)
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.ReadFull(late, buf)
+		done <- err
+	}()
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("late reader: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("late reader never completed")
+	}
+	if !bytes.Equal(buf, segments.Payload(0, segSize)) {
+		t.Fatal("late reader got wrong bytes")
+	}
+	if got := fp.BodyStreamPriorityCalls(); got != 1 {
+		t.Fatalf("stream fetches = %d, want 1 (late reader must join the finishing fetch)", got)
+	}
+	_ = late.Close()
+}


### PR DESCRIPTION
## Summary

Local rerun of [Viren070/nzb-streaming-benchmarks](https://github.com/Viren070/nzb-streaming-benchmarks) against AltMount `2f9a80d7` and the full field (raw, AIOStreams, nzbdav, nzbdavex, InfiniDysk, StremThru, StreamNZB, Decypharr), published as `bench/nzb-streaming-benchmarks/RESULTS.md` with a provenance preamble, plus three latency fixes for the gaps it exposed.

**Benchmark result (pre-fix binary):** AltMount 10/11 served, 0 wrongly served, the one gap shared by every app; cold TTFB 62 ms (best), full seek 205 ms (best), RSS/item 508 MiB; behind AIOStreams on click→byte (1.18 s vs 1.12 s) and warm TTFB (11 vs 4 ms, 42–46 ms on plain posts). Corpus is local, so numbers compare within the report only.

**Fixes**

1. `postprocessor/coordinator.go`: the 1 s mount-propagation wait ran on every import because `arrs.Service` is constructed unconditionally; gated on configured instances + notifiable item.
2. `usenet/usenet_reader.go`: a demand-window article fetch that has started receiving bytes now survives reader close (15 s cap), is stored, and holds its flight-map entry so late readers join it. Previously a 1 MB head read of a 4 MB article was aborted mid-body (closing the connection past nntppool's 1 MiB drain limit) and every reopen refetched. Speculative read-ahead is still cancelled.
3. `importer/processor.go` + `parser.WarmFirstSegments`: first-segment fetches overlap the fast-fail probe; the parse pass hits the head cache.

**Measured with the harness after the fixes**

| | Before | After |
|---|---:|---:|
| Warm TTFB, plain posts | 42–46 ms (bimodal to 470 ms) | 1.8–2.4 ms |
| 1-byte probe TTFB | 45–200 ms | 2.5–4.3 ms |
| plain-large pre-processing | 1.3–1.9 s | ~0.7–0.8 s |

## Test plan

- [x] New tests: `TestShouldWaitForMountPropagation`, `TestClosedReader*` (3), `TestLateReaderJoinsFinishingArticle`, `TestWarmFirstSegments*` (2); `TestFollowerTakesOverWhenLeaderCloses` updated to the new single-fetch behaviour
- [x] `go test -race ./internal/usenet/... ./internal/importer/...`
- [x] `go build ./... && go vet ./...`; golangci-lint 2.13.0 clean on changed packages (`make`'s `go tool golangci-lint` fails identically on main with a Go 1.27 export-data mismatch)
- [x] Harness rerun on rar4-small / plain-medium / plain-large, twice, with the table above