### PR TITLE
fix(importer): keep transient content-probe errors out of the blocklist path

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -590,7 +590,7 @@ class APIClient {
 		);
 	}
 
-	async directHealthCheck(id: number) {
+	async directHealthCheck(id: number, verifyContent?: boolean) {
 		return this.request<{
 			message: string;
 			id: number;
@@ -601,6 +601,9 @@ class APIClient {
 			health_data: FileHealth;
 		}>(`/health/${id}/check-now`, {
 			method: "POST",
+			...(verifyContent === undefined
+				? {}
+				: { body: JSON.stringify({ verify_content: verifyContent }) }),
 		});
 	}
 

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -424,7 +424,8 @@ export const useDirectHealthCheck = () => {
 	const queryClient = useQueryClient();
 
 	return useMutation({
-		mutationFn: (id: number) => apiClient.directHealthCheck(id),
+		mutationFn: ({ id, verifyContent }: { id: number; verifyContent?: boolean }) =>
+			apiClient.directHealthCheck(id, verifyContent),
 		onSuccess: () => {
 			// Immediately refresh health data to show "checking" status
 			queryClient.invalidateQueries({ queryKey: ["health"] });

--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -341,9 +341,9 @@ export function HealthPage() {
 	};
 
 	const handleManualCheck = useCallback(
-		async (id: number) => {
+		async (id: number, verifyContent?: boolean) => {
 			try {
-				await directHealthCheck.mutateAsync(id);
+				await directHealthCheck.mutateAsync({ id, verifyContent });
 			} catch (err) {
 				console.error("Failed to perform direct health check:", err);
 			}

--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthItemActionsMenu.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthItemActionsMenu.tsx
@@ -4,6 +4,7 @@ import {
 	MoreHorizontal,
 	PlayCircle,
 	RefreshCw,
+	ScanSearch,
 	Trash2,
 	Wrench,
 	X,
@@ -21,7 +22,7 @@ interface HealthItemActionsMenuProps {
 	isUnmaskPending: boolean;
 	isRegeneratePending?: boolean;
 	onCancelCheck: (id: number) => void;
-	onManualCheck: (id: number) => void;
+	onManualCheck: (id: number, verifyContent?: boolean) => void;
 	onRepair: (id: number) => void;
 	onPar2Repair?: (filePath: string) => void;
 	onDelete: (id: number) => void;
@@ -98,16 +99,28 @@ export function HealthItemActionsMenu({
 						</button>
 					</li>
 				) : (
-					<li>
-						<button
-							type="button"
-							onClick={() => onManualCheck(item.id)}
-							disabled={isDirectCheckPending}
-						>
-							<PlayCircle className="h-4 w-4" />
-							Retry Check
-						</button>
-					</li>
+					<>
+						<li>
+							<button
+								type="button"
+								onClick={() => onManualCheck(item.id)}
+								disabled={isDirectCheckPending}
+							>
+								<PlayCircle className="h-4 w-4" />
+								Retry Check
+							</button>
+						</li>
+						<li>
+							<button
+								type="button"
+								onClick={() => onManualCheck(item.id, true)}
+								disabled={isDirectCheckPending}
+							>
+								<ScanSearch className="h-4 w-4" />
+								Verify Media Content
+							</button>
+						</li>
+					</>
 				)}
 				{onRegenerate && (
 					<li>

--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthItemCard.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthItemCard.tsx
@@ -28,7 +28,7 @@ interface HealthItemCardProps {
 	onSelectChange: (filePath: string, checked: boolean) => void;
 	onSetPriority: (id: number, priority: HealthPriority) => void;
 	onCancelCheck: (id: number) => void;
-	onManualCheck: (id: number) => void;
+	onManualCheck: (id: number, verifyContent?: boolean) => void;
 	onRepair: (id: number) => void;
 	onPar2Repair?: (filePath: string) => void;
 	onDelete: (id: number) => void;

--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthTable.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthTable.tsx
@@ -25,7 +25,7 @@ interface HealthTableProps {
 	onSelectAllPages: () => void;
 	onSort: (column: SortBy) => void;
 	onCancelCheck: (id: number) => void;
-	onManualCheck: (id: number) => void;
+	onManualCheck: (id: number, verifyContent?: boolean) => void;
 	onRepair: (id: number) => void;
 	onPar2Repair?: (filePath: string) => void;
 	onDelete: (id: number) => void;

--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthTableRow.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthTableRow.tsx
@@ -23,7 +23,7 @@ interface HealthTableRowProps {
 	isRegeneratePending?: boolean;
 	onSelectChange: (filePath: string, checked: boolean) => void;
 	onCancelCheck: (id: number) => void;
-	onManualCheck: (id: number) => void;
+	onManualCheck: (id: number, verifyContent?: boolean) => void;
 	onRepair: (id: number) => void;
 	onPar2Repair?: (filePath: string) => void;
 	onDelete: (id: number) => void;

--- a/internal/contentverify/probe.go
+++ b/internal/contentverify/probe.go
@@ -70,6 +70,16 @@ type Opener interface {
 // content is confirmed bad; ContentProbeError means the check itself
 // failed and must not be treated as a content failure.
 func Probe(ctx context.Context, opener Opener, path string, timeout time.Duration) ProbeResult {
+	res := probeOnce(ctx, opener, path, timeout)
+	if res.Result != ContentProbeError {
+		return res
+	}
+	// A probe costs a single article, so one immediate re-attempt is cheaper
+	// than letting a momentary provider hiccup stall the whole release.
+	return probeOnce(ctx, opener, path, timeout)
+}
+
+func probeOnce(ctx context.Context, opener Opener, path string, timeout time.Duration) ProbeResult {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	ctx = context.WithValue(ctx, utils.MaxPrefetchKey, 1)

--- a/internal/contentverify/probe_test.go
+++ b/internal/contentverify/probe_test.go
@@ -39,14 +39,18 @@ type fakeOpener struct {
 	file        *fakeFile
 	err         error
 	capturedCtx context.Context
+	calls       int
 }
 
 func (o *fakeOpener) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (afero.File, error) {
 	o.capturedCtx = ctx
+	o.calls++
 	if o.err != nil {
 		return nil, o.err
 	}
-	return o.file, nil
+	// Each attempt gets its own reader: a retried probe must not resume from
+	// the previous attempt's read offset.
+	return &fakeFile{data: o.file.data, readErr: o.file.readErr}, nil
 }
 
 func TestProbe_ValidSignature(t *testing.T) {
@@ -99,6 +103,39 @@ func TestProbe_OpenFileError(t *testing.T) {
 	res := Probe(context.Background(), opener, "movie.mkv", time.Second)
 	if res.Result != ContentProbeError {
 		t.Errorf("got %s, want %s", res.Result, ContentProbeError)
+	}
+}
+
+func TestProbe_TransientErrorIsRetriedOnce(t *testing.T) {
+	opener := &fakeOpener{file: &fakeFile{readErr: errors.New("connection reset by peer")}}
+	res := Probe(context.Background(), opener, "movie.mkv", time.Second)
+	if res.Result != ContentProbeError {
+		t.Fatalf("got %s, want %s", res.Result, ContentProbeError)
+	}
+	if opener.calls != 2 {
+		t.Errorf("got %d probe attempts, want 2 (one retry on a transient error)", opener.calls)
+	}
+}
+
+func TestProbe_MissingSegmentIsNotRetried(t *testing.T) {
+	opener := &fakeOpener{file: &fakeFile{readErr: nntppool.ErrArticleNotFound}}
+	res := Probe(context.Background(), opener, "movie.mkv", time.Second)
+	if res.Result != ContentSegmentMissing {
+		t.Fatalf("got %s, want %s", res.Result, ContentSegmentMissing)
+	}
+	if opener.calls != 1 {
+		t.Errorf("got %d probe attempts, want 1 (a definitive result must not be retried)", opener.calls)
+	}
+}
+
+func TestProbe_InvalidSignatureIsNotRetried(t *testing.T) {
+	opener := &fakeOpener{file: &fakeFile{data: make([]byte, 512)}}
+	res := Probe(context.Background(), opener, "movie.mkv", time.Second)
+	if res.Result != ContentInvalid {
+		t.Fatalf("got %s, want %s", res.Result, ContentInvalid)
+	}
+	if opener.calls != 1 {
+		t.Errorf("got %d probe attempts, want 1 (a definitive result must not be retried)", opener.calls)
 	}
 }
 

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -357,7 +357,9 @@ func (hc *HealthChecker) shouldVerifyContent(prep preparedCheck) bool {
 // either verification is not eligible for this file (not a verifiable media
 // type), passed, or failed only transiently — in all three cases the caller
 // proceeds to the normal healthy branch, since a transient probe error must
-// never mark a file corrupted.
+// never mark a file corrupted. A transient failure is logged, because a
+// healthy record is deleted and would otherwise leave no trace that
+// verification never actually ran.
 func (hc *HealthChecker) judgeContentVerification(ctx context.Context, prep preparedCheck) *HealthEvent {
 	if !fileinfo.IsVerifiableMediaFile(prep.filePath) {
 		return nil
@@ -368,7 +370,12 @@ func (hc *HealthChecker) judgeContentVerification(ctx context.Context, prep prep
 
 	var errType, message string
 	switch result.Result {
-	case contentverify.ContentValid, contentverify.ContentProbeError:
+	case contentverify.ContentValid:
+		return nil
+	case contentverify.ContentProbeError:
+		slog.WarnContext(ctx, "Content verification could not complete",
+			"file_path", prep.filePath,
+			"error", result.Err)
 		return nil
 	case contentverify.ContentInvalid:
 		errType = "content_invalid"

--- a/internal/health/content_verify_test.go
+++ b/internal/health/content_verify_test.go
@@ -91,6 +91,15 @@ func TestJudgeValidation_ContentProbeErrorLeavesStatusUnchanged(t *testing.T) {
 	}
 }
 
+func TestJudgeContentVerification_ProbeErrorReturnsNoEvent(t *testing.T) {
+	hc := newTestHealthCheckerWithVerifyContentEnabled(&fakeContentOpener{err: errors.New("connection reset")})
+	prep := preparedCheck{filePath: "/movie.mkv", currentStatus: database.HealthStatusPending}
+
+	if event := hc.judgeContentVerification(context.Background(), prep); event != nil {
+		t.Errorf("a transient probe error must produce no event, got %+v", *event)
+	}
+}
+
 func TestJudgeValidation_SkipsProbeWhenNotPending(t *testing.T) {
 	hc := newTestHealthCheckerWithVerifyContentEnabled(&fakeContentOpener{data: make([]byte, 512)}) // would fail if probed
 	prep := preparedCheck{filePath: "/movie.mkv", currentStatus: database.HealthStatusDegraded}

--- a/internal/importer/content_verify_test.go
+++ b/internal/importer/content_verify_test.go
@@ -92,18 +92,36 @@ func TestVerifyWrittenContent_SkipsNonMediaFiles(t *testing.T) {
 	}
 }
 
-func TestVerifyWrittenContent_TransientErrorFailsAsRetryable(t *testing.T) {
+func TestVerifyWrittenContent_TransientErrorIsInconclusive(t *testing.T) {
 	enabled := true
 	s := &Service{
-		configGetter: func() *config.Config { return &config.Config{Import: config.ImportConfig{VerifyContent: &enabled}} },
+		configGetter:    func() *config.Config { return &config.Config{Import: config.ImportConfig{VerifyContent: &enabled}} },
 		contentVerifyFS: &fakeContentOpener{data: nil}, // Read returns os.ErrClosed immediately (transient, not a recognized-missing sentinel)
 	}
 	_ = time.Second // keep import used if timeout const changes
 	err := s.verifyWrittenContent(context.Background(), []string{"movie.mkv"})
 	if err == nil {
-		t.Fatal("expected a transient probe error to still return a non-nil error (routed through the existing retry path)")
+		t.Fatal("expected a transient probe error to still return a non-nil error")
+	}
+	if !errors.Is(err, ErrContentProbeInconclusive) {
+		t.Errorf("expected ErrContentProbeInconclusive, got %v", err)
 	}
 	if !errors.Is(err, os.ErrClosed) {
 		t.Errorf("expected wrapped os.ErrClosed, got %v", err)
+	}
+}
+
+func TestVerifyWrittenContent_DefinitiveFailuresAreNotInconclusive(t *testing.T) {
+	enabled := true
+	s := &Service{
+		configGetter:    func() *config.Config { return &config.Config{Import: config.ImportConfig{VerifyContent: &enabled}} },
+		contentVerifyFS: &fakeContentOpener{data: make([]byte, 512)}, // no recognized signature
+	}
+	err := s.verifyWrittenContent(context.Background(), []string{"movie.mkv"})
+	if err == nil {
+		t.Fatal("expected an error when content verification fails")
+	}
+	if errors.Is(err, ErrContentProbeInconclusive) {
+		t.Errorf("a definitive content failure must stay definitive, got %v", err)
 	}
 }

--- a/internal/importer/errors.go
+++ b/internal/importer/errors.go
@@ -2,8 +2,16 @@
 package importer
 
 import (
+	"errors"
+
 	sharedErrors "github.com/javi11/altmount/internal/errors"
 )
+
+// ErrContentProbeInconclusive means the media content probe could not reach a
+// verdict because of a transient provider, timeout, or connection error.
+// Nothing is known about the written content, so the release must not be
+// reported to the Arr app or counted towards its blocklist breaker.
+var ErrContentProbeInconclusive = errors.New("content verification inconclusive")
 
 // Re-export error types and functions from shared errors package
 // for backward compatibility with existing code.

--- a/internal/importer/handle_failure_test.go
+++ b/internal/importer/handle_failure_test.go
@@ -3,6 +3,7 @@ package importer
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -176,6 +177,30 @@ func TestHandleFailure_FastFailInconclusiveSkipsDefinitiveFailureHandling(t *tes
 	require.NotNil(t, dbItem.ErrorMessage)
 	assert.Contains(t, *dbItem.ErrorMessage, validation.ErrFastFailInconclusive.Error())
 	assert.FileExists(t, item.NzbPath, "inconclusive validation must retain the NZB for manual retry")
+}
+
+func TestHandleFailure_ContentProbeInconclusiveSkipsDefinitiveFailureHandling(t *testing.T) {
+	svc := newMoveToFailedTestService(t)
+	ctx := context.Background()
+	item := &database.ImportQueueItem{
+		NzbPath: filepath.Join(t.TempDir(), "probe-inconclusive.nzb"),
+		Status:  database.QueueStatusPending,
+	}
+	require.NoError(t, os.WriteFile(item.NzbPath, []byte("<nzb/>"), 0644))
+	require.NoError(t, svc.database.Repository.AddToQueue(ctx, item))
+
+	// postProcessor is deliberately nil: HandleFailure/NoteImportFailure and the
+	// ARR notification would panic here, so reaching them fails this test.
+	svc.HandleFailure(ctx, item, fmt.Errorf("content verification could not complete for %q: %w: %w",
+		"movie.mkv", ErrContentProbeInconclusive, errors.New("connection reset")))
+
+	dbItem, err := svc.database.Repository.GetQueueItem(ctx, item.ID)
+	require.NoError(t, err)
+	require.NotNil(t, dbItem)
+	assert.Equal(t, database.QueueStatusFailed, dbItem.Status)
+	require.NotNil(t, dbItem.ErrorMessage)
+	assert.Contains(t, *dbItem.ErrorMessage, ErrContentProbeInconclusive.Error())
+	assert.FileExists(t, item.NzbPath, "an inconclusive content probe must retain the NZB for manual retry")
 }
 
 // TestCleanupFailedItems_RemovesNzbFile verifies that cleanupFailedItems deletes the

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -947,9 +947,8 @@ func (s *Service) processNzbItem(ctx context.Context, item *database.ImportQueue
 // confirmed-missing head article) is returned as an error so the caller
 // routes the item to HandleFailure exactly like any other import error,
 // letting the Arr app blocklist the release. A transient probe error is
-// likewise returned as an error — it flows through the same existing
-// retry/backoff path as any other transient import failure; no separate
-// mechanism is introduced.
+// wrapped with ErrContentProbeInconclusive instead, so handleProcessingFailure
+// retains the item for retry without reporting a bad release.
 func (s *Service) verifyWrittenContent(ctx context.Context, writtenPaths []string) error {
 	s.mu.Lock()
 	contentVerifyFS := s.contentVerifyFS
@@ -975,7 +974,7 @@ func (s *Service) verifyWrittenContent(ctx context.Context, writtenPaths []strin
 		case contentverify.ContentSegmentMissing:
 			return fmt.Errorf("content verification failed for %q: head article missing: %w", path, result.Err)
 		case contentverify.ContentProbeError:
-			return fmt.Errorf("content verification could not complete for %q: %w", path, result.Err)
+			return fmt.Errorf("content verification could not complete for %q: %w: %w", path, ErrContentProbeInconclusive, result.Err)
 		}
 	}
 	return nil
@@ -1549,13 +1548,14 @@ func (s *Service) handleProcessingFailure(ctx context.Context, item *database.Im
 	}
 
 	errorMessage := processingErr.Error()
-	if errors.Is(processingErr, validation.ErrFastFailInconclusive) {
-		// The provider never produced a conclusive answer within the validator's
-		// bounded retry budget. Keep this distinct from a bad release: do not log
-		// an indexer failure, notify/blocklist in ARR, invoke fallback, or move the
-		// NZB away. The retained failed item can be retried manually once the
-		// provider is healthy again.
-		s.log.WarnContext(ctx, "Import stopped because segment availability was inconclusive",
+	if errors.Is(processingErr, validation.ErrFastFailInconclusive) || errors.Is(processingErr, ErrContentProbeInconclusive) {
+		// The provider never produced a conclusive answer within the bounded
+		// retry budget of segment validation or of the content probe. Keep this
+		// distinct from a bad release: do not log an indexer failure,
+		// notify/blocklist in ARR, invoke fallback, or move the NZB away. The
+		// retained failed item can be retried manually once the provider is
+		// healthy again.
+		s.log.WarnContext(ctx, "Import stopped because verification was inconclusive",
 			"queue_id", item.ID,
 			"file", item.NzbPath,
 			"error", processingErr)


### PR DESCRIPTION
Follow-up to #860, which shipped most of #851. A `content_probe_error` — explicitly meant to be retried, not blocklisted — was treated exactly like a definitive failure: the item was marked permanently failed, an indexer failure was logged, and `HandleFailure` → `NoteImportFailure` notified the ARR and incremented the blocklist breaker. The comment claiming it "flows through the same existing retry/backoff path" was not backed by the code.

- new `ErrContentProbeInconclusive`, routed through the existing `ErrFastFailInconclusive` branch: no indexer log, no ARR notification, item stays retryable
- one cheap retry inside `Probe` on a transient error (cost is a single article)
- health now warns when verification cannot complete instead of silently reporting healthy
- the manual-recheck `verify_content` override — already supported end-to-end in the backend — is now reachable from the UI

The blocklist test leaves `postProcessor` nil, so reaching `HandleFailure` would panic; it passing is the proof the path is skipped.

**Stack 7/8** — base: `fix/corrupted-metadata-retention`

Addresses the remaining gaps from #851 (the bulk shipped in #860).