### PR TITLE
perf(par2repair): repair fetches ride the pool's background lane

### DIFF
--- a/cmd/altmount/cmd/setup.go
+++ b/cmd/altmount/cmd/setup.go
@@ -402,18 +402,14 @@ func startPar2RepairService(
 	configGetter config.ConfigGetter,
 	streamsActive func() bool,
 ) *par2repair.Service {
-	// Repair fetches hold both budgets: the repair's own cap (narrow, so at
-	// most that many fetches queue on the shared budget) and the pool-wide
-	// import connection budget, whose stream headroom makes repair yield to
-	// playback exactly as imports do.
+	// Repair fetches ride the pool's background lane, which the pool keeps
+	// behind playback and imports on its own. The repair's cap only bounds how
+	// much of an idle pool one repair may fill.
 	fetcher := par2repair.NewPoolFetcher(func() (par2repair.BodyClient, error) {
 		return poolManager.GetPool()
-	}, par2repair.CombineBudgets(
-		par2repair.NewConnLimiter(func() int {
-			return configGetter().Par2Repair.EffectiveMaxConnections()
-		}),
-		par2repair.ConnBudgetFunc(poolManager.AcquireImportConnection),
-	))
+	}, par2repair.NewConnLimiter(func() int {
+		return configGetter().Par2Repair.EffectiveMaxConnections()
+	}))
 	// Stream-aware sweep width (conservative while anything plays, bounded
 	// widening when idle), further capped by the repair's own connection
 	// budget so a 10-connection repair never floods every connection's STAT

--- a/docs/superpowers/plans/2026-09-05-nntppool-background-lane.md
+++ b/docs/superpowers/plans/2026-09-05-nntppool-background-lane.md
@@ -1,0 +1,83 @@
+# Background Request Lane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop PAR2 repair from starving playback by adding a third, lowest-priority request lane to nntppool and moving repair traffic onto it.
+
+**Architecture:** nntppool already has two lanes (priority, normal) read in strict preference by every connection writer. A `background` lane is read only after both are found empty, and only while the provider group's background in-flight count is under a floor whenever any foreground request was dispatched in the last few seconds. When nothing else is asking, background may use every connection. altmount then calls `BodyBackground` and `StatMany{Background: true}` from par2repair and drops its caller-side workarounds.
+
+**Tech Stack:** Go 1.25+, nntppool v4 (`~/mio/nntppool`), altmount (`internal/par2repair`, `internal/pool`, `cmd/altmount/cmd/setup.go`).
+
+**Spec:** Conversation decision of 2026-09-05: scheduler-level priority with a background floor of one quarter of the group, implemented in the library, not in the caller.
+
+## Global Constraints
+
+- Conventional Commits; branches `feat/background-lane` (nntppool) and `perf/par2repair-background-lane` (altmount).
+- No competitor names anywhere in code, comments, or commits.
+- nntppool: `go test ./... -count=1` green and `go tool golangci-lint run` clean before each commit.
+- Never trade correctness: every request that increments the background in-flight counter must decrement it on every exit path (reader completion and pending drain).
+
+---
+
+### Task 1 (nntppool): lane type and strict-preference read order
+
+**Files:**
+- Modify: `nntp.go` (Request struct ~line 214-222, `NNTPConnection` struct ~259, `tryNextRequest` ~500, writer blocking select ~1200, `runConnSlot` ~805-845 and ~928, `startProviderGroup` ~2140, `tryGroupTimeout` ~2700, `sendSync`, `tryGroup`, `tryGroupResilient`, `doSendWithRetry`)
+- Modify: `stat.go` (`statOne`, `statViaGroup`, `StatManyOptions`, `StatMany`)
+- Modify: `client.go` (new `SendBackground`, `BodyBackground`, `StatBackground`)
+- Modify: `metrics.go` (`providerStats` gains `bgInflight atomic.Int32`, `lastForeground atomic.Int64`, `bgFloor int32`)
+- Test: `background_lane_test.go`
+
+**Interfaces produced:**
+```go
+type lane uint8
+const ( laneNormal lane = iota; lanePriority; laneBackground )
+func (c *Client) SendBackground(ctx, payload, bodyWriter, onMeta...) <-chan Response
+func (c *Client) BodyBackground(ctx, messageID, onMeta...) (*ArticleBody, error)
+func (c *Client) StatBackground(ctx, messageID) (*StatResult, error)
+type StatManyOptions struct { ...; Background bool }
+type Provider struct { ...; BackgroundFloor int } // 0 => max(1, Connections/4)
+```
+
+- [ ] Step 1: failing test `TestTryNextRequest_BackgroundAfterNormal` (100 trials: bg and normal both queued, normal always wins) plus `TestTryNextRequest_BackgroundServedWhenAlone`.
+- [ ] Step 2: run, expect compile failure on `bgCh`.
+- [ ] Step 3: add `lane` type, `Request.lane`, `NNTPConnection.bgCh`, probe `c.bgLane()` last in `tryNextRequest` and as a case in the blocking select; `bgLane()` returns `c.bgCh` when `c.stats == nil`.
+- [ ] Step 4: green; commit `feat(lane): add background request lane read after priority and normal`.
+
+### Task 2 (nntppool): background floor while foreground is recent
+
+- [ ] Step 1: failing test `TestBackgroundLaneGate`: table over (`lastForeground` age, `bgInflight`, floor) → expect nil channel only when age < `backgroundYieldWindow` AND inflight >= floor.
+- [ ] Step 2: run, expect failure (`bgLane` ignores stats).
+- [ ] Step 3: implement `backgroundLaneFor(stats *providerStats, bgCh <-chan *Request)`; `backgroundYieldWindow = 3 * time.Second`.
+- [ ] Step 4: green; commit `feat(lane): cap background in-flight while foreground traffic is recent`.
+
+### Task 3 (nntppool): accounting on the wire
+
+- [ ] Step 1: failing test `TestBackgroundInflightAccounting`: unit-level writer/reader with a pipe server; after one `BodyBackground` completes, `g.stats.bgInflight == 0` and `lastForeground` is untouched; after one `Body`, `lastForeground` is recent.
+- [ ] Step 2: run, expect failure (counter never moves).
+- [ ] Step 3: in both writer paths (bootstrap and main loop), after `bw.Write` succeeds: background → `stats.bgInflight.Add(1)`, `req.heldBg = true`; otherwise `stats.lastForeground.Store(now)`. Release in reader completion (next to `heldBody`) and in `drainPending`.
+- [ ] Step 4: green; commit `feat(lane): track background in-flight per provider group`.
+
+### Task 4 (nntppool): dispatch and public API
+
+- [ ] Step 1: failing tests `TestBackgroundDispatchUsesBackgroundChannel` (stand-in receiver on `g.bgCh` gets the request; `hotIdleBodyCh`/`hotPrioCh` stand-ins do not) and `TestClient_BodyBackgroundRoundTrip` (real pipe server, decoded bytes match) and `TestStatManyBackgroundOption`.
+- [ ] Step 2: run, expect compile failure on `BodyBackground`.
+- [ ] Step 3: thread `lane` through `sendSync`, `tryGroup*`, `doSendWithRetry` (post-430 escalation: normal → priority, background stays background), `statOne`, `statViaGroup`; `g.bgCh` buffered `p.Connections`; `runConnSlot` idle wait includes the gated `bgCh`; `Provider.BackgroundFloor` resolved into `stats.bgFloor` in `startProviderGroup`.
+- [ ] Step 4: `go test ./... -count=1` and `go tool golangci-lint run` green; commit `feat(client): BodyBackground, StatBackground, SendBackground and StatManyOptions.Background`.
+- [ ] Step 5: tag `v4.23.0`, push branch and tag.
+
+### Task 5 (altmount): repair on the background lane
+
+**Files:**
+- Modify: `go.mod` (nntppool v4.23.0)
+- Modify: `internal/par2repair/fetch.go` (`BodyClient` uses `BodyBackground`; `statOnce` passes `Background: true`)
+- Modify: `internal/par2repair/job.go` (remove `yieldFetchDepth` collapse from `fetchDepth`; keep fold-width yield)
+- Modify: `cmd/altmount/cmd/setup.go` (drop the import-budget half of `CombineBudgets`)
+- Modify: `internal/pool/pool.go` and fakes if `BodyBackground` must be on the `ConnectionPool` interface
+- Test: `internal/par2repair/fetch_test.go`, `job_test.go`
+
+- [ ] Step 1: failing test: fake `BodyClient` records which method was called; `PoolFetcher.Fetch` must call `BodyBackground`; `statOnce` must pass `Background: true`. `TestFetchDepthYieldsToStreams` inverted: depth no longer collapses when streams are active.
+- [ ] Step 2: run, expect compile failures.
+- [ ] Step 3: implement; update `Par2RepairConfig.MaxConnections` doc comment to say repair runs on the background lane.
+- [ ] Step 4: `go build ./... && go test ./internal/par2repair/... ./internal/pool/...` green; commit `perf(par2repair): fetch on the pool's background lane and drop caller-side yielding`.
+- [ ] Step 5: push, open PR.

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/javi11/gopar-turbo v0.2.1
-	github.com/javi11/nntppool/v4 v4.22.2
+	github.com/javi11/nntppool/v4 v4.22.3-0.20260905174153-b41f86bcc694
 	github.com/javi11/nxg v0.1.0
 	github.com/javi11/nzbparser v0.5.5
 	github.com/javi11/rardecode/v2 v2.2.4

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/javi11/gopar-turbo v0.2.1
-	github.com/javi11/nntppool/v4 v4.22.3-0.20260905174153-b41f86bcc694
+	github.com/javi11/nntppool/v4 v4.22.3-0.20260905181219-f59773674c9b
 	github.com/javi11/nxg v0.1.0
 	github.com/javi11/nzbparser v0.5.5
 	github.com/javi11/rardecode/v2 v2.2.4

--- a/go.sum
+++ b/go.sum
@@ -382,6 +382,10 @@ github.com/javi11/nntppool/v4 v4.22.2 h1:JHE+78M3yqJp1AGbJQhFKglB0l4cm45XwwetskJ
 github.com/javi11/nntppool/v4 v4.22.2/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
 github.com/javi11/nntppool/v4 v4.22.3-0.20260905174153-b41f86bcc694 h1:+JMpLDUMTlbOulcR8oI4WPSlBmNaHacpomGqvc+M0JQ=
 github.com/javi11/nntppool/v4 v4.22.3-0.20260905174153-b41f86bcc694/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
+github.com/javi11/nntppool/v4 v4.22.3-0.20260905180010-2b928c3f6a9a h1:EF8NVzeaN/at+6ZO/51yNwLDsbFIWWtw54yW16J3qTA=
+github.com/javi11/nntppool/v4 v4.22.3-0.20260905180010-2b928c3f6a9a/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
+github.com/javi11/nntppool/v4 v4.22.3-0.20260905181219-f59773674c9b h1:FRcY+c9I9oy6Fy9U0Z2vfxIwFwHdIXWUlCkbjpDBweU=
+github.com/javi11/nntppool/v4 v4.22.3-0.20260905181219-f59773674c9b/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
 github.com/javi11/nxg v0.1.0 h1:CTThldYlaVIPIhpkrMw0HcTD0NLrW1uYMoDILjjEOtM=
 github.com/javi11/nxg v0.1.0/go.mod h1:+GvYpp+y1oq+qBOWxFMvfTjtin/0zCeomWfjiPkiu8A=
 github.com/javi11/nzbparser v0.5.5 h1:kMKyX0xNO7bIeIlQvSPGzdWs71MG2Krf+yojOj+FuUc=

--- a/go.sum
+++ b/go.sum
@@ -380,6 +380,8 @@ github.com/javi11/gopar-turbo v0.2.1 h1:0xUZtofwBcjxle6QIl9EZAwxmLtWkECMM69tQhmc
 github.com/javi11/gopar-turbo v0.2.1/go.mod h1:fOQZIbPz+ADJ8vGAzVLXvQhsOsE08hvAcev8nQvBFfY=
 github.com/javi11/nntppool/v4 v4.22.2 h1:JHE+78M3yqJp1AGbJQhFKglB0l4cm45XwwetskJQS+A=
 github.com/javi11/nntppool/v4 v4.22.2/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
+github.com/javi11/nntppool/v4 v4.22.3-0.20260905174153-b41f86bcc694 h1:+JMpLDUMTlbOulcR8oI4WPSlBmNaHacpomGqvc+M0JQ=
+github.com/javi11/nntppool/v4 v4.22.3-0.20260905174153-b41f86bcc694/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
 github.com/javi11/nxg v0.1.0 h1:CTThldYlaVIPIhpkrMw0HcTD0NLrW1uYMoDILjjEOtM=
 github.com/javi11/nxg v0.1.0/go.mod h1:+GvYpp+y1oq+qBOWxFMvfTjtin/0zCeomWfjiPkiu8A=
 github.com/javi11/nzbparser v0.5.5 h1:kMKyX0xNO7bIeIlQvSPGzdWs71MG2Krf+yojOj+FuUc=

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -100,9 +100,10 @@ type Par2RepairConfig struct {
 	MaxConcurrentJobs int `yaml:"max_concurrent_jobs" mapstructure:"max_concurrent_jobs" json:"max_concurrent_jobs,omitempty"`
 	// MaxConnections bounds how many NNTP connections repair jobs use for
 	// article fetches (shared across concurrent jobs). Repair streams the
-	// whole release once, so this directly sets its download speed; it runs on
-	// the pool's normal lane, so streaming playback keeps priority either way.
-	// 0 (default) means 10.
+	// whole release once, so this directly sets its download speed on an idle
+	// pool. Fetches ride the pool's background lane: while anything streams
+	// or imports, the pool holds repair to a quarter of each provider's
+	// connections regardless of this value. 0 (default) means 10.
 	MaxConnections int `yaml:"max_connections" mapstructure:"max_connections" json:"max_connections,omitempty"`
 	// MinReleaseSizeMB / MaxReleaseSizeMB bound the size of releases repair
 	// takes on (content bytes, PAR2 files excluded). A repair downloads the

--- a/internal/par2repair/fetch.go
+++ b/internal/par2repair/fetch.go
@@ -11,17 +11,16 @@ import (
 	"github.com/javi11/nntppool/v4"
 )
 
-// BodyClient is the one pool method the fetcher needs: a normal-lane (import)
+// BodyClient is the one pool method the fetcher needs: a background-lane
 // article body fetch. Satisfied by pool.NntpClient.
 type BodyClient interface {
-	Body(ctx context.Context, messageID string, onMeta ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error)
+	BodyBackground(ctx context.Context, messageID string, onMeta ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error)
 }
 
 // ConnBudget bounds how many article fetches the repair keeps on the wire at
-// once. Repair traffic runs on the pool's normal lane (streaming reads use
-// the priority lane); the wired budget stacks the repair's own cap with the
-// pool-wide import connection budget, so repair both shapes background
-// bandwidth and yields headroom to active streams the way imports do.
+// once. Repair traffic rides the pool's background lane, which the pool
+// itself keeps behind playback and imports; the budget only shapes how much
+// of an idle pool a repair may fill.
 type ConnBudget interface {
 	Acquire(ctx context.Context) (release func(), err error)
 }
@@ -111,8 +110,8 @@ func (l *connLimiter) Acquire(ctx context.Context) (func(), error) {
 }
 
 // PoolFetcher fetches decoded article payloads through the NNTP pool's
-// normal request lane, budget-gated like imports. The client is resolved per
-// fetch so the fetcher survives pool reconfiguration and boot ordering.
+// background lane. The client is resolved per fetch so the fetcher survives
+// pool reconfiguration and boot ordering.
 type PoolFetcher struct {
 	getClient func() (BodyClient, error)
 	budget    ConnBudget // optional; nil skips budget gating
@@ -277,7 +276,7 @@ func (p *PoolFetcher) statOnce(
 	}
 	resolved := make(map[string]bool, len(ids))
 	var firstErr error
-	for r := range sc.StatMany(statCtx, ids, nntppool.StatManyOptions{Concurrency: conc}) {
+	for r := range sc.StatMany(statCtx, ids, nntppool.StatManyOptions{Concurrency: conc, Background: true}) {
 		switch {
 		case errors.Is(r.Err, nntppool.ErrArticleNotFound):
 			missing[r.MessageID] = true
@@ -360,7 +359,7 @@ func (p *PoolFetcher) fetchOnce(ctx context.Context, messageID string) ([]byte, 
 		return nil, fmt.Errorf("par2repair: nntp pool unavailable: %w", err)
 	}
 	// nntppool adds the angle brackets itself; message IDs here are bare.
-	body, err := client.Body(ctx, messageID)
+	body, err := client.BodyBackground(ctx, messageID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/par2repair/fetch_test.go
+++ b/internal/par2repair/fetch_test.go
@@ -18,7 +18,7 @@ type fakeStatClient struct {
 	articles map[string]bool
 }
 
-func (c *fakeStatClient) Body(_ context.Context, messageID string, _ ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
+func (c *fakeStatClient) BodyBackground(_ context.Context, messageID string, _ ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
 	if !c.articles[messageID] {
 		return nil, nntppool.ErrArticleNotFound
 	}
@@ -62,7 +62,7 @@ type flakyStatClient struct {
 	calls    map[string]int
 }
 
-func (c *flakyStatClient) Body(_ context.Context, messageID string, _ ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
+func (c *flakyStatClient) BodyBackground(_ context.Context, messageID string, _ ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
 	if !c.articles[messageID] {
 		return nil, nntppool.ErrArticleNotFound
 	}
@@ -246,10 +246,63 @@ func TestPoolFetcherStatIDsUsesConfiguredStatConcurrency(t *testing.T) {
 		}
 	}
 }
+
+// laneRecordingClient counts which body lane each fetch used.
+type laneRecordingClient struct {
+	normal, background atomic.Int32
+}
+
+func (c *laneRecordingClient) Body(_ context.Context, _ string, _ ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
+	c.normal.Add(1)
+	return &nntppool.ArticleBody{Bytes: []byte("payload")}, nil
+}
+
+func (c *laneRecordingClient) BodyBackground(_ context.Context, _ string, _ ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
+	c.background.Add(1)
+	return &nntppool.ArticleBody{Bytes: []byte("payload")}, nil
+}
+
+// Repair reads a whole release nobody is waiting on. Every article must go
+// through the pool's background lane, so the pool itself keeps playback and
+// imports ahead of it instead of the fetcher guessing at a connection share.
+func TestPoolFetcherFetchesOnBackgroundLane(t *testing.T) {
+	client := &laneRecordingClient{}
+	f := NewPoolFetcher(func() (BodyClient, error) { return client, nil }, nil)
+
+	if _, err := f.Fetch(context.Background(), "a@x"); err != nil {
+		t.Fatal(err)
+	}
+	if got := client.background.Load(); got != 1 {
+		t.Fatalf("BodyBackground calls = %d, want 1", got)
+	}
+	if got := client.normal.Load(); got != 0 {
+		t.Fatalf("Body calls = %d, want 0: repair must not ride the normal lane", got)
+	}
+}
+
+// The liveness census is the same kind of work: it sweeps on the background
+// lane so a full-release STAT burst never queues ahead of a stream's STAT.
+func TestPoolFetcherStatIDsUsesBackgroundLane(t *testing.T) {
+	client := &concurrencyRecordingStatClient{fakeStatClient: fakeStatClient{articles: map[string]bool{"live@x": true}}}
+	f := NewPoolFetcher(func() (BodyClient, error) { return client, nil }, nil)
+
+	if _, err := f.StatIDs(context.Background(), []string{"live@x", "gone@x"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(client.opts) == 0 {
+		t.Fatal("StatMany never called")
+	}
+	for _, o := range client.opts {
+		if !o.Background {
+			t.Fatal("StatMany called without Background: census must ride the background lane")
+		}
+	}
+}
+
 // bodyOnlyClient has no stat surface; StatIDs must degrade to a no-op.
 type bodyOnlyClient struct{}
 
-func (bodyOnlyClient) Body(_ context.Context, _ string, _ ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
+func (bodyOnlyClient) BodyBackground(_ context.Context, _ string, _ ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
 	return &nntppool.ArticleBody{}, nil
 }
 
@@ -274,7 +327,7 @@ type flakyBodyClient struct {
 	err      error
 }
 
-func (c *flakyBodyClient) Body(_ context.Context, messageID string, _ ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
+func (c *flakyBodyClient) BodyBackground(_ context.Context, messageID string, _ ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.calls == nil {

--- a/internal/par2repair/job.go
+++ b/internal/par2repair/job.go
@@ -25,8 +25,8 @@ type ArticleFetcher interface {
 // fetchAhead is the default prefetch depth when no concurrency was
 // configured (WithConcurrency): how many article fetches a job keeps in
 // flight, and how many fetched-but-unconsumed payloads it buffers. Fetches
-// also pass through the repair connection budget, which is the real global
-// throttle.
+// ride the pool's background lane, which is what keeps them behind playback
+// and imports.
 const fetchAhead = 8
 
 // SweepDeadArticleError reports an article that was live at planning time but
@@ -127,19 +127,15 @@ func WithLiveConcurrency(get func() int) JobOption {
 
 // WithYieldToStreams wires a live playback-activity signal (typically the
 // stream tracker's count) into the job. While active() reports true, the
-// fetch pipeline collapses to yieldFetchDepth connections and the solver's
-// fold runs on a single goroutine, so a repair sharing the box with playback
-// costs it neither bandwidth nor CPU. Both bounds are re-read continuously —
-// a stream starting mid-sweep throttles the job at the next fetch/fold, and
-// its end restores full speed without restarting anything.
+// solver's fold runs on a single goroutine so a repair sharing the box with
+// playback costs it no CPU. Connections are not throttled here: repair
+// fetches ride the pool's background lane, and the pool keeps them behind
+// playback and imports itself. The bound is re-read continuously — a stream
+// starting mid-sweep narrows the fold at the next slice, and its end restores
+// full width without restarting anything.
 func WithYieldToStreams(active func() bool) JobOption {
 	return func(o *jobOptions) { o.streamsActive = active }
 }
-
-// yieldFetchDepth is the fetch pipeline depth while playback streams are
-// active: enough to keep the sweep moving, small enough that the repair's
-// normal-lane bodies leave the link and the CPU to the streams.
-const yieldFetchDepth = 2
 
 // yieldFoldWorkers is the solver fold width while playback streams are
 // active. The fold's memory traffic is rows × input rate on every core it
@@ -162,9 +158,6 @@ func (o jobOptions) fetchDepth() func() int {
 			if c := o.concurrency(); c > 0 {
 				n = c
 			}
-		}
-		if o.streamsActive != nil && o.streamsActive() {
-			n = min(n, yieldFetchDepth)
 		}
 		return min(n, maxFetchAhead)
 	}

--- a/internal/par2repair/job_test.go
+++ b/internal/par2repair/job_test.go
@@ -830,10 +830,10 @@ func TestPrefetchArticlesHonorsLiveDepthRaise(t *testing.T) {
 	}
 }
 
-// While playback streams, the job's fetch depth collapses to the yield bound
-// regardless of the configured repair connection count, and recovers as soon
-// as the streams stop.
-func TestFetchDepthYieldsToStreams(t *testing.T) {
+// The pool's background lane owns the connection share now: while playback
+// streams, the fetch depth stays at the configured bound instead of collapsing
+// to a caller-side guess, and only the solver's fold width still yields CPU.
+func TestFetchDepthIgnoresStreamActivity(t *testing.T) {
 	active := true
 	var o jobOptions
 	for _, opt := range []JobOption{
@@ -843,50 +843,15 @@ func TestFetchDepthYieldsToStreams(t *testing.T) {
 		opt(&o)
 	}
 	depth := o.fetchDepth()
-	if got := depth(); got != yieldFetchDepth {
-		t.Fatalf("streams active: depth = %d, want %d", got, yieldFetchDepth)
+	if got := depth(); got != 20 {
+		t.Fatalf("streams active: depth = %d, want the configured 20", got)
+	}
+	if limit := o.foldWorkerLimit(); limit == nil || limit() != yieldFoldWorkers {
+		t.Fatal("streams active: fold width must still yield to playback")
 	}
 	active = false
 	if got := depth(); got != 20 {
 		t.Fatalf("streams idle: depth = %d, want 20", got)
-	}
-
-	// A configured bound below the yield bound stays authoritative.
-	var narrow jobOptions
-	for _, opt := range []JobOption{
-		WithLiveConcurrency(func() int { return 1 }),
-		WithYieldToStreams(func() bool { return true }),
-	} {
-		opt(&narrow)
-	}
-	if got := narrow.fetchDepth()(); got != 1 {
-		t.Fatalf("narrow config while yielding: depth = %d, want 1", got)
-	}
-}
-
-// The yield getter plumbs through RunJob down to the sweep's fetch pipeline:
-// with a stream active the whole job must run at the yield bound.
-func TestRunJobYieldsToActiveStreams(t *testing.T) {
-	fx := mkRepairFixture(t, 1024, 512, 6, 1) // 32 sweep articles
-	fetch := &concurrencyFetcher{inner: fx.fetch}
-
-	plan, err := BuildPlan(fx.idx, fx.files, Caps{MaxRepairRatio: 0.5, MaxMemoryBytes: 64 << 20})
-	if err != nil {
-		t.Fatal(err)
-	}
-	store := NewPatchStore(t.TempDir())
-	err = RunJob(context.Background(), plan, fx.idx, fx.par2Files, fetch, store, testLogger(),
-		WithLiveConcurrency(func() int { return 8 }),
-		WithYieldToStreams(func() bool { return true }))
-	if err != nil {
-		t.Fatal(err)
-	}
-	got, ok := store.Get(fx.deadMsgID)
-	if !ok || !bytes.Equal(got, fx.deadOrig) {
-		t.Fatal("yielding sweep must still produce a byte-exact patch")
-	}
-	if fetch.maxInFlight > yieldFetchDepth {
-		t.Fatalf("max in-flight fetches = %d, want <= %d while streams are active", fetch.maxInFlight, yieldFetchDepth)
 	}
 }
 

--- a/internal/par2repair/resolve.go
+++ b/internal/par2repair/resolve.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"math/rand/v2"
 	"sort"
 	"strings"
@@ -84,7 +85,8 @@ func Resolve(
 	}
 
 	started := time.Now()
-	hidden, err := statSweep(ctx, fetch, releaseArticleIDs(store, par2Files), dead, progress)
+	hidden, err := statSweepBudgeted(ctx, fetch, releaseArticleIDs(store, par2Files), dead,
+		newDamageBudget(store.Files, par2Files, caps), progress)
 	if err != nil {
 		return nil, err
 	}
@@ -206,6 +208,14 @@ const statSampleSize = 512
 // exact damage picture: caps and recovery-count verdicts become accurate at
 // plan time instead of after downloading the recovery set.
 func statSweep(ctx context.Context, fetch ArticleFetcher, ids []string, dead map[string]bool, progress JobProgress) (int, error) {
+	return statSweepBudgeted(ctx, fetch, ids, dead, nil, progress)
+}
+
+// statSweepBudgeted is statSweep with an early verdict: when budget is set and
+// the sample alone proves the damage exceeds the repair cap, the sweep stops
+// with ErrUnrepairable instead of spending minutes confirming it article by
+// article. A nil budget never aborts.
+func statSweepBudgeted(ctx context.Context, fetch ArticleFetcher, ids []string, dead map[string]bool, budget *damageBudget, progress JobProgress) (int, error) {
 	stater, ok := fetch.(ArticleStater)
 	if !ok {
 		return 0, nil
@@ -241,6 +251,12 @@ func statSweep(ctx context.Context, fetch ArticleFetcher, ids []string, dead map
 	if len(rest) == 0 || len(missing) == 0 {
 		return 0, nil
 	}
+	if budget != nil {
+		if ratio, proven := budget.sampleProves(sample, dead); proven {
+			return 0, fmt.Errorf("%w: damage ratio at least %.4f exceeds max_repair_ratio %.4f (decided from a %d-article sample)",
+				ErrUnrepairable, ratio, budget.maxRatio, len(sample))
+		}
+	}
 
 	// The sample surfaced damage nothing declared. STATing the whole release
 	// would pin the damage exactly, but it costs one round trip per article —
@@ -264,6 +280,85 @@ func statSweep(ctx context.Context, fetch ArticleFetcher, ids []string, dead map
 		dead[id] = true
 	}
 	return 0, nil
+}
+
+// damageBudget is what the liveness sweep needs to call a release unrepairable
+// early: the encoded size of every content article, their sum, and the cap.
+type damageBudget struct {
+	bytes    map[string]int64
+	total    int64
+	maxRatio float64
+}
+
+// newDamageBudget builds the budget from the NZB layout, PAR2 articles
+// excluded on both sides of the ratio. nil when no cap is configured.
+func newDamageBudget(files []*metapb.NzbFileEntry, par2Files []SetFile, caps Caps) *damageBudget {
+	if caps.MaxRepairRatio <= 0 {
+		return nil
+	}
+	par2IDs := map[string]bool{}
+	for _, f := range par2Files {
+		for _, a := range f.Articles {
+			par2IDs[a.MessageID] = true
+		}
+	}
+	b := &damageBudget{bytes: map[string]int64{}, maxRatio: caps.MaxRepairRatio * ratioPrecheckMargin}
+	for _, f := range files {
+		if len(f.Segments) == 0 || par2IDs[normalizeMsgID(f.Segments[0].Id)] {
+			continue
+		}
+		for _, seg := range f.Segments {
+			id := normalizeMsgID(seg.Id)
+			b.bytes[id] = seg.Bytes
+			b.total += seg.Bytes
+		}
+	}
+	if b.total == 0 {
+		return nil
+	}
+	return b
+}
+
+// sampleProves reports whether the STATed sample already proves the damage
+// ratio exceeds the cap, and the ratio it proves. The dead fraction of the
+// sampled bytes is taken three standard errors low and applied to the bytes
+// not yet checked, known-dead bytes are added in full, and the result is
+// divided by every content byte — the largest denominator ratioPrecheck could
+// use. Each step errs towards "repairable": a wrong "unrepairable" here is a
+// wrong verdict, not just a slow one, so the bound is wide (about one release
+// in a thousand sitting exactly on the cap), while a 95%-dead release is still
+// decided from the sample alone.
+func (b *damageBudget) sampleProves(sample []string, dead map[string]bool) (float64, bool) {
+	var sampled, sampledDead int64
+	inSample := make(map[string]bool, len(sample))
+	for _, id := range sample {
+		n, ok := b.bytes[id]
+		if !ok {
+			continue
+		}
+		inSample[id] = true
+		sampled += n
+		if dead[id] {
+			sampledDead += n
+		}
+	}
+	if sampled == 0 {
+		return 0, false
+	}
+	var knownDead int64
+	for id := range dead {
+		if !inSample[id] {
+			knownDead += b.bytes[id]
+		}
+	}
+	p := float64(sampledDead) / float64(sampled)
+	lower := p - 3*math.Sqrt(p*(1-p)/float64(len(sample)))
+	if lower < 0 {
+		lower = 0
+	}
+	unknown := float64(b.total - sampled - knownDead)
+	ratio := (float64(sampledDead) + float64(knownDead) + lower*unknown) / float64(b.total)
+	return ratio, ratio > b.maxRatio
 }
 
 // par2Streams builds one lazy reader per PAR2 file, with the dead flags the

--- a/internal/par2repair/resolve_nzb.go
+++ b/internal/par2repair/resolve_nzb.go
@@ -92,7 +92,9 @@ func ResolveFromNzb(
 	}
 
 	started := time.Now()
-	hidden, err := statSweep(ctx, fetch, releaseArticleIDs(store, par2Files), dead, progress)
+	// store carries only content entries here, so nothing to exclude.
+	hidden, err := statSweepBudgeted(ctx, fetch, releaseArticleIDs(store, par2Files), dead,
+		newDamageBudget(store.Files, nil, caps), progress)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/par2repair/resolve_test.go
+++ b/internal/par2repair/resolve_test.go
@@ -407,6 +407,78 @@ func (s *sweepStater) StatIDs(_ context.Context, ids []string, onResult func(don
 	return out, nil
 }
 
+// uniformBudget is a damage budget over ids of equal size, for sweep tests.
+func uniformBudget(ids []string, maxRatio float64) *damageBudget {
+	b := &damageBudget{bytes: make(map[string]int64, len(ids)), maxRatio: maxRatio}
+	for _, id := range ids {
+		b.bytes[id] = 1000
+		b.total += 1000
+	}
+	return b
+}
+
+// When the sample alone proves the damage exceeds the repair cap, the sweep
+// stops there: STATing the remaining thousands of articles could only confirm
+// a verdict that is already certain, and costs minutes of a provider's time.
+func TestStatSweepSampleProvesUnrepairable(t *testing.T) {
+	ids := make([]string, statSampleSize*8)
+	missing := map[string]bool{}
+	for i := range ids {
+		ids[i] = fmt.Sprintf("a-%d@test", i)
+		missing[ids[i]] = true // total loss
+	}
+	st := &sweepStater{missing: missing}
+	dead := map[string]bool{}
+	_, err := statSweepBudgeted(context.Background(), st, ids, dead, uniformBudget(ids, 0.02), nil)
+	if !errors.Is(err, ErrUnrepairable) {
+		t.Fatalf("err = %v, want ErrUnrepairable from the sample alone", err)
+	}
+	if len(st.calls) != 1 || len(st.calls[0]) != statSampleSize {
+		t.Fatalf("StatIDs calls = %d, want exactly the %d-article sample", len(st.calls), statSampleSize)
+	}
+}
+
+// Damage near the cap is not provable from a sample, so the full census still
+// runs and the exact check decides.
+func TestStatSweepInconclusiveSampleRunsCensus(t *testing.T) {
+	ids := make([]string, statSampleSize*8)
+	missing := map[string]bool{}
+	for i := range ids {
+		ids[i] = fmt.Sprintf("a-%d@test", i)
+		if i%20 == 0 { // 5% dead against a 6% cap: the sample cannot prove the excess
+			missing[ids[i]] = true
+		}
+	}
+	st := &sweepStater{missing: missing}
+	dead := map[string]bool{}
+	if _, err := statSweepBudgeted(context.Background(), st, ids, dead, uniformBudget(ids, 0.06), nil); err != nil {
+		t.Fatalf("err = %v, want the census to run to completion", err)
+	}
+	if len(st.calls) != 2 {
+		t.Fatalf("StatIDs calls = %d, want sample + full census", len(st.calls))
+	}
+	if len(dead) != len(missing) {
+		t.Fatalf("dead = %d, want %d after a full census", len(dead), len(missing))
+	}
+}
+
+// The budget counts content bytes only: PAR2 articles are neither damage nor
+// denominator, since the ratio is about the bytes being streamed.
+func TestNewDamageBudgetExcludesPar2(t *testing.T) {
+	store := &metapb.NzbStore{Files: []*metapb.NzbFileEntry{
+		{Segments: []*metapb.NzbSeg{{Id: "<c1@x>", Bytes: 700}, {Id: "<c2@x>", Bytes: 300}}},
+		{Segments: []*metapb.NzbSeg{{Id: "<p1@x>", Bytes: 5000}}},
+	}}
+	par2 := []SetFile{{Articles: []Article{{MessageID: "p1@x", Size: 5000}}}}
+	b := newDamageBudget(store.Files, par2, Caps{MaxRepairRatio: 0.02})
+	if b == nil || b.total != 1000 || len(b.bytes) != 2 {
+		t.Fatalf("budget = %+v, want total 1000 over 2 content articles", b)
+	}
+	if newDamageBudget(store.Files, par2, Caps{}) != nil {
+		t.Fatal("no cap configured: budget must be nil so the sweep never aborts")
+	}
+}
+
 // A clean sample skips the full-release STAT sweep: the plan trusts the known
 // holes and the payload sweep's margin rows absorb any stragglers.
 func TestStatSweepCleanSampleSkipsFullSweep(t *testing.T) {

--- a/internal/pool/nntpclient.go
+++ b/internal/pool/nntpclient.go
@@ -33,6 +33,12 @@ type NntpClient interface {
 	// reads use this so live playback isn't queued behind a background import.
 	BodyPriority(ctx context.Context, messageID string, onMeta ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error)
 
+	// BodyBackground fetches an article body via the background lane: served
+	// only when nothing priority or normal is queued and capped per provider
+	// while foreground traffic is recent. PAR2 repair reads whole releases
+	// through it so playback and imports stay ahead of it.
+	BodyBackground(ctx context.Context, messageID string, onMeta ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error)
+
 	// BodyStreamPriority fetches an article on the priority lane, writing
 	// decoded bytes to w as each wire read is decoded so a reader can serve
 	// the head of an article before its tail arrives. Bytes on the result is

--- a/internal/testsupport/fakepool/fakepool.go
+++ b/internal/testsupport/fakepool/fakepool.go
@@ -119,6 +119,7 @@ type Client struct {
 	totalCalls         atomic.Int64
 	bodyCalls          atomic.Int64
 	bodyPriCalls       atomic.Int64
+	bodyBgCalls        atomic.Int64
 	bodyStreamPriCalls atomic.Int64
 	bodyAsyncCalls     atomic.Int64
 	statCalls          atomic.Int64
@@ -193,6 +194,9 @@ func (c *Client) BodyCalls() int64 { return c.bodyCalls.Load() }
 func (c *Client) BodyPriorityCalls() int64 {
 	return c.bodyPriCalls.Load() + c.bodyStreamPriCalls.Load()
 }
+
+// BodyBackgroundCalls reports how many BodyBackground (repair) fetches were made.
+func (c *Client) BodyBackgroundCalls() int64 { return c.bodyBgCalls.Load() }
 
 // BodyStreamPriorityCalls returns the count of BodyStreamPriority invocations.
 func (c *Client) BodyStreamPriorityCalls() int64 { return c.bodyStreamPriCalls.Load() }
@@ -312,6 +316,15 @@ func (c *Client) Body(ctx context.Context, messageID string, onMeta ...func(nntp
 // distinguish streaming from importer traffic.
 func (c *Client) BodyPriority(ctx context.Context, messageID string, onMeta ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
 	c.bodyPriCalls.Add(1)
+	c.countMessage(messageID)
+	defer c.enter()()
+	return c.serveBody(ctx, messageID, nil, onMeta...)
+}
+
+// BodyBackground is identical to Body but counted separately so tests can
+// distinguish repair traffic from importer traffic.
+func (c *Client) BodyBackground(ctx context.Context, messageID string, onMeta ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
+	c.bodyBgCalls.Add(1)
 	c.countMessage(messageID)
 	defer c.enter()()
 	return c.serveBody(ctx, messageID, nil, onMeta...)


### PR DESCRIPTION
Stacked on #912. Depends on javi11/nntppool#101 (pinned as a pseudo-version of its head; bump to the release tag once that merges).

## Summary
- PAR2 repair bodies go through `BodyBackground` and the liveness census through `StatMany{Background: true}`. The pool reads lanes in strict order (priority, normal, background), holds background to a quarter of each provider's connections while playback or imports are active, dedicates the connections carrying background work so no stream body queues behind a slow background STAT, and lets background requests wait for dispatch instead of expiring.
- Removed the caller-side approximations that could not do this: the fetch depth no longer collapses to 2 while streams are active, and the repair budget no longer stacks on the import connection budget. The solver's fold-width yield (CPU) stays.
- `pool.NntpClient` gains `BodyBackground`; `fakepool.Client` implements it with its own counter.

## Measured on this branch (WebDAV stream of a 31 GB file, one 50-connection provider, `par2_repair.max_connections: 30`)
| Scenario | Stream MB/s |
|---|---|
| No repair | 71 |
| Repair census, before | 12 |
| Repair census, now | 59–119 |
| Repair body sweep, now | 62–77 |

Census runs at 8.5 articles/s beside the stream and 21/s when it stops; the body sweep pulls ~50 articles/s beside the stream. No "attempt expired awaiting dispatch" errors since the fix.

## Tests
- `TestPoolFetcherFetchesOnBackgroundLane`, `TestPoolFetcherStatIDsUsesBackgroundLane`, `TestFetchDepthIgnoresStreamActivity` (all failed before the change).
- `go test -race ./internal/par2repair/` and `./internal/pool/... ./internal/testsupport/... ./internal/usenet/... ./internal/config/...` green; `go build ./...` clean.

## Early unrepairable verdict
The liveness census now stops after its 512-article random sample when the sample alone proves the damage ratio exceeds `max_repair_ratio`: the dead fraction of sampled bytes is taken three standard errors low, applied to the unchecked bytes, and divided by all content bytes, so every step errs toward repairable and the exact post-census check would have rejected the same release. Live: the 95%-dead test release used to spend 355 s STATing all 4659 articles before the verdict; it is now decided after the sample. Borderline releases still get the full census.