### PR TITLE
fix(health): release the worker lock before waiting on the health cycle

### DIFF
--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/javi11/altmount/internal/arrs"
@@ -87,12 +88,14 @@ type HealthWorker struct {
 	par2Repair          Par2RepairEnqueuer            // optional, may be nil
 
 	// Worker state
-	status       WorkerStatus
-	running      bool
-	cycleRunning bool // Flag to prevent overlapping cycles
-	stopChan     chan struct{}
-	wg           sync.WaitGroup
-	mu           sync.RWMutex
+	status   WorkerStatus
+	running  bool
+	stopChan chan struct{}
+	wg       sync.WaitGroup
+	mu       sync.RWMutex
+
+	// Kept off mu so the cycle can clear it while Stop is blocked in wg.Wait().
+	cycleRunning atomic.Bool
 
 	// Active checks tracking for cancellation
 	activeChecks   map[string]*activeCheck // filePath -> in-flight check
@@ -180,6 +183,7 @@ func (hw *HealthWorker) Start(ctx context.Context) error {
 	}
 
 	// Start the main worker goroutine
+	hw.stopChan = make(chan struct{})
 	hw.wg.Go(func() {
 		hw.run(ctx)
 	})
@@ -196,25 +200,31 @@ func (hw *HealthWorker) Start(ctx context.Context) error {
 // Stop gracefully stops the health worker
 func (hw *HealthWorker) Stop(ctx context.Context) error {
 	hw.mu.Lock()
-	defer hw.mu.Unlock()
-
 	if !hw.running {
+		hw.mu.Unlock()
 		return fmt.Errorf("health worker not running")
 	}
 
+	hw.running = false
 	hw.status = WorkerStatusStopping
+	stopCh := hw.stopChan
+	hw.mu.Unlock()
+
 	hw.updateStats(func(s *WorkerStats) {
 		s.Status = WorkerStatusStopping
 	})
 
 	slog.InfoContext(ctx, "Stopping health worker...")
-	close(hw.stopChan)
-	hw.running = false
+	close(stopCh)
 
-	// Wait for all goroutines to finish
+	// mu must not be held here: the worker goroutine can still need it to finish,
+	// which would deadlock Stop against the very goroutine it is waiting on.
 	hw.wg.Wait()
 
+	hw.mu.Lock()
 	hw.status = WorkerStatusStopped
+	hw.mu.Unlock()
+
 	hw.updateStats(func(s *WorkerStats) {
 		s.Status = WorkerStatusStopped
 		s.CurrentRunStartTime = nil
@@ -292,11 +302,7 @@ func (hw *HealthWorker) run(ctx context.Context) {
 			return
 		case <-ticker.C:
 			// Check if a cycle is already running
-			hw.mu.RLock()
-			isCycleRunning := hw.cycleRunning
-			hw.mu.RUnlock()
-
-			if isCycleRunning {
+			if hw.cycleRunning.Load() {
 				slog.DebugContext(ctx, "Skipping health check cycle - previous cycle still running")
 				continue
 			}
@@ -956,16 +962,10 @@ func (hw *HealthWorker) performDirectCheck(ctx context.Context, filePath string,
 // runHealthCheckCycle runs a single cycle of health checks
 func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 	// Set the cycle running flag
-	hw.mu.Lock()
-	hw.cycleRunning = true
-	hw.mu.Unlock()
+	hw.cycleRunning.Store(true)
 
 	// Ensure we clear the flag when done
-	defer func() {
-		hw.mu.Lock()
-		hw.cycleRunning = false
-		hw.mu.Unlock()
-	}()
+	defer hw.cycleRunning.Store(false)
 
 	now := time.Now().UTC()
 	hw.updateStats(func(s *WorkerStats) {

--- a/internal/health/worker_shutdown_test.go
+++ b/internal/health/worker_shutdown_test.go
@@ -1,0 +1,72 @@
+package health
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStopDuringActiveCycle verifies that Stop returns while a health check cycle is
+// still draining. Stop used to hold hw.mu for its whole body, including wg.Wait(), while
+// the finishing cycle needed that same lock to clear its running flag.
+func TestStopDuringActiveCycle(t *testing.T) {
+	tempDir := t.TempDir()
+	bp := &blockingPoolManager{entered: make(chan struct{}), release: make(chan struct{})}
+	env := newRepairTestEnvWithPool(t, tempDir, nil, bp, func(cfg *config.Config) {
+		cfg.Health.CheckIntervalSeconds = 1
+	})
+
+	ctx := context.Background()
+	filePath := "series/show.s02e01.mkv"
+
+	meta := validSegmentMeta(env.metadataService, 1024)
+	require.NoError(t, env.metadataService.WriteFileMetadata(filePath, meta))
+	insertFileHealth(t, env.db, filePath, "/media/library/show.s02e01.mkv", 0, 3)
+
+	require.NoError(t, env.hw.Start(ctx))
+
+	select {
+	case <-bp.entered:
+	case <-time.After(10 * time.Second):
+		close(bp.release)
+		t.Fatal("health check cycle never started")
+	}
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- env.hw.Stop(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return env.hw.GetStats().Status == WorkerStatusStopping
+	}, 2*time.Second, 5*time.Millisecond, "Stop never reached its wait")
+
+	close(bp.release)
+
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop deadlocked while a health check cycle was draining")
+	}
+
+	assert.False(t, env.hw.IsRunning())
+	assert.Equal(t, WorkerStatusStopped, env.hw.GetStats().Status)
+}
+
+// TestStartStopRestart verifies a worker can be restarted, which the config watcher does
+// whenever health checking is toggled: the second Stop used to close an already closed
+// channel because Start never re-armed it.
+func TestStartStopRestart(t *testing.T) {
+	env := newRepairTestEnv(t, t.TempDir(), nil)
+	ctx := context.Background()
+
+	for range 2 {
+		require.NoError(t, env.hw.Start(ctx))
+		assert.True(t, env.hw.IsRunning())
+		require.NoError(t, env.hw.Stop(ctx))
+		assert.False(t, env.hw.IsRunning())
+	}
+}


### PR DESCRIPTION
Fixes a graceful-shutdown deadlock: `Stop()` held `hw.mu` via `defer` across `hw.wg.Wait()`, while the running cycle's deferred flag reset (`worker.go:965`) needed that same lock to finish. Shutdown hung past the Docker stop grace period.

Also fixes a latent `close of closed channel` panic: `Start()` never re-created `stopChan`, so a Stop→Start via the config watcher left a closed channel.

- `Stop()` split into two short critical sections, `wg.Wait()` outside the lock
- `cycleRunning` moved to an `atomic.Bool`
- `stopChan` re-armed in `Start()`

Both new tests were confirmed to fail against unmodified main.

**Stack 1/8** — base: `main`

Closes #872