### PR TITLE
fix(webdav): allow anonymous access when login is not required

### DIFF
--- a/internal/webdav/adapter.go
+++ b/internal/webdav/adapter.go
@@ -280,6 +280,13 @@ func NewHandler(
 
 	// Create the main handler with authentication
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		loginRequired := true
+		if configGetter != nil {
+			if cfg := configGetter(); cfg != nil && cfg.Auth.LoginRequired != nil {
+				loginRequired = *cfg.Auth.LoginRequired
+			}
+		}
+
 		// Fallback to basic authentication if JWT failed
 		username, password, hasBasicAuth := r.BasicAuth()
 
@@ -321,7 +328,9 @@ func NewHandler(
 			}
 		}
 
-		if !authenticated {
+		// An explicit Basic credential is always verified: mounts configured with
+		// webdav.user/password must fail loudly rather than fall back to anonymous.
+		if !authenticated && (loginRequired || hasBasicAuth) {
 			slog.DebugContext(r.Context(), "WebDAV auth failed", "method", r.Method, "path", r.URL.Path, "has_basic", hasBasicAuth)
 			w.Header().Set("WWW-Authenticate", `Basic realm="BASIC WebDAV REALM"`)
 			w.WriteHeader(http.StatusUnauthorized)

--- a/internal/webdav/adapter_test.go
+++ b/internal/webdav/adapter_test.go
@@ -1,0 +1,134 @@
+package webdav
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/javi11/altmount/internal/config"
+)
+
+func newTestHandler(t *testing.T, loginRequired *bool) *Handler {
+	t.Helper()
+
+	getter := config.ConfigGetter(func() *config.Config {
+		return &config.Config{
+			Auth: config.AuthConfig{LoginRequired: loginRequired},
+		}
+	})
+
+	h, err := NewHandler(
+		&Config{User: "dav-user", Pass: "dav-pass", Prefix: "/webdav/"},
+		nil,
+		nil,
+		nil,
+		getter,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	return h
+}
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestHandlerAuthentication(t *testing.T) {
+	tests := []struct {
+		name          string
+		loginRequired *bool
+		user          string
+		pass          string
+		withBasicAuth bool
+		wantStatus    int
+	}{
+		{
+			name:          "login not required without credentials is allowed",
+			loginRequired: boolPtr(false),
+			wantStatus:    http.StatusOK,
+		},
+		{
+			name:          "login not required with wrong credentials is rejected",
+			loginRequired: boolPtr(false),
+			user:          "dav-user",
+			pass:          "wrong",
+			withBasicAuth: true,
+			wantStatus:    http.StatusUnauthorized,
+		},
+		{
+			name:          "login not required with correct credentials is allowed",
+			loginRequired: boolPtr(false),
+			user:          "dav-user",
+			pass:          "dav-pass",
+			withBasicAuth: true,
+			wantStatus:    http.StatusOK,
+		},
+		{
+			name:          "login required without credentials is rejected",
+			loginRequired: boolPtr(true),
+			wantStatus:    http.StatusUnauthorized,
+		},
+		{
+			name:          "login required with correct credentials is allowed",
+			loginRequired: boolPtr(true),
+			user:          "dav-user",
+			pass:          "dav-pass",
+			withBasicAuth: true,
+			wantStatus:    http.StatusOK,
+		},
+		{
+			name:       "unset login required defaults to required",
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := newTestHandler(t, tt.loginRequired)
+
+			req := httptest.NewRequest(http.MethodOptions, "/webdav/", nil)
+			if tt.withBasicAuth {
+				req.SetBasicAuth(tt.user, tt.pass)
+			}
+
+			rec := httptest.NewRecorder()
+			handler.GetHTTPHandler().ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+
+			challenge := rec.Header().Get("WWW-Authenticate")
+			if tt.wantStatus == http.StatusUnauthorized {
+				if challenge != `Basic realm="BASIC WebDAV REALM"` {
+					t.Errorf("WWW-Authenticate = %q, want the Basic challenge", challenge)
+				}
+			} else if challenge != "" {
+				t.Errorf("WWW-Authenticate = %q, want empty", challenge)
+			}
+		})
+	}
+}
+
+func TestHandlerAuthenticationNilConfigGetter(t *testing.T) {
+	handler, err := NewHandler(
+		&Config{User: "dav-user", Pass: "dav-pass", Prefix: "/webdav/"},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodOptions, "/webdav/", nil)
+	rec := httptest.NewRecorder()
+	handler.GetHTTPHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}


### PR DESCRIPTION
`/webdav` returned 401 even with `auth.login_required: false`, so the Files tab (plus download and preview) could not browse anonymously — the handler never consulted the flag, unlike the API at `internal/api/server.go:232-251`.

Deliberately the stricter variant: anonymous access only when login is not required **and** the request carried no `Authorization` header. An explicit but wrong Basic credential still gets a 401, so a misconfigured rclone mount fails loudly instead of silently downgrading to anonymous.

New `adapter_test.go` covers both flag states plus the unset default.

**Stack 2/8** — base: `fix/health-worker-shutdown-deadlock`

Closes #873