### PR TITLE
fix(segcache): evict on write when the disk tier exceeds max_size_gb

### DIFF
--- a/internal/nzbfilesystem/segcache/cache.go
+++ b/internal/nzbfilesystem/segcache/cache.go
@@ -43,6 +43,7 @@ type SegmentCache struct {
 	logger    *slog.Logger
 	totalSize int64
 	dirty     atomic.Bool
+	evicting  atomic.Bool
 	ready     chan struct{}
 	readyOnce sync.Once
 }
@@ -150,16 +151,37 @@ func (c *SegmentCache) Put(messageID string, data []byte) error {
 
 	c.dirty.Store(true)
 
+	c.evictIfOver()
+
 	return nil
+}
+
+// evictLowWaterPercent is how far below MaxSizeBytes a sweep drives the cache,
+// so a stream at line rate does not re-trigger a sweep on every Put.
+const evictLowWaterPercent = 95
+
+func (c *SegmentCache) evictIfOver() {
+	c.mu.Lock()
+	over := c.totalSize > c.config.MaxSizeBytes
+	c.mu.Unlock()
+	if !over || !c.evicting.CompareAndSwap(false, true) {
+		return
+	}
+	defer c.evicting.Store(false)
+	c.evictTo(c.config.MaxSizeBytes * evictLowWaterPercent / 100)
 }
 
 // Evict removes the oldest entries (by LastAccess) until total size is within MaxSizeBytes.
 func (c *SegmentCache) Evict() {
 	c.waitReady()
+	c.evictTo(c.config.MaxSizeBytes)
+}
+
+func (c *SegmentCache) evictTo(target int64) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	if c.totalSize <= c.config.MaxSizeBytes {
+		c.mu.Unlock()
 		return
 	}
 
@@ -177,18 +199,26 @@ func (c *SegmentCache) Evict() {
 		return sorted[i].e.LastAccess.Before(sorted[j].e.LastAccess)
 	})
 
-	removed := false
+	victims := make([]string, 0, len(sorted))
+	freed := int64(0)
 	for _, pair := range sorted {
-		if c.totalSize <= c.config.MaxSizeBytes {
+		if c.totalSize <= target {
 			break
 		}
-		_ = os.Remove(pair.e.DataPath)
+		victims = append(victims, pair.e.DataPath)
 		c.totalSize -= pair.e.Size
+		freed += pair.e.Size
 		delete(c.items, pair.id)
-		removed = true
 	}
-	if removed {
+	remaining := c.totalSize
+	c.mu.Unlock()
+
+	for _, p := range victims {
+		_ = os.Remove(p)
+	}
+	if len(victims) > 0 {
 		c.dirty.Store(true)
+		c.logger.Info("segcache: evicted segments", "count", len(victims), "freed_bytes", freed, "total_bytes", remaining)
 	}
 }
 

--- a/internal/nzbfilesystem/segcache/cache_test.go
+++ b/internal/nzbfilesystem/segcache/cache_test.go
@@ -1,9 +1,11 @@
 package segcache_test
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -53,23 +55,62 @@ func TestCacheGetMiss(t *testing.T) {
 }
 
 func TestCacheEvictLRU(t *testing.T) {
-	// Allow only 20 bytes total. Each entry is 10 bytes.
-	c := newTestCache(t, 20, 0)
+	// Allow 100 bytes total. Each entry is 10 bytes, so the 95% low-water
+	// mark (95 bytes) leaves room for several entries after a sweep.
+	const maxBytes = 100
+	c := newTestCache(t, maxBytes, 0)
 
 	require.NoError(t, c.Put("old@msg", []byte("0123456789"))) // 10 bytes — oldest
 	time.Sleep(5 * time.Millisecond)
-	require.NoError(t, c.Put("new@msg", []byte("abcdefghij"))) // 10 bytes
+	for i := 0; i < 9; i++ {
+		require.NoError(t, c.Put(fmt.Sprintf("fill-%d@msg", i), []byte("abcdefghij")))
+		time.Sleep(time.Millisecond)
+	}
 
-	assert.EqualValues(t, 2, c.ItemCount())
+	assert.EqualValues(t, 10, c.ItemCount())
+	assert.EqualValues(t, maxBytes, c.TotalSize())
 
-	// Adding a third entry should evict the oldest.
-	require.NoError(t, c.Put("newest@msg", []byte("ABCDEFGHIJ"))) // 10 bytes
-	c.Evict()
+	// Adding one more entry pushes past the budget and evicts the oldest.
+	require.NoError(t, c.Put("newest@msg", []byte("ABCDEFGHIJ")))
 
-	assert.EqualValues(t, 2, c.ItemCount())
 	assert.False(t, c.Has("old@msg"), "oldest entry should have been evicted")
-	assert.True(t, c.Has("new@msg"))
-	assert.True(t, c.Has("newest@msg"))
+	assert.True(t, c.Has("newest@msg"), "newest entry should be retained")
+	assert.LessOrEqual(t, c.TotalSize(), int64(maxBytes*95/100))
+}
+
+func TestCachePutEnforcesMaxSizeWithoutExplicitEvict(t *testing.T) {
+	const maxBytes = 100
+	c := newTestCache(t, maxBytes, 0)
+
+	// Write well past the budget; no explicit Evict() call anywhere.
+	for i := 0; i < 50; i++ {
+		require.NoError(t, c.Put(fmt.Sprintf("seg-%d@msg", i), []byte("0123456789")))
+		assert.LessOrEqual(t, c.TotalSize(), int64(maxBytes),
+			"cache exceeded MaxSizeBytes after Put %d", i)
+	}
+}
+
+func TestCacheConcurrentPutsRespectMaxSize(t *testing.T) {
+	const maxBytes = 1000
+	c := newTestCache(t, maxBytes, 0)
+
+	payload := make([]byte, 100)
+	var wg sync.WaitGroup
+	for w := 0; w < 8; w++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < 50; i++ {
+				assert.NoError(t, c.Put(fmt.Sprintf("w%d-seg-%d@msg", worker, i), payload))
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// A concurrent Put may land while a sweep is in flight, so the final size can
+	// sit above the low-water mark, but it must settle within the budget.
+	c.Evict()
+	assert.LessOrEqual(t, c.TotalSize(), int64(maxBytes))
 }
 
 func TestCacheCleanupExpiry(t *testing.T) {


### PR DESCRIPTION
`max_size_gb` was enforced only by a hard-coded 5-minute ticker, so the disk tier could overshoot by minutes of downloaded data (~18 GB at 500 Mbps) and fill the filesystem before the next pass. The in-memory tier added in #901 already evicts synchronously in its own `Put`; the disk tier never got the same.

- `Put` triggers a CAS-debounced sweep to a 95% low-water mark
- `Evict` split into a wrapper + `evictTo(target)`, with `os.Remove` moved off the lock
- periodic loop retained for expiry and as a safety net

`TestCacheEvictLRU` rebuilt (its 20-byte budget made a low-water mark meaningless), plus a no-explicit-`Evict` regression test and an 8-goroutine race test. Both new tests confirmed to fail with the trigger removed.

**Stack 4/8** — base: `fix/provider-stat-pipeline-depth`

Closes #883