### PR TITLE
fix(pool): lower STAT pipeline depth when body pipelining is disabled

### DIFF
--- a/docs/static/openapi.yaml
+++ b/docs/static/openapi.yaml
@@ -4302,6 +4302,8 @@ components:
           type: number
         recommended_inflight:
           type: integer
+        recommended_stat_inflight:
+          type: integer
         test_connections:
           type: integer
         tested:

--- a/docs/static/swagger.json
+++ b/docs/static/swagger.json
@@ -6450,6 +6450,9 @@
                 "recommended_inflight": {
                     "type": "integer"
                 },
+                "recommended_stat_inflight": {
+                    "type": "integer"
+                },
                 "test_connections": {
                     "type": "integer"
                 },

--- a/docs/static/swagger.yaml
+++ b/docs/static/swagger.yaml
@@ -616,6 +616,8 @@ definitions:
         type: number
       recommended_inflight:
         type: integer
+      recommended_stat_inflight:
+        type: integer
       test_connections:
         type: integer
       tested:

--- a/frontend/src/components/config/ProvidersConfigSection.tsx
+++ b/frontend/src/components/config/ProvidersConfigSection.tsx
@@ -237,7 +237,7 @@ export function ProvidersConfigSection({
 		}
 
 		setPipelineTuning({ current: 0, total: targets.length });
-		const recommendations = new Map<string, number>();
+		const recommendations = new Map<string, { inflight: number; statInflight: number }>();
 		const skipped: string[] = [];
 
 		for (let i = 0; i < targets.length; i++) {
@@ -248,7 +248,10 @@ export function ProvidersConfigSection({
 				if (result.warning) {
 					skipped.push(`${provider.host}: ${result.warning}`);
 				} else {
-					recommendations.set(provider.id, result.recommended_inflight);
+					recommendations.set(provider.id, {
+						inflight: result.recommended_inflight,
+						statInflight: result.recommended_stat_inflight,
+					});
 				}
 			} catch (error) {
 				console.error("Failed to tune pipeline:", error);
@@ -266,11 +269,13 @@ export function ProvidersConfigSection({
 			return;
 		}
 
-		const newFormData = formData.map((p) =>
-			recommendations.has(p.id)
-				? { ...p, inflight_requests: recommendations.get(p.id) as number }
-				: p,
-		);
+		const newFormData = formData.map((p) => {
+			const rec = recommendations.get(p.id);
+			if (!rec) {
+				return p;
+			}
+			return { ...p, inflight_requests: rec.inflight, stat_inflight_requests: rec.statInflight };
+		});
 		setFormData(newFormData);
 
 		if (!onUpdate) {
@@ -298,7 +303,11 @@ export function ProvidersConfigSection({
 	};
 
 	const handleDisablePipelining = async () => {
-		const newFormData = formData.map((p) => ({ ...p, inflight_requests: 1 }));
+		const newFormData = formData.map((p) => ({
+			...p,
+			inflight_requests: 1,
+			stat_inflight_requests: 1,
+		}));
 		setFormData(newFormData);
 		if (!onUpdate) {
 			setHasChanges(true);
@@ -729,8 +738,8 @@ export function ProvidersConfigSection({
 					<h3 className="font-bold text-base-content text-lg tracking-tight">NNTP Pipeline</h3>
 					<p className="text-base-content/50 text-xs">
 						Auto-tune the pipeline depth (requests in flight per connection) by speed-testing each
-						enabled provider, or disable pipelining everywhere. Run when downloads are idle for the
-						most accurate result.
+						enabled provider, or disable pipelining everywhere. Both actions cover the body and STAT
+						pipeline depths. Run when downloads are idle for the most accurate result.
 					</p>
 				</div>
 				<div className="flex flex-wrap items-center gap-3">

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -326,6 +326,7 @@ export interface PipelineDepthSample {
 
 export interface PipelineTuneResponse {
 	recommended_inflight: number;
+	recommended_stat_inflight: number;
 	baseline_mbps: number;
 	best_mbps: number;
 	improvement_pct: number;

--- a/internal/api/provider_pipeline_tune_handler.go
+++ b/internal/api/provider_pipeline_tune_handler.go
@@ -19,6 +19,7 @@ const (
 	pipelineTuneSegments = 160
 	pipelineLevelTimeout = 20 * time.Second
 	pipelineWinFactor    = 1.10
+	defaultStatInflight  = 100
 )
 
 // pipelineTuneDepths are the inflight depths compared against the depth-1 baseline.
@@ -30,14 +31,15 @@ type PipelineDepthSample struct {
 }
 
 type PipelineTuneResponse struct {
-	RecommendedInflight int                   `json:"recommended_inflight"`
-	BaselineMbps        float64               `json:"baseline_mbps"`
-	BestMbps            float64               `json:"best_mbps"`
-	Improvement         float64               `json:"improvement_pct"`
-	Enabled             bool                  `json:"enabled"`
-	TestConnections     int                   `json:"test_connections"`
-	Tested              []PipelineDepthSample `json:"tested"`
-	Warning             string                `json:"warning,omitempty"`
+	RecommendedInflight     int                   `json:"recommended_inflight"`
+	RecommendedStatInflight int                   `json:"recommended_stat_inflight"`
+	BaselineMbps            float64               `json:"baseline_mbps"`
+	BestMbps                float64               `json:"best_mbps"`
+	Improvement             float64               `json:"improvement_pct"`
+	Enabled                 bool                  `json:"enabled"`
+	TestConnections         int                   `json:"test_connections"`
+	Tested                  []PipelineDepthSample `json:"tested"`
+	Warning                 string                `json:"warning,omitempty"`
 }
 
 // handleTunePipeline sweeps pipeline depths and recommends the best inflight (1 = off).
@@ -99,9 +101,15 @@ func (s *Server) runPipelineSweep(ctx context.Context, p *config.ProviderConfig)
 		current = 1
 	}
 
+	currentStat := p.StatInflightRequests
+	if currentStat <= 0 {
+		currentStat = defaultStatInflight
+	}
+
 	resp := &PipelineTuneResponse{
-		RecommendedInflight: current,
-		TestConnections:     conns,
+		RecommendedInflight:     current,
+		RecommendedStatInflight: currentStat,
+		TestConnections:         conns,
 	}
 
 	nzbBytes, err := fetchSpeedTestNZB(ctx)
@@ -125,7 +133,20 @@ func (s *Server) runPipelineSweep(ctx context.Context, p *config.ProviderConfig)
 
 	resp.RecommendedInflight, resp.Enabled, resp.Improvement, resp.BestMbps =
 		pickPipelineDepth(baseline, resp.Tested[1:])
+	resp.RecommendedStatInflight = pickStatDepth(resp.RecommendedStatInflight, resp.Enabled)
 	return resp, nil
+}
+
+// pickStatDepth keeps the configured STAT depth while bodies pipeline, and drops to 1
+// otherwise: a server that refuses pipelined bodies cannot absorb 100 pipelined STATs.
+func pickStatDepth(configured int, pipeliningEnabled bool) int {
+	if !pipeliningEnabled {
+		return 1
+	}
+	if configured <= 0 {
+		return defaultStatInflight
+	}
+	return configured
 }
 
 // pickPipelineDepth returns the smallest depth beating the baseline by the win factor, else 1.

--- a/internal/api/provider_pipeline_tune_handler_test.go
+++ b/internal/api/provider_pipeline_tune_handler_test.go
@@ -48,3 +48,24 @@ func TestPickPipelineDepth(t *testing.T) {
 		})
 	}
 }
+
+func TestPickStatDepth(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured int
+		enabled    bool
+		want       int
+	}{
+		{name: "pipelining off drops stat depth to 1", configured: 100, enabled: false, want: 1},
+		{name: "pipelining off drops tuned stat depth to 1", configured: 25, enabled: false, want: 1},
+		{name: "pipelining on preserves configured depth", configured: 25, enabled: true, want: 25},
+		{name: "pipelining on falls back to default", configured: 0, enabled: true, want: defaultStatInflight},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pickStatDepth(tt.configured, tt.enabled); got != tt.want {
+				t.Fatalf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Autotune and "Disable Pipelining" only ever touched `inflight_requests`, leaving providers that reject pipelining on `inflight_requests: 1` + `stat_inflight_requests: 100` — enough to cause connection deaths and unreliable missing-article results during large STAT sweeps.

Root asymmetry: `stream_inflight_requests` is clamped to `inflight` (`config/manager.go:1574-1577`); `StatInflight` has no such clamp, which is why only STAT leaked.

- new `recommended_stat_inflight` on the tune response, forced to 1 when the body verdict is "no pipelining"
- frontend applies both fields in autotune and in the disable action
- section copy now matches what the controls actually do

**Note:** the tracked swagger specs are drifted from the generator on main (`par2_repair`, `memory_limit_mb`, `rcd_restart_after`, …). Hand-edited here to keep the diff surgical; worth a separate resync.

**Stack 3/8** — base: `fix/webdav-anonymous-access`

Closes #868