### PR TITLE
perf(importer): stop mapping a file after its first confirmed missing segment

### DIFF
--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -451,11 +451,15 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 	}
 
 	// Report progress within the 0–10% band so the queue item doesn't appear
-	// frozen at "Checking segment availability" during the network sweep.
+	// frozen during the network sweep. NOT gated on HasSubscribers(): the
+	// tracker also persists the latest percentage for clients that connect
+	// mid-import, and this sweep can outlast the moment it starts.
 	var fastFailTracker *progress.Tracker
-	if proc.broadcaster != nil && proc.broadcaster.HasSubscribers() {
-		fastFailTracker = proc.broadcaster.CreateTracker(queueID, 0, 10).WithStage("Checking segment availability")
+	if proc.broadcaster != nil {
+		fastFailTracker = proc.broadcaster.CreateTracker(queueID, 0, 10).WithStage("Mapping missing segments")
 	}
+
+	acceptableMissingPercent := cfg.GetAcceptableMissingSegmentsPercentage()
 
 	results, err := validation.FastFailCheckFiles(
 		ctx,
@@ -466,6 +470,7 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 		proc.validationTimeout,
 		fastFailTracker,
 		proc.patchIndex,
+		acceptableMissingPercent == 0,
 	)
 	if err != nil {
 		return nil, nil, nil, err
@@ -486,7 +491,6 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 	}
 	missingIDs := make(map[string]struct{})
 	eligibleRegularCount := 0
-	acceptableMissingPercent := cfg.GetAcceptableMissingSegmentsPercentage()
 	// Archive-set members whose only misses are gaps the NZB declares,
 	// keyed by set; judged together below against the whole set's size.
 	gappedSets := make(map[string]*gappedSet)

--- a/internal/importer/validation/fast_fail.go
+++ b/internal/importer/validation/fast_fail.go
@@ -390,6 +390,10 @@ type FastFailFileResult struct {
 // Operational failures are retried, and exhaustion returns
 // ErrFastFailInconclusive without marking files broken. progressTracker may be
 // nil; when set it reports completed Stats as work progresses.
+// stopFileOnFirstMiss condemns a file (and its group) on its first definitive
+// miss and ends the sweep once no eligible file is left. Callers running with
+// zero missing-segment tolerance set it: the extent of the damage cannot
+// change the verdict, so mapping the rest of a doomed file is wasted work.
 func FastFailCheckFiles(
 	ctx context.Context,
 	files []FastFailFile,
@@ -399,6 +403,7 @@ func FastFailCheckFiles(
 	timeout time.Duration,
 	progressTracker progress.ProgressTracker,
 	patchIdx PatchIndex,
+	stopFileOnFirstMiss bool,
 ) ([]FastFailFileResult, error) {
 	if !poolManager.HasPool() {
 		return nil, fmt.Errorf("cannot fast-fail import: usenet connection pool is nil")
@@ -418,6 +423,9 @@ func FastFailCheckFiles(
 	// brokenGroups records group keys with at least one unreachable segment, so
 	// remaining Stats for those groups can be skipped in later chunks.
 	brokenGroups := make(map[string]struct{})
+
+	// brokenFiles does the same per file, for stopFileOnFirstMiss.
+	brokenFiles := make(map[int]struct{})
 
 	// Build the flat work list first so we know the total up front for progress.
 	type statJob struct {
@@ -461,6 +469,15 @@ func FastFailCheckFiles(
 		}
 	}
 
+	// Files with no sample generate no jobs and are never eligible: PAR2 and
+	// other sidecars reach here with nil Segments to keep index alignment.
+	remaining := 0
+	for _, selected := range perFile {
+		if len(selected) > 0 {
+			remaining++
+		}
+	}
+
 	var jobs []statJob
 	for round := 0; round < maxSamples; round++ {
 		for fileIdx, selected := range perFile {
@@ -481,14 +498,24 @@ func FastFailCheckFiles(
 
 	var done, lastPct int
 	advance := func() {
+		done++
 		if progressTracker == nil {
 			return
 		}
-		done++
 		pct := done * 100 / total
 		if pct != lastPct {
 			lastPct = pct
 			progressTracker.Update(done, total)
+		}
+	}
+
+	condemnFile := func(fileIdx int) {
+		if _, already := brokenFiles[fileIdx]; already {
+			return
+		}
+		brokenFiles[fileIdx] = struct{}{}
+		if len(perFile[fileIdx]) > 0 {
+			remaining--
 		}
 	}
 
@@ -516,6 +543,12 @@ func FastFailCheckFiles(
 
 		toCheck := make([]statJob, 0, len(chunk))
 		for _, job := range chunk {
+			if stopFileOnFirstMiss {
+				if _, broken := brokenFiles[job.fileIdx]; broken {
+					advance()
+					continue
+				}
+			}
 			if job.groupKey != "" {
 				if _, broken := brokenGroups[job.groupKey]; broken {
 					// Group already doomed — skip the Stat but still advance
@@ -547,8 +580,29 @@ func FastFailCheckFiles(
 				if job.groupKey != "" {
 					brokenGroups[job.groupKey] = struct{}{}
 				}
+				if stopFileOnFirstMiss {
+					condemnFile(job.fileIdx)
+					if job.groupKey != "" {
+						for idx := range files {
+							if files[idx].GroupKey == job.groupKey {
+								condemnFile(idx)
+							}
+						}
+					}
+				}
 			}
 			advance()
+		}
+
+		if stopFileOnFirstMiss && remaining == 0 {
+			for range jobs[end:] {
+				advance()
+			}
+			slog.InfoContext(ctx, "Fast-fail sweep stopped early: no eligible files remain",
+				"files", len(files),
+				"checked", done,
+				"total", total)
+			break
 		}
 
 		if err == nil {

--- a/internal/importer/validation/fast_fail_test.go
+++ b/internal/importer/validation/fast_fail_test.go
@@ -208,6 +208,7 @@ func TestFastFailCheckFilesRetriesOnlyTransientIDs(t *testing.T) {
 		context.Background(), files, fastFailPoolManager{client: client},
 		100, 2, 100*time.Millisecond, nil,
 		nil,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("FastFailCheckFiles error = %v, want nil after transient recovery", err)
@@ -234,6 +235,7 @@ func TestFastFailCheckFilesTransientExhaustionIsInconclusive(t *testing.T) {
 		fastFailPoolManager{client: client},
 		100, 1, 100*time.Millisecond, nil,
 		nil,
+		false,
 	)
 	if err == nil {
 		t.Fatal("FastFailCheckFiles error = nil, want inconclusive error after retries are exhausted")
@@ -439,6 +441,7 @@ func TestFastFailCheckFilesAllReachable(t *testing.T) {
 		100, 2, 100*time.Millisecond,
 		nil,
 		nil,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("FastFailCheckFiles error = %v, want nil", err)
@@ -470,6 +473,7 @@ func TestFastFailCheckFilesOneFileBroken(t *testing.T) {
 		100, 2, 100*time.Millisecond,
 		nil,
 		nil,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("FastFailCheckFiles error = %v, want nil", err)
@@ -504,6 +508,7 @@ func TestFastFailCheckFilesBrokenSidecarsAreReported(t *testing.T) {
 		100, 2, 100*time.Millisecond,
 		nil,
 		nil,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("FastFailCheckFiles error = %v, want nil", err)
@@ -536,6 +541,7 @@ func TestFastFailCheckFilesBrokenSidecarIsReported(t *testing.T) {
 		100, 1, 100*time.Millisecond,
 		nil,
 		nil,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("FastFailCheckFiles error = %v, want nil", err)
@@ -559,6 +565,7 @@ func TestFastFailCheckFilesPoolUnavailableReturnsError(t *testing.T) {
 		100, 1, 100*time.Millisecond,
 		nil,
 		nil,
+		false,
 	)
 	if err == nil {
 		t.Fatal("FastFailCheckFiles returned nil error, want error for nil pool")
@@ -592,6 +599,7 @@ func TestFastFailCheckFilesFirstSegmentAlwaysChecked(t *testing.T) {
 		0, 1, 100*time.Millisecond,
 		nil,
 		nil,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("FastFailCheckFiles error = %v, want nil", err)
@@ -624,6 +632,7 @@ func TestFastFailCheckFilesGroupPropagation(t *testing.T) {
 		100, 4, 100*time.Millisecond,
 		nil,
 		nil,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("FastFailCheckFiles error = %v, want nil", err)
@@ -668,6 +677,7 @@ func TestFastFailCheckFilesGroupShortCircuitSkipsStats(t *testing.T) {
 		100, 1, 100*time.Millisecond, // single connection → deterministic ordering
 		nil,
 		nil,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("FastFailCheckFiles error = %v, want nil", err)
@@ -703,6 +713,7 @@ func TestFastFailCheckFilesEmptyGroupKeyNoPropagation(t *testing.T) {
 		100, 2, 100*time.Millisecond,
 		nil,
 		nil,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("FastFailCheckFiles error = %v, want nil", err)
@@ -732,6 +743,7 @@ func TestFastFailCheckFilesIndexAligned(t *testing.T) {
 		100, 2, 100*time.Millisecond,
 		nil,
 		nil,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("FastFailCheckFiles error = %v", err)
@@ -826,6 +838,7 @@ func TestFastFailCheckFilesTimeoutIsInconclusive(t *testing.T) {
 		10*time.Millisecond,
 		nil,
 		nil,
+		false,
 	)
 	if err == nil {
 		t.Fatal("FastFailCheckFiles error = nil, want inconclusive error after retries")
@@ -869,6 +882,7 @@ func TestFastFailCheckFilesDeadReleaseSettlesWithoutWaitingForUnverified(t *test
 		fastFailPoolManager{client: client},
 		100, 10, 100*time.Millisecond, nil,
 		nil,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("FastFailCheckFiles error = %v, want nil for a dead release", err)
@@ -927,6 +941,7 @@ func TestFastFailCheckFilesPlaceholdersAreKnownMissesWithoutStat(t *testing.T) {
 		context.Background(), files,
 		fastFailPoolManager{client: client},
 		100, 8, 100*time.Millisecond, nil, nil,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("FastFailCheckFiles error = %v", err)
@@ -988,5 +1003,174 @@ func TestCapReleaseProbeSampleKeepsEdgesAndBounds(t *testing.T) {
 	small := makeTestSegments("small", 20)
 	if got := capReleaseProbeSample(small); len(got) != 20 {
 		t.Fatalf("small sample must pass through untouched, got %d", len(got))
+	}
+}
+
+type recordingTracker struct {
+	mu      sync.Mutex
+	current int
+	total   int
+}
+
+func (r *recordingTracker) Update(current, total int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.current, r.total = current, total
+}
+
+func (r *recordingTracker) UpdateAbsolute(int) {}
+
+func (r *recordingTracker) last() (int, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.current, r.total
+}
+
+// A standalone file (no GroupKey) is condemned by its first definitive miss:
+// the rest of its sample is never STAT-ed.
+func TestFastFailCheckFilesStopFileOnFirstMissSkipsRestOfFile(t *testing.T) {
+	client := fakepool.New()
+	client.SetBehavior("a-0", fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+	files := []FastFailFile{
+		{Filename: "a.mkv", Segments: makeTestSegments("a", 3)},
+		{Filename: "b.mkv", Segments: makeTestSegments("b", 3)},
+	}
+
+	results, err := FastFailCheckFiles(
+		context.Background(), files,
+		fastFailPoolManager{client: client},
+		100, 1, 100*time.Millisecond, // single connection → deterministic ordering
+		nil,
+		nil,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("FastFailCheckFiles error = %v, want nil", err)
+	}
+	if !results[0].Broken {
+		t.Error("results[0].Broken = false, want true")
+	}
+	if results[1].Broken {
+		t.Error("results[1].Broken = true, want false")
+	}
+	if got := client.PerMessageCalls("a-0"); got != 1 {
+		t.Errorf("a-0 STAT calls = %d, want 1", got)
+	}
+	for _, id := range []string{"a-1", "a-2"} {
+		if got := client.PerMessageCalls(id); got != 0 {
+			t.Errorf("%s STAT calls = %d, want 0 once the file is condemned", id, got)
+		}
+	}
+	if got := client.StatCalls(); got != 4 {
+		t.Errorf("StatCalls = %d, want 4 (1 for the condemned file, 3 for the healthy one)", got)
+	}
+}
+
+// Once every eligible file is condemned the sweep returns without STAT-ing the
+// remaining jobs, and progress still reports the full job count.
+func TestFastFailCheckFilesStopsWhenNoEligibleFilesRemain(t *testing.T) {
+	client := fakepool.New()
+	client.SetBehavior("a-0", fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+	client.SetBehavior("b-0", fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+	files := []FastFailFile{
+		{Filename: "a.mkv", Segments: makeTestSegments("a", 3)},
+		{Filename: "b.mkv", Segments: makeTestSegments("b", 3)},
+	}
+
+	tracker := &recordingTracker{}
+	results, err := FastFailCheckFiles(
+		context.Background(), files,
+		fastFailPoolManager{client: client},
+		100, 1, 100*time.Millisecond,
+		tracker,
+		nil,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("FastFailCheckFiles error = %v, want nil", err)
+	}
+	for i, r := range results {
+		if !r.Broken {
+			t.Errorf("results[%d].Broken = false, want true", i)
+		}
+	}
+	if got := client.StatCalls(); got != 2 {
+		t.Errorf("StatCalls = %d, want 2 (one per file, then the sweep ends)", got)
+	}
+	if current, total := tracker.last(); current != total || total != 6 {
+		t.Errorf("progress = %d/%d, want 6/6", current, total)
+	}
+}
+
+// Regression guard: with stopFileOnFirstMiss disabled the sweep still checks
+// every selected segment of a broken file.
+func TestFastFailCheckFilesWithoutStopFileSweepsWholeSample(t *testing.T) {
+	client := fakepool.New()
+	client.SetBehavior("a-0", fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+	files := []FastFailFile{
+		{Filename: "a.mkv", Segments: makeTestSegments("a", 3)},
+		{Filename: "b.mkv", Segments: makeTestSegments("b", 3)},
+	}
+
+	results, err := FastFailCheckFiles(
+		context.Background(), files,
+		fastFailPoolManager{client: client},
+		100, 1, 100*time.Millisecond,
+		nil,
+		nil,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("FastFailCheckFiles error = %v, want nil", err)
+	}
+	if !results[0].Broken || results[1].Broken {
+		t.Fatalf("results = %+v, want only the first file broken", results)
+	}
+	if got := client.StatCalls(); got != 6 {
+		t.Errorf("StatCalls = %d, want 6 (full sample for both files)", got)
+	}
+	for _, id := range []string{"a-1", "a-2"} {
+		if got := client.PerMessageCalls(id); got != 1 {
+			t.Errorf("%s STAT calls = %d, want 1", id, got)
+		}
+	}
+}
+
+// A miss in one volume condemns every member of its set, so the sweep ends
+// without STAT-ing any sibling.
+func TestFastFailCheckFilesStopFileOnFirstMissCondemnsGroup(t *testing.T) {
+	client := fakepool.New()
+	client.SetBehavior("p0-0", fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+	files := make([]FastFailFile, 3)
+	for i := range files {
+		files[i] = FastFailFile{
+			Filename: fmt.Sprintf("set.part%02d.rar", i+1),
+			Segments: makeTestSegments(fmt.Sprintf("p%d", i), 3),
+			GroupKey: "set",
+		}
+	}
+
+	results, err := FastFailCheckFiles(
+		context.Background(), files,
+		fastFailPoolManager{client: client},
+		100, 1, 100*time.Millisecond,
+		nil,
+		nil,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("FastFailCheckFiles error = %v, want nil", err)
+	}
+	for i, r := range results {
+		if !r.Broken {
+			t.Errorf("results[%d].Broken = false, want true", i)
+		}
+	}
+	if got := client.StatCalls(); got != 1 {
+		t.Errorf("StatCalls = %d, want 1 (the whole set is condemned by the first miss)", got)
 	}
 }

--- a/internal/importer/validation/patch_aware_test.go
+++ b/internal/importer/validation/patch_aware_test.go
@@ -59,7 +59,7 @@ func TestCheckFilesTreatsPatchedSegmentAsAvailable(t *testing.T) {
 
 	results, err := FastFailCheckFiles(context.Background(), files,
 		fastFailPoolManager{client: client}, 100, 1, time.Second, nil,
-		fakePatchIndex{have: map[string]bool{dead: true}})
+		fakePatchIndex{have: map[string]bool{dead: true}}, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
With `acceptable_missing_segments_percentage: 0` and 100% sampling, a doomed 35 GB MKV took 41 minutes to fail: the fast-fail probe stopped at the first miss, but the damage-mapping phase then swept all ~47k segments before rejecting it.

#867 added early-stop to the *health* sweep only. The importer has an independent sweep whose only skip was group-scoped — a standalone file has an empty `GroupKey`, so nothing was ever skipped. Tolerance was read only *after* the sweep, so at zero tolerance every one of those STATs fed already-dead logic.

- files and archive groups condemned on first confirmed miss
- sweep ends once no eligible candidate remains
- tolerance threaded in from the processor; damage mapping unchanged when tolerance > 0
- phase now reports a `Mapping missing segments` stage; dropped the `HasSubscribers()` gate that hid progress from late-connecting clients (matching the convention at `processor.go:1321-1324`)

Declared-gap placeholder files are deliberately not condemned. Counting tests confirmed to fail without the short-circuit.

**Stack 5/8** — base: `fix/segcache-enforce-max-size`

Closes #869