### PR TITLE
fix(metadata): give corrupted_metadata safety copies a lifecycle

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -203,6 +203,7 @@ health:
   library_sync_interval_minutes: 360 # Library synchronization interval in minutes (default: 360 = 6 hours)
   library_sync_concurrency: 5 # Number of concurrent library sync operations (default: 5)
   resolve_repair_on_import: false # Automatically resolve pending repairs in the same directory when a new file is imported (default: false)
+  corrupted_retention_days: 0 # Days a corrupted file's metadata is kept in the corrupted_metadata safety folder before it is pruned and its segment store released (0 = keep forever, default: 0)
 
 # WebDAV mount path configuration
 # Go soft memory limit in MB. Unset or 0: derived from segment_cache.memory_mb plus the PAR2 solver

--- a/docs/static/openapi.yaml
+++ b/docs/static/openapi.yaml
@@ -1867,6 +1867,62 @@ paths:
       summary: Get scan status
       tags:
         - Import
+  /metadata/corrupted:
+    delete:
+      description: Removes every corrupted metadata safety copy and releases the
+        segment stores they hold.
+      responses:
+        "204":
+          description: No Content
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+      summary: Purge corrupted metadata
+      tags:
+        - Metadata
+    get:
+      description: Returns how many corrupted metadata safety copies are retained and
+        how much disk they occupy.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.CorruptedMetadataStatsResponse"
+                    type: object
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+      summary: Get corrupted metadata stats
+      tags:
+        - Metadata
   /metadata/migration/cancel:
     post:
       description: Stops an in-flight migration after the current file.
@@ -3930,6 +3986,17 @@ components:
           $ref: "#/components/schemas/api.ImportAPIResponse"
         log:
           $ref: "#/components/schemas/config.LogConfig"
+        memory_limit_mb:
+          description: >-
+            MemoryLimitMB is the Go soft memory limit. Unset or 0 derives it
+            from
+
+            the budgets that allocate (see SoftMemoryLimit); a positive value pins
+
+            it; a negative value leaves the runtime default. GOMEMLIMIT in the
+
+            environment always takes precedence.
+          type: integer
         metadata:
           $ref: "#/components/schemas/config.MetadataConfig"
         mount_path:
@@ -3938,6 +4005,8 @@ components:
           $ref: "#/components/schemas/config.MountType"
         network:
           $ref: "#/components/schemas/config.NetworkConfig"
+        par2_repair:
+          $ref: "#/components/schemas/config.Par2RepairConfig"
         profiler_enabled:
           type: boolean
         providers:
@@ -3969,6 +4038,13 @@ components:
           type: string
         webdav:
           $ref: "#/components/schemas/api.WebDAVAPIResponse"
+      type: object
+    api.CorruptedMetadataStatsResponse:
+      properties:
+        file_count:
+          type: integer
+        total_bytes:
+          type: integer
       type: object
     api.DailyStat:
       properties:
@@ -4361,7 +4437,8 @@ components:
         host:
           type: string
         id:
-          description: Stable public provider identifier; never credentials or non-graphic characters
+          description: ID is a stable public provider identifier; it is not an
+            authentication field.
           type: string
         inflight_requests:
           type: integer
@@ -4498,7 +4575,6 @@ components:
         host:
           type: string
         id:
-          description: Stable public provider identifier; never credentials or non-graphic characters
           type: string
         last_connection_attempt:
           type: string
@@ -4767,6 +4843,13 @@ components:
         rc_url:
           type: string
         rc_user:
+          type: string
+        rcd_restart_after:
+          description: >-
+            RcdRestartAfter is how long the rcd may stay unresponsive to
+            liveness
+
+            probes before it is killed and restarted. Empty means the built-in default.
           type: string
         read_only:
           type: boolean
@@ -5368,6 +5451,17 @@ components:
           type: integer
         cleanup_orphaned_metadata:
           type: boolean
+        corrupted_retention_days:
+          description: >-
+            CorruptedRetentionDays bounds how long the corrupted_metadata safety
+            copies
+
+            created by MoveToCorrupted are kept before the health cycle prunes them.
+
+            nil or 0 means keep forever, which is what every install did before this
+
+            setting existed.
+          type: integer
         corruption_action:
           description: >-
             CorruptionAction controls what happens when the health checker or a
@@ -5661,6 +5755,104 @@ components:
         weight:
           type: integer
       type: object
+    config.Par2RepairConfig:
+      properties:
+        arr_first:
+          description: >-
+            ArrFirst makes PAR2 repair the fallback for corrupted files: the
+            health
+
+            worker triggers the ARR rescan first exactly as before, and enqueues a
+
+            PAR2 repair only when nothing is found in the ARRs (no instance
+
+            configured, none tracks the file) or ARR repair is disabled. On by
+
+            default; disable to keep PAR2 out of the corrupted-file flow (degraded
+
+            files, playback holes and repair-on-import still repair via PAR2
+
+            directly).
+          type: boolean
+        enabled:
+          type: boolean
+        max_concurrent_jobs:
+          description: MaxConcurrentJobs bounds simultaneously running repair jobs.
+          type: integer
+        max_connections:
+          description: >-
+            MaxConnections bounds how many NNTP connections repair jobs use for
+
+            article fetches (shared across concurrent jobs). Repair streams the
+
+            whole release once, so this directly sets its download speed on an idle
+
+            pool. Fetches ride the pool's background lane: while anything streams
+
+            or imports, the pool holds repair to a quarter of each provider's
+
+            connections regardless of this value. 0 (default) means 10.
+          type: integer
+        max_memory_mb:
+          description: >-
+            MaxMemoryMB bounds one job's in-heap solver memory; jobs needing
+            more
+
+            still run, backed by memory-mapped scratch files next to the patch store.
+          type: integer
+        max_patch_store_mb:
+          description: >-
+            MaxPatchStoreMB bounds the on-disk patch store size; oldest patches
+            are
+
+            evicted first when the cap is exceeded. 0 (default) means unlimited.
+          type: integer
+        max_release_size_mb:
+          type: integer
+        max_repair_ratio:
+          description: >-
+            MaxRepairRatio caps how large a fraction of a file's bytes a repair
+            may
+
+            reconstruct. The release's PAR2 redundancy is always the hard ceiling.
+          type: number
+        min_release_size_mb:
+          description: >-
+            MinReleaseSizeMB / MaxReleaseSizeMB bound the size of releases
+            repair
+
+            takes on (content bytes, PAR2 files excluded). A repair downloads the
+
+            whole release once, so these let users skip releases too large to be
+
+            worth the bandwidth or too small to bother with. 0 (default) means
+
+            unbounded on that side — all sizes are repaired.
+          type: integer
+        patch_dir:
+          description: >-
+            PatchDir is where repaired article payloads (and the solver's
+            transient
+
+            scratch files) are stored. Empty (default) means <metadata_root>/patches.
+
+            Applied at startup; changing it does not move existing patches.
+          type: string
+        repair_on_import:
+          description: >-
+            RepairOnImport queues a repair as soon as an import completes with
+
+            confirmed missing segments, instead of waiting for the first playback or
+
+            a health check. Off by default: every repair costs one full release
+
+            download, so a large damaged backlog would be expensive. Worth enabling
+
+            when your library outlives article retention — a release's PAR2 volumes
+
+            are most likely to still be retrievable close to the post date.
+          type: boolean
+      type: object
     config.ProviderConfig:
       properties:
         account_expiration_date:
@@ -5670,6 +5862,11 @@ components:
         host:
           type: string
         id:
+          description: >-
+            ID is a stable public identifier used in pool names, metrics, and
+            errors.
+
+            It must never contain credentials or non-graphic characters.
           type: string
         inflight_requests:
           description: >-
@@ -5725,6 +5922,17 @@ components:
           type: integer
         storage_group:
           type: string
+        stream_inflight_requests:
+          description: >-
+            StreamInflightRequests caps streaming (priority-lane) bodies in
+            flight
+
+            per connection, so a playback read never queues behind a connection's
+
+            worth of read-ahead. 0 defaults to 4; values above inflight_requests
+
+            are capped to it.
+          type: integer
         tls:
           type: boolean
         user_agent:
@@ -5872,6 +6080,19 @@ components:
           type: string
         rc_user:
           type: string
+        rcd_restart_after:
+          description: >-
+            RcdRestartAfter is how long the rcd subprocess must stay
+            unresponsive to
+
+            liveness probes before it is killed and restarted. Empty means the built-in
+
+            default. Restarting is disruptive, because re-establishing the mount
+
+            unmounts it out from under every process reading it, so an install whose
+
+            rcd goes briefly slow under load can raise this to ride the stall out.
+          type: string
         read_only:
           type: boolean
         syslog:
@@ -5984,6 +6205,12 @@ components:
             MaxSizeGB via LRU eviction). Left unset (nil) it defaults to 24 hours.
           type: integer
         max_size_gb:
+          type: integer
+        memory_mb:
+          description: |-
+            MemoryMB bounds the in-memory tier of decoded articles that sits in
+            front of the disk cache and is on even when the disk cache is off.
+            Left unset (nil) it defaults to 256; an explicit 0 disables it.
           type: integer
       type: object
     config.StreamScoringConfig:
@@ -6246,6 +6473,7 @@ components:
         - failed
         - paused
         - fallback
+        - waiting_repair
       type: string
       x-enum-comments:
         QueueStatusFallback: Sent to external SABnzbd as fallback
@@ -6256,6 +6484,7 @@ components:
         - ""
         - ""
         - Sent to external SABnzbd as fallback
+        - ""
       x-enum-varnames:
         - QueueStatusPending
         - QueueStatusProcessing
@@ -6263,3 +6492,4 @@ components:
         - QueueStatusFailed
         - QueueStatusPaused
         - QueueStatusFallback
+        - QueueStatusWaitingRepair

--- a/docs/static/swagger.json
+++ b/docs/static/swagger.json
@@ -2866,6 +2866,87 @@
                 }
             }
         },
+        "/metadata/corrupted": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns how many corrupted metadata safety copies are retained and how much disk they occupy.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Metadata"
+                ],
+                "summary": "Get corrupted metadata stats",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/api.CorruptedMetadataStatsResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.APIResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/api.APIResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Removes every corrupted metadata safety copy and releases the segment stores they hold.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Metadata"
+                ],
+                "summary": "Purge corrupted metadata",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.APIResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/api.APIResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/metadata/migration/cancel": {
             "post": {
                 "security": [
@@ -5909,6 +5990,10 @@
                 "log": {
                     "$ref": "#/definitions/config.LogConfig"
                 },
+                "memory_limit_mb": {
+                    "description": "MemoryLimitMB is the Go soft memory limit. Unset or 0 derives it from\nthe budgets that allocate (see SoftMemoryLimit); a positive value pins\nit; a negative value leaves the runtime default. GOMEMLIMIT in the\nenvironment always takes precedence.",
+                    "type": "integer"
+                },
                 "metadata": {
                     "$ref": "#/definitions/config.MetadataConfig"
                 },
@@ -5920,6 +6005,9 @@
                 },
                 "network": {
                     "$ref": "#/definitions/config.NetworkConfig"
+                },
+                "par2_repair": {
+                    "$ref": "#/definitions/config.Par2RepairConfig"
                 },
                 "profiler_enabled": {
                     "type": "boolean"
@@ -5951,6 +6039,17 @@
                 },
                 "webdav": {
                     "$ref": "#/definitions/api.WebDAVAPIResponse"
+                }
+            }
+        },
+        "api.CorruptedMetadataStatsResponse": {
+            "type": "object",
+            "properties": {
+                "file_count": {
+                    "type": "integer"
+                },
+                "total_bytes": {
+                    "type": "integer"
                 }
             }
         },
@@ -6538,7 +6637,7 @@
                     "type": "string"
                 },
                 "id": {
-                    "description": "Stable public provider identifier; never credentials or non-graphic characters",
+                    "description": "ID is a stable public provider identifier; it is not an authentication field.",
                     "type": "string"
                 },
                 "inflight_requests": {
@@ -6747,7 +6846,6 @@
                     "type": "string"
                 },
                 "id": {
-                    "description": "Stable public provider identifier; never credentials or non-graphic characters",
                     "type": "string"
                 },
                 "last_connection_attempt": {
@@ -7149,6 +7247,10 @@
                     "type": "string"
                 },
                 "rc_user": {
+                    "type": "string"
+                },
+                "rcd_restart_after": {
+                    "description": "RcdRestartAfter is how long the rcd may stay unresponsive to liveness\nprobes before it is killed and restarted. Empty means the built-in default.",
                     "type": "string"
                 },
                 "read_only": {
@@ -7971,6 +8073,10 @@
                 "cleanup_orphaned_metadata": {
                     "type": "boolean"
                 },
+                "corrupted_retention_days": {
+                    "description": "CorruptedRetentionDays bounds how long the corrupted_metadata safety copies\ncreated by MoveToCorrupted are kept before the health cycle prunes them.\nnil or 0 means keep forever, which is what every install did before this\nsetting existed.",
+                    "type": "integer"
+                },
                 "corruption_action": {
                     "description": "CorruptionAction controls what happens when the health checker or a streaming read\nconfirms real (non-degraded) corruption: \"repair\" (default) triggers an Arr rescan;\n\"delete\" removes the file's metadata/NZB/health record and cleans up now-empty\nparent directories instead. Degraded files are never affected either way.",
                     "type": "string"
@@ -8252,6 +8358,53 @@
                 }
             }
         },
+        "config.Par2RepairConfig": {
+            "type": "object",
+            "properties": {
+                "arr_first": {
+                    "description": "ArrFirst makes PAR2 repair the fallback for corrupted files: the health\nworker triggers the ARR rescan first exactly as before, and enqueues a\nPAR2 repair only when nothing is found in the ARRs (no instance\nconfigured, none tracks the file) or ARR repair is disabled. On by\ndefault; disable to keep PAR2 out of the corrupted-file flow (degraded\nfiles, playback holes and repair-on-import still repair via PAR2\ndirectly).",
+                    "type": "boolean"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "max_concurrent_jobs": {
+                    "description": "MaxConcurrentJobs bounds simultaneously running repair jobs.",
+                    "type": "integer"
+                },
+                "max_connections": {
+                    "description": "MaxConnections bounds how many NNTP connections repair jobs use for\narticle fetches (shared across concurrent jobs). Repair streams the\nwhole release once, so this directly sets its download speed on an idle\npool. Fetches ride the pool's background lane: while anything streams\nor imports, the pool holds repair to a quarter of each provider's\nconnections regardless of this value. 0 (default) means 10.",
+                    "type": "integer"
+                },
+                "max_memory_mb": {
+                    "description": "MaxMemoryMB bounds one job's in-heap solver memory; jobs needing more\nstill run, backed by memory-mapped scratch files next to the patch store.",
+                    "type": "integer"
+                },
+                "max_patch_store_mb": {
+                    "description": "MaxPatchStoreMB bounds the on-disk patch store size; oldest patches are\nevicted first when the cap is exceeded. 0 (default) means unlimited.",
+                    "type": "integer"
+                },
+                "max_release_size_mb": {
+                    "type": "integer"
+                },
+                "max_repair_ratio": {
+                    "description": "MaxRepairRatio caps how large a fraction of a file's bytes a repair may\nreconstruct. The release's PAR2 redundancy is always the hard ceiling.",
+                    "type": "number"
+                },
+                "min_release_size_mb": {
+                    "description": "MinReleaseSizeMB / MaxReleaseSizeMB bound the size of releases repair\ntakes on (content bytes, PAR2 files excluded). A repair downloads the\nwhole release once, so these let users skip releases too large to be\nworth the bandwidth or too small to bother with. 0 (default) means\nunbounded on that side — all sizes are repaired.",
+                    "type": "integer"
+                },
+                "patch_dir": {
+                    "description": "PatchDir is where repaired article payloads (and the solver's transient\nscratch files) are stored. Empty (default) means \u003cmetadata_root\u003e/patches.\nApplied at startup; changing it does not move existing patches.",
+                    "type": "string"
+                },
+                "repair_on_import": {
+                    "description": "RepairOnImport queues a repair as soon as an import completes with\nconfirmed missing segments, instead of waiting for the first playback or\na health check. Off by default: every repair costs one full release\ndownload, so a large damaged backlog would be expensive. Worth enabling\nwhen your library outlives article retention — a release's PAR2 volumes\nare most likely to still be retrievable close to the post date.",
+                    "type": "boolean"
+                }
+            }
+        },
         "config.ProviderConfig": {
             "type": "object",
             "properties": {
@@ -8265,6 +8418,7 @@
                     "type": "string"
                 },
                 "id": {
+                    "description": "ID is a stable public identifier used in pool names, metrics, and errors.\nIt must never contain credentials or non-graphic characters.",
                     "type": "string"
                 },
                 "inflight_requests": {
@@ -8322,6 +8476,10 @@
                 },
                 "storage_group": {
                     "type": "string"
+                },
+                "stream_inflight_requests": {
+                    "description": "StreamInflightRequests caps streaming (priority-lane) bodies in flight\nper connection, so a playback read never queues behind a connection's\nworth of read-ahead. 0 defaults to 4; values above inflight_requests\nare capped to it.",
+                    "type": "integer"
                 },
                 "tls": {
                     "type": "boolean"
@@ -8492,6 +8650,10 @@
                 "rc_user": {
                     "type": "string"
                 },
+                "rcd_restart_after": {
+                    "description": "RcdRestartAfter is how long the rcd subprocess must stay unresponsive to\nliveness probes before it is killed and restarted. Empty means the built-in\ndefault. Restarting is disruptive, because re-establishing the mount\nunmounts it out from under every process reading it, so an install whose\nrcd goes briefly slow under load can raise this to ride the stall out.",
+                    "type": "string"
+                },
                 "read_only": {
                     "type": "boolean"
                 },
@@ -8638,6 +8800,10 @@
                     "type": "integer"
                 },
                 "max_size_gb": {
+                    "type": "integer"
+                },
+                "memory_mb": {
+                    "description": "MemoryMB bounds the in-memory tier of decoded articles that sits in\nfront of the disk cache and is on even when the disk cache is off.\nLeft unset (nil) it defaults to 256; an explicit 0 disables it.",
                     "type": "integer"
                 }
             }
@@ -8930,7 +9096,8 @@
                 "completed",
                 "failed",
                 "paused",
-                "fallback"
+                "fallback",
+                "waiting_repair"
             ],
             "x-enum-comments": {
                 "QueueStatusFallback": "Sent to external SABnzbd as fallback"
@@ -8941,7 +9108,8 @@
                 "",
                 "",
                 "",
-                "Sent to external SABnzbd as fallback"
+                "Sent to external SABnzbd as fallback",
+                ""
             ],
             "x-enum-varnames": [
                 "QueueStatusPending",
@@ -8949,7 +9117,8 @@
                 "QueueStatusCompleted",
                 "QueueStatusFailed",
                 "QueueStatusPaused",
-                "QueueStatusFallback"
+                "QueueStatusFallback",
+                "QueueStatusWaitingRepair"
             ]
         }
     },

--- a/docs/static/swagger.yaml
+++ b/docs/static/swagger.yaml
@@ -251,6 +251,13 @@ definitions:
         $ref: '#/definitions/api.ImportAPIResponse'
       log:
         $ref: '#/definitions/config.LogConfig'
+      memory_limit_mb:
+        description: |-
+          MemoryLimitMB is the Go soft memory limit. Unset or 0 derives it from
+          the budgets that allocate (see SoftMemoryLimit); a positive value pins
+          it; a negative value leaves the runtime default. GOMEMLIMIT in the
+          environment always takes precedence.
+        type: integer
       metadata:
         $ref: '#/definitions/config.MetadataConfig'
       mount_path:
@@ -259,6 +266,8 @@ definitions:
         $ref: '#/definitions/config.MountType'
       network:
         $ref: '#/definitions/config.NetworkConfig'
+      par2_repair:
+        $ref: '#/definitions/config.Par2RepairConfig'
       profiler_enabled:
         type: boolean
       providers:
@@ -285,6 +294,13 @@ definitions:
         type: string
       webdav:
         $ref: '#/definitions/api.WebDAVAPIResponse'
+    type: object
+  api.CorruptedMetadataStatsResponse:
+    properties:
+      file_count:
+        type: integer
+      total_bytes:
+        type: integer
     type: object
   api.DailyStat:
     properties:
@@ -675,7 +691,8 @@ definitions:
       host:
         type: string
       id:
-        description: Stable public provider identifier; never credentials or non-graphic characters
+        description: ID is a stable public provider identifier; it is not an authentication
+          field.
         type: string
       inflight_requests:
         type: integer
@@ -812,7 +829,6 @@ definitions:
       host:
         type: string
       id:
-        description: Stable public provider identifier; never credentials or non-graphic characters
         type: string
       last_connection_attempt:
         type: string
@@ -1081,6 +1097,11 @@ definitions:
       rc_url:
         type: string
       rc_user:
+        type: string
+      rcd_restart_after:
+        description: |-
+          RcdRestartAfter is how long the rcd may stay unresponsive to liveness
+          probes before it is killed and restarted. Empty means the built-in default.
         type: string
       read_only:
         type: boolean
@@ -1653,6 +1674,13 @@ definitions:
         type: integer
       cleanup_orphaned_metadata:
         type: boolean
+      corrupted_retention_days:
+        description: |-
+          CorruptedRetentionDays bounds how long the corrupted_metadata safety copies
+          created by MoveToCorrupted are kept before the health cycle prunes them.
+          nil or 0 means keep forever, which is what every install did before this
+          setting existed.
+        type: integer
       corruption_action:
         description: |-
           CorruptionAction controls what happens when the health checker or a streaming read
@@ -1902,6 +1930,73 @@ definitions:
       weight:
         type: integer
     type: object
+  config.Par2RepairConfig:
+    properties:
+      arr_first:
+        description: |-
+          ArrFirst makes PAR2 repair the fallback for corrupted files: the health
+          worker triggers the ARR rescan first exactly as before, and enqueues a
+          PAR2 repair only when nothing is found in the ARRs (no instance
+          configured, none tracks the file) or ARR repair is disabled. On by
+          default; disable to keep PAR2 out of the corrupted-file flow (degraded
+          files, playback holes and repair-on-import still repair via PAR2
+          directly).
+        type: boolean
+      enabled:
+        type: boolean
+      max_concurrent_jobs:
+        description: MaxConcurrentJobs bounds simultaneously running repair jobs.
+        type: integer
+      max_connections:
+        description: |-
+          MaxConnections bounds how many NNTP connections repair jobs use for
+          article fetches (shared across concurrent jobs). Repair streams the
+          whole release once, so this directly sets its download speed on an idle
+          pool. Fetches ride the pool's background lane: while anything streams
+          or imports, the pool holds repair to a quarter of each provider's
+          connections regardless of this value. 0 (default) means 10.
+        type: integer
+      max_memory_mb:
+        description: |-
+          MaxMemoryMB bounds one job's in-heap solver memory; jobs needing more
+          still run, backed by memory-mapped scratch files next to the patch store.
+        type: integer
+      max_patch_store_mb:
+        description: |-
+          MaxPatchStoreMB bounds the on-disk patch store size; oldest patches are
+          evicted first when the cap is exceeded. 0 (default) means unlimited.
+        type: integer
+      max_release_size_mb:
+        type: integer
+      max_repair_ratio:
+        description: |-
+          MaxRepairRatio caps how large a fraction of a file's bytes a repair may
+          reconstruct. The release's PAR2 redundancy is always the hard ceiling.
+        type: number
+      min_release_size_mb:
+        description: |-
+          MinReleaseSizeMB / MaxReleaseSizeMB bound the size of releases repair
+          takes on (content bytes, PAR2 files excluded). A repair downloads the
+          whole release once, so these let users skip releases too large to be
+          worth the bandwidth or too small to bother with. 0 (default) means
+          unbounded on that side — all sizes are repaired.
+        type: integer
+      patch_dir:
+        description: |-
+          PatchDir is where repaired article payloads (and the solver's transient
+          scratch files) are stored. Empty (default) means <metadata_root>/patches.
+          Applied at startup; changing it does not move existing patches.
+        type: string
+      repair_on_import:
+        description: |-
+          RepairOnImport queues a repair as soon as an import completes with
+          confirmed missing segments, instead of waiting for the first playback or
+          a health check. Off by default: every repair costs one full release
+          download, so a large damaged backlog would be expensive. Worth enabling
+          when your library outlives article retention — a release's PAR2 volumes
+          are most likely to still be retrievable close to the post date.
+        type: boolean
+    type: object
   config.ProviderConfig:
     properties:
       account_expiration_date:
@@ -1911,6 +2006,9 @@ definitions:
       host:
         type: string
       id:
+        description: |-
+          ID is a stable public identifier used in pool names, metrics, and errors.
+          It must never contain credentials or non-graphic characters.
         type: string
       inflight_requests:
         description: |-
@@ -1958,6 +2056,13 @@ definitions:
         type: integer
       storage_group:
         type: string
+      stream_inflight_requests:
+        description: |-
+          StreamInflightRequests caps streaming (priority-lane) bodies in flight
+          per connection, so a playback read never queues behind a connection's
+          worth of read-ahead. 0 defaults to 4; values above inflight_requests
+          are capped to it.
+        type: integer
       tls:
         type: boolean
       user_agent:
@@ -2093,6 +2198,14 @@ definitions:
         type: string
       rc_user:
         type: string
+      rcd_restart_after:
+        description: |-
+          RcdRestartAfter is how long the rcd subprocess must stay unresponsive to
+          liveness probes before it is killed and restarted. Empty means the built-in
+          default. Restarting is disruptive, because re-establishing the mount
+          unmounts it out from under every process reading it, so an install whose
+          rcd goes briefly slow under load can raise this to ride the stall out.
+        type: string
       read_only:
         type: boolean
       syslog:
@@ -2199,6 +2312,12 @@ definitions:
           MaxSizeGB via LRU eviction). Left unset (nil) it defaults to 24 hours.
         type: integer
       max_size_gb:
+        type: integer
+      memory_mb:
+        description: |-
+          MemoryMB bounds the in-memory tier of decoded articles that sits in
+          front of the disk cache and is on even when the disk cache is off.
+          Left unset (nil) it defaults to 256; an explicit 0 disables it.
         type: integer
     type: object
   config.StreamScoringConfig:
@@ -2436,6 +2555,7 @@ definitions:
     - failed
     - paused
     - fallback
+    - waiting_repair
     type: string
     x-enum-comments:
       QueueStatusFallback: Sent to external SABnzbd as fallback
@@ -2446,6 +2566,7 @@ definitions:
     - ""
     - ""
     - Sent to external SABnzbd as fallback
+    - ""
     x-enum-varnames:
     - QueueStatusPending
     - QueueStatusProcessing
@@ -2453,6 +2574,7 @@ definitions:
     - QueueStatusFailed
     - QueueStatusPaused
     - QueueStatusFallback
+    - QueueStatusWaitingRepair
 host: localhost:8080
 info:
   contact:
@@ -4235,6 +4357,56 @@ paths:
       summary: Get scan status
       tags:
       - Import
+  /metadata/corrupted:
+    delete:
+      description: Removes every corrupted metadata safety copy and releases the segment
+        stores they hold.
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/api.APIResponse'
+      security:
+      - BearerAuth: []
+      summary: Purge corrupted metadata
+      tags:
+      - Metadata
+    get:
+      description: Returns how many corrupted metadata safety copies are retained
+        and how much disk they occupy.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.APIResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.CorruptedMetadataStatsResponse'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/api.APIResponse'
+      security:
+      - BearerAuth: []
+      summary: Get corrupted metadata stats
+      tags:
+      - Metadata
   /metadata/migration/cancel:
     post:
       description: Stops an in-flight migration after the current file.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,6 +3,7 @@ import type {
 	APIResponse,
 	AuthResponse,
 	ChangeOwnPasswordRequest,
+	CorruptedMetadataStats,
 	FileHealth,
 	FileMetadata,
 	FuseStatus,
@@ -142,6 +143,10 @@ class APIClient {
 				}
 
 				throw extractApiError(response.status, response.statusText, errorData);
+			}
+
+			if (response.status === 204) {
+				return undefined as T;
 			}
 
 			const data: APIResponse<T> = await response.json();
@@ -537,6 +542,14 @@ class APIClient {
 		return this.request<{ message: string }>("/health/library-sync/cancel", {
 			method: "POST",
 		});
+	}
+
+	async getCorruptedMetadataStats() {
+		return this.request<CorruptedMetadataStats>("/metadata/corrupted");
+	}
+
+	async purgeCorruptedMetadata() {
+		return this.request<void>("/metadata/corrupted", { method: "DELETE" });
 	}
 
 	async getMetadataMigrationStatus() {

--- a/frontend/src/components/config/CorruptedMetadataCard.tsx
+++ b/frontend/src/components/config/CorruptedMetadataCard.tsx
@@ -1,0 +1,99 @@
+import { Trash2 } from "lucide-react";
+import { useState } from "react";
+import {
+	useCorruptedMetadataStats,
+	usePurgeCorruptedMetadata,
+} from "../../hooks/useCorruptedMetadata";
+import { ConfirmModal } from "../ui/ConfirmModal";
+import { LoadingSpinner } from "../ui/LoadingSpinner";
+
+interface CorruptedMetadataCardProps {
+	isReadOnly?: boolean;
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes <= 0) return "0 B";
+	const units = ["B", "KB", "MB", "GB", "TB"];
+	const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+	return `${(bytes / 1024 ** exponent).toFixed(exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+}
+
+export function CorruptedMetadataCard({ isReadOnly = false }: CorruptedMetadataCardProps) {
+	const { data: stats, isLoading, error } = useCorruptedMetadataStats();
+	const purge = usePurgeCorruptedMetadata();
+	const [showConfirm, setShowConfirm] = useState(false);
+
+	const fileCount = stats?.file_count ?? 0;
+
+	const handleConfirmPurge = async () => {
+		setShowConfirm(false);
+		await purge.mutateAsync();
+	};
+
+	return (
+		<div className="card bg-base-100 shadow-lg">
+			<div className="card-body">
+				<h2 className="card-title">
+					<Trash2 className="h-5 w-5" aria-hidden="true" />
+					Corrupted Safety Copies
+				</h2>
+				<p className="text-base-content/70 text-sm">
+					When a file is marked corrupted its metadata is moved to
+					<code className="mx-1">corrupted_metadata</code> instead of being deleted. Copies older
+					than the retention window above are pruned automatically; purge removes all of them now
+					and releases the segment stores they hold.
+				</p>
+
+				{isLoading ? (
+					<div className="flex justify-center py-6">
+						<LoadingSpinner size="md" />
+					</div>
+				) : error ? (
+					<div className="alert alert-error">
+						<span className="text-sm">Failed to read corrupted metadata stats.</span>
+					</div>
+				) : (
+					<div className="stats stats-vertical sm:stats-horizontal bg-base-200">
+						<div className="stat">
+							<div className="stat-title">Retained Copies</div>
+							<div className="stat-value text-2xl">{fileCount}</div>
+						</div>
+						<div className="stat">
+							<div className="stat-title">On Disk</div>
+							<div className="stat-value text-2xl">{formatBytes(stats?.total_bytes ?? 0)}</div>
+						</div>
+					</div>
+				)}
+
+				<div className="card-actions justify-end">
+					<button
+						type="button"
+						className="btn btn-error"
+						onClick={() => setShowConfirm(true)}
+						disabled={isReadOnly || isLoading || fileCount === 0 || purge.isPending}
+					>
+						{purge.isPending ? (
+							<LoadingSpinner size="sm" />
+						) : (
+							<Trash2 className="h-4 w-4" aria-hidden="true" />
+						)}
+						Purge Now
+					</button>
+				</div>
+			</div>
+
+			<ConfirmModal
+				isOpen={showConfirm}
+				title="Purge corrupted metadata?"
+				message={`This permanently removes ${fileCount} safety ${
+					fileCount === 1 ? "copy" : "copies"
+				} (${formatBytes(stats?.total_bytes ?? 0)}). Files you have not re-imported cannot be recovered from them afterwards.`}
+				type="error"
+				confirmText="Purge"
+				confirmButtonClass="btn-error"
+				onConfirm={handleConfirmPurge}
+				onCancel={() => setShowConfirm(false)}
+			/>
+		</div>
+	);
+}

--- a/frontend/src/components/config/HealthConfigSection.tsx
+++ b/frontend/src/components/config/HealthConfigSection.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, Info, Save, TestTube } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { ConfigResponse, DryRunSyncResult, HealthConfig } from "../../types/config";
 import { LoadingSpinner } from "../ui/LoadingSpinner";
+import { CorruptedMetadataCard } from "./CorruptedMetadataCard";
 
 interface HealthConfigSectionProps {
 	config: ConfigResponse;
@@ -205,6 +206,30 @@ export function HealthConfigSection({
 						</p>
 					</fieldset>
 
+					<fieldset className="fieldset mt-6 border-base-300/50 border-t pt-6">
+						<legend className="fieldset-legend font-semibold">
+							Corrupted Metadata Retention (Days)
+						</legend>
+						<input
+							type="number"
+							className="input input-bordered w-full bg-base-100 font-mono text-sm"
+							value={formData.corrupted_retention_days ?? 0}
+							disabled={isReadOnly}
+							onChange={(e) =>
+								handleInputChange(
+									"corrupted_retention_days",
+									Number.parseInt(e.target.value, 10) || 0,
+								)
+							}
+							min="0"
+						/>
+						<p className="label break-words text-[10px] text-base-content/50">
+							How long a corrupted file's metadata is kept in the corrupted_metadata safety folder
+							before the health cycle prunes it and releases the segment store it holds. 0 keeps
+							safety copies forever.
+						</p>
+					</fieldset>
+
 					<div className="mt-6 flex items-start justify-between gap-4 border-base-300/50 border-t pt-6">
 						<div className="min-w-0 flex-1">
 							<h4 className="break-words font-bold text-base-content text-sm">Repair Engine</h4>
@@ -321,6 +346,8 @@ export function HealthConfigSection({
 						</div>
 					)}
 				</div>
+
+				<CorruptedMetadataCard isReadOnly={isReadOnly} />
 
 				{/* Directory Configuration */}
 				<div className="space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">

--- a/frontend/src/hooks/useCorruptedMetadata.ts
+++ b/frontend/src/hooks/useCorruptedMetadata.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "../api/client";
+import type { CorruptedMetadataStats } from "../types/api";
+
+const CORRUPTED_METADATA_KEY = ["metadata", "corrupted"];
+
+export function useCorruptedMetadataStats() {
+	return useQuery<CorruptedMetadataStats>({
+		queryKey: CORRUPTED_METADATA_KEY,
+		queryFn: () => apiClient.getCorruptedMetadataStats(),
+		retry: 1,
+	});
+}
+
+export function usePurgeCorruptedMetadata() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: () => apiClient.purgeCorruptedMetadata(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: CORRUPTED_METADATA_KEY });
+		},
+		onError: (error) => {
+			console.error("Failed to purge corrupted metadata:", error);
+		},
+	});
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -411,6 +411,11 @@ export interface LibrarySyncStatus {
 }
 
 // Metadata migration types (legacy inline-segment .meta → v3 shared NZB store)
+export interface CorruptedMetadataStats {
+	file_count: number;
+	total_bytes: number;
+}
+
 export interface MetadataMigrationProgress {
 	total_groups: number;
 	processed_groups: number;

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -154,6 +154,9 @@ export interface HealthConfig {
 	corruption_action?: "repair" | "delete";
 	verify_content?: boolean; // Probe each media file's header for a valid container signature during health checks
 	verify_content_timeout_seconds?: number; // Per-file content probe timeout (default 15s)
+	// Days a corrupted_metadata safety copy is kept before the health cycle prunes it.
+	// 0 or absent means keep forever.
+	corrupted_retention_days?: number;
 }
 
 export interface RepairConfig {

--- a/internal/api/metadata_corrupted_handlers.go
+++ b/internal/api/metadata_corrupted_handlers.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"log/slog"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// CorruptedMetadataStatsResponse reports what the corrupted_metadata safety folder
+// currently holds.
+type CorruptedMetadataStatsResponse struct {
+	FileCount  int   `json:"file_count"`
+	TotalBytes int64 `json:"total_bytes"`
+}
+
+// handleGetCorruptedMetadata handles GET /api/metadata/corrupted
+//
+//	@Summary		Get corrupted metadata stats
+//	@Description	Returns how many corrupted metadata safety copies are retained and how much disk they occupy.
+//	@Tags			Metadata
+//	@Produce		json
+//	@Success		200	{object}	APIResponse{data=CorruptedMetadataStatsResponse}
+//	@Failure		500	{object}	APIResponse
+//	@Failure		503	{object}	APIResponse
+//	@Security		BearerAuth
+//	@Router			/metadata/corrupted [get]
+func (s *Server) handleGetCorruptedMetadata(c *fiber.Ctx) error {
+	if s.metadataService == nil {
+		return RespondServiceUnavailable(c, "Metadata service not available", "")
+	}
+
+	count, totalBytes, err := s.metadataService.CorruptedStats(c.Context())
+	if err != nil {
+		slog.ErrorContext(c.Context(), "Failed to read corrupted metadata stats", "error", err)
+		return RespondInternalError(c, "Failed to read corrupted metadata stats", err.Error())
+	}
+
+	return RespondSuccess(c, CorruptedMetadataStatsResponse{FileCount: count, TotalBytes: totalBytes})
+}
+
+// handlePurgeCorruptedMetadata handles DELETE /api/metadata/corrupted
+//
+//	@Summary		Purge corrupted metadata
+//	@Description	Removes every corrupted metadata safety copy and releases the segment stores they hold.
+//	@Tags			Metadata
+//	@Produce		json
+//	@Success		204	"No Content"
+//	@Failure		500	{object}	APIResponse
+//	@Failure		503	{object}	APIResponse
+//	@Security		BearerAuth
+//	@Router			/metadata/corrupted [delete]
+func (s *Server) handlePurgeCorruptedMetadata(c *fiber.Ctx) error {
+	if s.metadataService == nil {
+		return RespondServiceUnavailable(c, "Metadata service not available", "")
+	}
+
+	removed, err := s.metadataService.PruneCorrupted(c.Context(), 0)
+	if err != nil {
+		slog.ErrorContext(c.Context(), "Failed to purge corrupted metadata", "error", err, "removed", removed)
+		return RespondInternalError(c, "Failed to purge corrupted metadata", err.Error())
+	}
+
+	return RespondNoContent(c)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -314,6 +314,8 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	api.Post("/health/library-sync/cancel", s.handleCancelLibrarySync)
 	api.Post("/health/library-sync/dry-run", s.handleDryRunLibrarySync)
 
+	api.Get("/metadata/corrupted", s.handleGetCorruptedMetadata)
+	api.Delete("/metadata/corrupted", s.handlePurgeCorruptedMetadata)
 	api.Get("/metadata/migration/status", s.handleGetMetadataMigrationStatus)
 	api.Post("/metadata/migration/dry-run", s.handleDryRunMetadataMigration)
 	api.Post("/metadata/migration/start", s.handleStartMetadataMigration)

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -737,6 +737,11 @@ type HealthConfig struct {
 	// is found. Distinct from the unrelated, unused VerifyData field above.
 	VerifyContent               *bool `yaml:"verify_content" mapstructure:"verify_content" json:"verify_content,omitempty"`
 	VerifyContentTimeoutSeconds *int  `yaml:"verify_content_timeout_seconds" mapstructure:"verify_content_timeout_seconds" json:"verify_content_timeout_seconds,omitempty"`
+	// CorruptedRetentionDays bounds how long the corrupted_metadata safety copies
+	// created by MoveToCorrupted are kept before the health cycle prunes them.
+	// nil or 0 means keep forever, which is what every install did before this
+	// setting existed.
+	CorruptedRetentionDays *int `yaml:"corrupted_retention_days" mapstructure:"corrupted_retention_days" json:"corrupted_retention_days,omitempty"`
 }
 
 // Path validation functions have been moved to internal/utils/path.go
@@ -1257,6 +1262,9 @@ func (c *Config) Validate() error {
 	}
 	if c.Health.VerifyContentTimeoutSeconds != nil && *c.Health.VerifyContentTimeoutSeconds <= 0 {
 		return fmt.Errorf("health verify_content_timeout_seconds must be greater than 0")
+	}
+	if c.Health.CorruptedRetentionDays != nil && *c.Health.CorruptedRetentionDays < 0 {
+		return fmt.Errorf("health corrupted_retention_days must be zero (keep forever) or greater")
 	}
 
 	// Validate health configuration - requires library_dir when enabled and using a strategy other than NONE
@@ -2021,6 +2029,7 @@ func DefaultConfig(configDir ...string) *Config {
 	importVerifyContentTimeoutSeconds := defaultVerifyContentTimeoutSeconds
 	healthVerifyContent := false // Content verification disabled by default (destructive if misfired)
 	healthVerifyContentTimeoutSeconds := defaultVerifyContentTimeoutSeconds
+	healthCorruptedRetentionDays := 0
 
 	// Set paths based on whether we're running in Docker or have a specific config directory
 	var dbPath, metadataPath, logPath, rclonePath, cachePath, backupPath string
@@ -2187,6 +2196,7 @@ func DefaultConfig(configDir ...string) *Config {
 			AcceptableMissingSegmentsPercentage: 2,                                  // Default: tolerate up to 2% missing segments
 			VerifyContent:                       &healthVerifyContent,               // Disabled by default
 			VerifyContentTimeoutSeconds:         &healthVerifyContentTimeoutSeconds, // Default: 15s per-file content probe timeout
+			CorruptedRetentionDays:              &healthCorruptedRetentionDays,      // Default: keep corrupted safety copies forever
 			Repair: RepairConfig{
 				Enabled:            &repairEnabled,
 				IntervalMinutes:    60,

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -1179,6 +1179,12 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 		slog.WarnContext(ctx, "Failed to cleanup empty directories in metadata", "error", err)
 	}
 
+	if days := cfg.Health.CorruptedRetentionDays; days != nil && *days > 0 {
+		if _, err := hw.metadataService.PruneCorrupted(ctx, time.Duration(*days)*24*time.Hour); err != nil {
+			slog.WarnContext(ctx, "Failed to prune corrupted metadata safety copies", "error", err)
+		}
+	}
+
 	// Perform bulk database update
 	if len(results) > 0 {
 		if err := hw.healthRepo.UpdateHealthStatusBulk(ctx, results); err != nil {

--- a/internal/metadata/corrupted_retention_test.go
+++ b/internal/metadata/corrupted_retention_test.go
@@ -1,0 +1,227 @@
+package metadata
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// corruptedMetaPath mirrors where MoveToCorrupted parks a virtual path's .meta.
+func corruptedMetaPath(root, virtualPath string) string {
+	v := strings.TrimPrefix(filepath.ToSlash(virtualPath), "/")
+	return filepath.Join(root, "corrupted_metadata", filepath.FromSlash(v)+".meta")
+}
+
+func ageFile(t *testing.T, path string, age time.Duration) {
+	t.Helper()
+	when := time.Now().Add(-age)
+	require.NoError(t, os.Chtimes(path, when, when))
+}
+
+func TestPruneCorrupted_MissingFolderIsNotAnError(t *testing.T) {
+	ms := NewMetadataService(t.TempDir())
+
+	removed, err := ms.PruneCorrupted(context.Background(), 24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+}
+
+func TestPruneCorrupted_RemovesOnlyExpiredCopies(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+	refs := newFakeStoreRefCounter()
+	ms.SetStoreRefCounter(refs)
+
+	storeRef := filepath.Join(t.TempDir(), "10767-release.nzbz")
+	paths := writeSharedRelease(t, ms, storeRef, "s01e01.mkv", "s01e02.mkv")
+
+	ctx := context.Background()
+	for _, p := range paths {
+		require.NoError(t, ms.MoveToCorrupted(ctx, p))
+	}
+	ageFile(t, corruptedMetaPath(root, paths[0]), 48*time.Hour)
+
+	removed, err := ms.PruneCorrupted(ctx, 24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed)
+
+	assert.NoFileExists(t, corruptedMetaPath(root, paths[0]))
+	assert.FileExists(t, corruptedMetaPath(root, paths[1]), "a copy inside the retention window must survive")
+
+	assert.FileExists(t, storeRef, "store must survive while the younger copy still references it")
+	assert.Equal(t, int64(1), refs.counts[storeRef], "ref count must drop by exactly one")
+}
+
+func TestPruneCorrupted_ReleasesStoreOnLastCopy(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+	refs := newFakeStoreRefCounter()
+	ms.SetStoreRefCounter(refs)
+
+	storeRef := filepath.Join(t.TempDir(), "10767-release.nzbz")
+	paths := writeSharedRelease(t, ms, storeRef, "s01e01.mkv", "s01e02.mkv")
+
+	ctx := context.Background()
+	for _, p := range paths {
+		require.NoError(t, ms.MoveToCorrupted(ctx, p))
+	}
+
+	removed, err := ms.PruneCorrupted(ctx, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, removed)
+
+	assert.NoFileExists(t, storeRef, "store must be released once the last safety copy is pruned")
+	assert.False(t, refs.tracked(storeRef))
+
+	assert.NoDirExists(t, filepath.Join(root, "corrupted_metadata", "tv"), "emptied sub-directory must be cleaned up")
+	assert.DirExists(t, filepath.Join(root, "corrupted_metadata"), "the safety folder itself must remain")
+}
+
+func TestPruneCorrupted_RemovesIDSidecar(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	storeRef := filepath.Join(t.TempDir(), "10767-release.nzbz")
+	paths := writeSharedRelease(t, ms, storeRef, "s01e01.mkv")
+
+	require.NoError(t, os.WriteFile(ms.GetMetadataFilePath(paths[0])+".id", []byte("nzbdav-id"), 0o644))
+
+	ctx := context.Background()
+	require.NoError(t, ms.MoveToCorrupted(ctx, paths[0]))
+
+	copyPath := corruptedMetaPath(root, paths[0])
+	require.FileExists(t, copyPath+".id")
+
+	removed, err := ms.PruneCorrupted(ctx, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed)
+	assert.NoFileExists(t, copyPath+".id")
+}
+
+func TestPruneCorrupted_RespectsContextCancellation(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	storeRef := filepath.Join(t.TempDir(), "10767-release.nzbz")
+	paths := writeSharedRelease(t, ms, storeRef, "s01e01.mkv")
+	require.NoError(t, ms.MoveToCorrupted(context.Background(), paths[0]))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	removed, err := ms.PruneCorrupted(ctx, 0)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, removed)
+	assert.FileExists(t, corruptedMetaPath(root, paths[0]), "a cancelled sweep must not remove anything")
+}
+
+func TestWriteFileMetadataAuto_DropsStaleCorruptedCopy(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+	refs := newFakeStoreRefCounter()
+	ms.SetStoreRefCounter(refs)
+
+	storeRef := filepath.Join(t.TempDir(), "10767-release.nzbz")
+	paths := writeSharedRelease(t, ms, storeRef, "s01e01.mkv")
+
+	ctx := context.Background()
+	require.NoError(t, ms.MoveToCorrupted(ctx, paths[0]))
+	require.FileExists(t, corruptedMetaPath(root, paths[0]))
+
+	reimported := &metapb.FileMetadata{
+		FileSize: 100,
+		Status:   metapb.FileStatus_FILE_STATUS_HEALTHY,
+		SegmentData: []*metapb.SegmentData{
+			{Id: "reimport@n", SegmentSize: 100, StartOffset: 0, EndOffset: 99},
+		},
+	}
+	require.NoError(t, ms.WriteFileMetadataAuto(ctx, paths[0], reimported, nil, ""))
+
+	assert.NoFileExists(t, corruptedMetaPath(root, paths[0]), "a successful re-import must reap its safety copy")
+	assert.NoFileExists(t, storeRef, "the copy's store reference must be released")
+	assert.False(t, refs.tracked(storeRef))
+
+	got, err := ms.ReadFileMetadata(paths[0])
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, int64(100), got.FileSize)
+}
+
+func TestWriteFileMetadataAuto_NoCorruptedCopyIsNoop(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+	refs := newFakeStoreRefCounter()
+	ms.SetStoreRefCounter(refs)
+
+	meta := &metapb.FileMetadata{
+		FileSize: 100,
+		Status:   metapb.FileStatus_FILE_STATUS_HEALTHY,
+		SegmentData: []*metapb.SegmentData{
+			{Id: "fresh@n", SegmentSize: 100, StartOffset: 0, EndOffset: 99},
+		},
+	}
+
+	ctx := context.Background()
+	require.NoError(t, ms.WriteFileMetadataAuto(ctx, "tv/fresh.mkv", meta, nil, ""))
+
+	got, err := ms.ReadFileMetadata("tv/fresh.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Empty(t, refs.counts)
+	assert.NoDirExists(t, filepath.Join(root, "corrupted_metadata"))
+}
+
+func TestCorruptedStats_CountsRetainedCopies(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	ctx := context.Background()
+	count, totalBytes, err := ms.CorruptedStats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+	assert.Equal(t, int64(0), totalBytes)
+
+	storeRef := filepath.Join(t.TempDir(), "10767-release.nzbz")
+	paths := writeSharedRelease(t, ms, storeRef, "s01e01.mkv", "s01e02.mkv")
+	for _, p := range paths {
+		require.NoError(t, ms.MoveToCorrupted(ctx, p))
+	}
+
+	count, totalBytes, err = ms.CorruptedStats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+	assert.Positive(t, totalBytes)
+}
+
+func TestMoveToCorrupted_RetentionClockStartsAtTheMove(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	virtualPath := "tv/old-import.mkv"
+	meta := &metapb.FileMetadata{
+		FileSize:   100,
+		Status:     metapb.FileStatus_FILE_STATUS_HEALTHY,
+		ModifiedAt: time.Now().Add(-365 * 24 * time.Hour).Unix(),
+		SegmentData: []*metapb.SegmentData{
+			{Id: "old@n", SegmentSize: 100, StartOffset: 0, EndOffset: 99},
+		},
+	}
+	require.NoError(t, ms.WriteFileMetadata(virtualPath, meta))
+
+	ctx := context.Background()
+	require.NoError(t, ms.MoveToCorrupted(ctx, virtualPath))
+
+	// The .meta's disk mtime tracks ModifiedAt, so without a restamp a year-old
+	// import would be pruned the instant it was quarantined.
+	removed, err := ms.PruneCorrupted(ctx, 24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+	assert.FileExists(t, corruptedMetaPath(root, virtualPath))
+}

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -348,14 +348,23 @@ func (ms *MetadataService) WriteFileMetadataV3(ctx context.Context, virtualPath 
 // problem on one file never blocks the import). With an empty storeRef it writes v1.
 // This is the single entry point import processors should use.
 func (ms *MetadataService) WriteFileMetadataAuto(ctx context.Context, virtualPath string, metadata *metapb.FileMetadata, index map[string]int64, storeRef string) error {
-	if storeRef == "" {
-		return ms.WriteFileMetadata(virtualPath, metadata)
+	write := func() error {
+		if storeRef == "" {
+			return ms.WriteFileMetadata(virtualPath, metadata)
+		}
+		if err := ms.WriteFileMetadataV3(ctx, virtualPath, metadata, index, storeRef); err != nil {
+			slog.WarnContext(ctx, "v3 metadata write failed; writing v1",
+				"path", virtualPath, "error", err)
+			return ms.WriteFileMetadata(virtualPath, metadata)
+		}
+		return nil
 	}
-	if err := ms.WriteFileMetadataV3(ctx, virtualPath, metadata, index, storeRef); err != nil {
-		slog.WarnContext(ctx, "v3 metadata write failed; writing v1",
-			"path", virtualPath, "error", err)
-		return ms.WriteFileMetadata(virtualPath, metadata)
+
+	if err := write(); err != nil {
+		return err
 	}
+
+	ms.removeCorruptedCopy(ctx, virtualPath)
 	return nil
 }
 
@@ -835,6 +844,7 @@ func (ms *MetadataService) DeleteCorruptedFile(ctx context.Context, virtualPath 
 	if err := ms.DeleteFileMetadata(ctx, virtualPath); err != nil {
 		return err
 	}
+	ms.removeCorruptedCopy(ctx, virtualPath)
 	if physicalPath == "" {
 		return nil
 	}
@@ -1114,6 +1124,15 @@ func (ms *MetadataService) MoveToCorrupted(ctx context.Context, virtualPath stri
 		return err
 	}
 
+	// The .meta's disk mtime is pinned to the proto's ModifiedAt (the import time),
+	// so left alone it would date the safety copy to the import rather than to the
+	// move. Retention counts from the move, so restart the clock here.
+	now := time.Now()
+	if err := os.Chtimes(targetPath, now, now); err != nil {
+		slog.DebugContext(ctx, "Failed to stamp corrupted metadata copy mtime",
+			"path", targetPath, "error", err)
+	}
+
 	// Also try to move the .id file if it exists
 	idPath := metadataPath + ".id"
 	if _, err := os.Stat(idPath); err == nil {
@@ -1124,6 +1143,162 @@ func (ms *MetadataService) MoveToCorrupted(ctx context.Context, virtualPath stri
 		"original", metadataPath,
 		"target", targetPath)
 	return nil
+}
+
+// PruneCorrupted removes safety copies under corrupted_metadata whose .meta is
+// older than maxAge, and reports how many were removed. A maxAge of zero or less
+// prunes every copy. A missing corrupted_metadata directory is not an error.
+func (ms *MetadataService) PruneCorrupted(ctx context.Context, maxAge time.Duration) (int, error) {
+	corruptedRoot := filepath.Join(ms.rootPath, "corrupted_metadata")
+	if _, err := os.Stat(corruptedRoot); os.IsNotExist(err) {
+		return 0, nil
+	}
+
+	cutoff := time.Now().Add(-maxAge)
+	removed := 0
+	prunedDirs := make(map[string]struct{})
+
+	err := filepath.WalkDir(corruptedRoot, func(path string, d fs.DirEntry, err error) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if err != nil {
+			return nil // skip errors
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".meta") {
+			return nil
+		}
+
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return nil
+		}
+		if maxAge > 0 && info.ModTime().After(cutoff) {
+			return nil
+		}
+
+		pruned, pruneErr := ms.pruneCorruptedMeta(ctx, path)
+		if pruneErr != nil {
+			slog.WarnContext(ctx, "Failed to prune corrupted metadata copy", "path", path, "error", pruneErr)
+			return nil
+		}
+		if pruned {
+			removed++
+			prunedDirs[filepath.Dir(path)] = struct{}{}
+		}
+		return nil
+	})
+
+	for dir := range prunedDirs {
+		utils.RemoveEmptyDirs(corruptedRoot, dir)
+	}
+
+	if err != nil {
+		return removed, err
+	}
+
+	if removed > 0 {
+		slog.InfoContext(ctx, "Pruned corrupted metadata safety copies",
+			"removed", removed, "max_age", maxAge)
+	}
+
+	return removed, nil
+}
+
+// CorruptedStats reports how many safety copies corrupted_metadata currently holds
+// and how much disk they occupy.
+func (ms *MetadataService) CorruptedStats(ctx context.Context) (int, int64, error) {
+	corruptedRoot := filepath.Join(ms.rootPath, "corrupted_metadata")
+	if _, err := os.Stat(corruptedRoot); os.IsNotExist(err) {
+		return 0, 0, nil
+	}
+
+	count := 0
+	var totalBytes int64
+
+	err := filepath.WalkDir(corruptedRoot, func(path string, d fs.DirEntry, err error) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".meta") {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return nil
+		}
+		count++
+		totalBytes += info.Size()
+		return nil
+	})
+	if err != nil {
+		return count, totalBytes, err
+	}
+
+	return count, totalBytes, nil
+}
+
+// pruneCorruptedMeta removes a single safety copy plus its .id sidecar, reporting
+// whether anything was there to remove.
+//
+// The store reference must be released here: MoveToCorrupted renames the .meta
+// without decrementing, so the copy is the only remaining holder of a reference to
+// the release's shared .nzbz store, and dropping it silently would pin that store
+// on disk forever.
+func (ms *MetadataService) pruneCorruptedMeta(ctx context.Context, metaPath string) (bool, error) {
+	storeRef := ms.readStoreRef(metaPath)
+
+	if err := os.Remove(metaPath); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to delete corrupted metadata file: %w", err)
+	}
+
+	idPath := metaPath + ".id"
+	if removeErr := os.Remove(idPath); removeErr != nil && !os.IsNotExist(removeErr) {
+		slog.DebugContext(ctx, "Failed to remove .id sidecar file", "path", idPath, "error", removeErr)
+	}
+
+	if ms.storeRefCounter != nil && storeRef != "" {
+		newCount, tracked, err := ms.storeRefCounter.DecStoreRef(ctx, storeRef)
+		if err != nil {
+			slog.WarnContext(ctx, "failed to decrement store ref count",
+				"store_path", storeRef, "error", err)
+		} else if tracked && newCount == 0 {
+			if removeErr := os.Remove(storeRef); removeErr != nil && !os.IsNotExist(removeErr) {
+				slog.WarnContext(ctx, "failed to delete orphaned store file",
+					"store_path", storeRef, "error", removeErr)
+			}
+		}
+	}
+
+	return true, nil
+}
+
+// removeCorruptedCopy drops the safety copy shadowing a virtual path, if one exists,
+// so a successful re-import or an explicit delete leaves nothing behind.
+func (ms *MetadataService) removeCorruptedCopy(ctx context.Context, virtualPath string) {
+	v := normalizeVirtualPath(virtualPath)
+	corruptedRoot := filepath.Join(ms.rootPath, "corrupted_metadata")
+	copyDir := filepath.Join(corruptedRoot, filepath.Dir(strings.TrimPrefix(v, "/")))
+	copyPath := filepath.Join(copyDir, ms.truncateFilename(filepath.Base(v))+".meta")
+
+	pruned, err := ms.pruneCorruptedMeta(ctx, copyPath)
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to remove corrupted metadata safety copy",
+			"path", copyPath, "error", err)
+		return
+	}
+	if pruned {
+		utils.RemoveEmptyDirs(corruptedRoot, copyDir)
+	}
 }
 
 // CleanupOrphanedIDSymlinks walks the .ids/ directory and removes symlinks whose

--- a/internal/nzbfilesystem/constants.go
+++ b/internal/nzbfilesystem/constants.go
@@ -11,6 +11,9 @@ import (
 const (
 	// RootPath represents the root directory path
 	RootPath = "/"
+
+	// corruptedDirName is the metadata-root folder holding corrupted safety copies.
+	corruptedDirName = "corrupted_metadata"
 )
 
 // Error constants

--- a/internal/nzbfilesystem/corrupted_dir_delete_test.go
+++ b/internal/nzbfilesystem/corrupted_dir_delete_test.go
@@ -1,0 +1,57 @@
+package nzbfilesystem
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newCorruptedDirFixture(t *testing.T) (*MetadataRemoteFile, string, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	ms := metadata.NewMetadataService(root)
+
+	filePath := "series/stream.s01e01.mkv"
+	writeStreamMeta(t, ms, filePath)
+	require.NoError(t, ms.MoveToCorrupted(context.Background(), filePath))
+
+	copyPath := filepath.Join(root, "corrupted_metadata", "series", "stream.s01e01.mkv.meta")
+	require.FileExists(t, copyPath)
+
+	cfg := config.DefaultConfig()
+	mrf := &MetadataRemoteFile{
+		metadataService: ms,
+		configGetter:    func() *config.Config { return cfg },
+	}
+
+	return mrf, root, copyPath
+}
+
+func TestRemoveFile_CorruptedFolderIsProtected(t *testing.T) {
+	mrf, root, copyPath := newCorruptedDirFixture(t)
+
+	for _, name := range []string{"corrupted_metadata", "/corrupted_metadata", "/corrupted_metadata/"} {
+		ok, err := mrf.RemoveFile(context.Background(), name)
+		assert.False(t, ok, name)
+		require.ErrorIs(t, err, os.ErrPermission, name)
+	}
+
+	assert.DirExists(t, filepath.Join(root, "corrupted_metadata"))
+	assert.FileExists(t, copyPath, "a recursive DELETE must not wipe the safety copies")
+}
+
+func TestRemoveFile_FileInsideCorruptedFolderIsRemovable(t *testing.T) {
+	mrf, _, copyPath := newCorruptedDirFixture(t)
+
+	ok, err := mrf.RemoveFile(context.Background(), "corrupted_metadata/series/stream.s01e01.mkv")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.NoFileExists(t, copyPath)
+}

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -169,7 +169,7 @@ func (mrf *MetadataRemoteFile) OpenFile(ctx context.Context, name string) (bool,
 
 	// Force showCorrupted if we are inside the corrupted_metadata folder
 	// normalizedName is clean and has no trailing slashes
-	if strings.HasPrefix(normalizedName, "corrupted_metadata/") || normalizedName == "corrupted_metadata" {
+	if strings.HasPrefix(normalizedName, corruptedDirName+"/") || normalizedName == corruptedDirName {
 		showCorrupted = true
 	}
 
@@ -341,6 +341,12 @@ func (mrf *MetadataRemoteFile) RemoveFile(ctx context.Context, fileName string) 
 	// Prevent removal of root directory
 	if normalizedName == RootPath {
 		return false, ErrCannotRemoveRoot
+	}
+
+	// A recursive DELETE on the safety folder itself would wipe every corrupted
+	// copy at once; purging is an explicit action. Paths inside it stay removable.
+	if strings.EqualFold(strings.Trim(normalizedName, "/"), corruptedDirName) {
+		return false, os.ErrPermission
 	}
 
 	// Prevent removal of category folders


### PR DESCRIPTION
Safety copies were retained forever: five production sites touch `corrupted_metadata` and none deletes. `corruption_action: delete` was provably a no-op — it resolves the *original* virtual path, which `MoveToCorrupted` has already renamed away, so `os.Remove` hits `IsNotExist` and is swallowed.

**Leak not in the original report:** `MoveToCorrupted` never decremented the v3 `StoreRef`, so every safety copy pinned its shared `.nzbz` segment store alive — the accumulation was far larger than the `.meta` files.

**Also found while implementing:** `WriteFileMetadata` pins a `.meta`'s mtime to the proto's `ModifiedAt` and `os.Rename` preserves it, so `ModTime` retention would have measured from *import* time and pruned an old release the instant it was quarantined. `MoveToCorrupted` now restamps the copy.

- `health.corrupted_retention_days` (**default 0 = keep forever**, so existing installs never start deleting silently) + `PruneCorrupted` sweep
- a successful re-import and `corruption_action: delete` now both reap the copy and release the store, regardless of the setting
- recursive WebDAV DELETE of the folder itself now returns `ErrPermission`; files inside stay deletable
- `GET`/`DELETE /api/metadata/corrupted` + a UI purge card with counts and size

Specs regenerated with the tracked generator, which also picks up pre-existing drift from main.

**Stack 6/8** — base: `perf/import-zero-tolerance-short-circuit`

Closes #871