### PR TITLE
fix(arrs): coordinate repair searches with the ARR automatic redownload

### DIFF
--- a/docs/docs/3. Configuration/health-monitoring.md
+++ b/docs/docs/3. Configuration/health-monitoring.md
@@ -304,6 +304,8 @@ health:
     max_cooldown_hours: 24
     exponential_backoff: true
     max_repair_retries: 3
+    auto_search_wait_seconds: 120 # wait for the *arr's own automatic re-download search before deleting the file record; 0 = don't wait
+    file_delete_confirm_seconds: 15 # wait for the *arr to report the deleted file record as unlinked before searching; 0 = don't wait
 ```
 
 ---

--- a/docs/static/openapi.yaml
+++ b/docs/static/openapi.yaml
@@ -6134,10 +6134,30 @@ components:
       type: object
     config.RepairConfig:
       properties:
+        auto_search_wait_seconds:
+          description: >-
+            AutoSearchWaitSeconds bounds how long a repair waits for the ARR's
+            own
+
+            automatic redownload search — queued by the ARR the moment a release is
+
+            blocklisted — to finish before the file record is deleted and AltMount
+
+            issues its own targeted search. 0 disables the wait and restores the
+
+            previous fire-and-forget ordering.
+          type: integer
         enabled:
           type: boolean
         exponential_backoff:
           type: boolean
+        file_delete_confirm_seconds:
+          description: >-
+            FileDeleteConfirmSeconds bounds how long a repair waits for the ARR
+            to
+
+            report the deleted file record as unlinked before issuing its search.
+          type: integer
         interval_minutes:
           type: integer
         max_cooldown_hours:

--- a/docs/static/swagger.json
+++ b/docs/static/swagger.json
@@ -8716,11 +8716,19 @@
         "config.RepairConfig": {
             "type": "object",
             "properties": {
+                "auto_search_wait_seconds": {
+                    "description": "AutoSearchWaitSeconds bounds how long a repair waits for the ARR's own\nautomatic redownload search — queued by the ARR the moment a release is\nblocklisted — to finish before the file record is deleted and AltMount\nissues its own targeted search. 0 disables the wait and restores the\nprevious fire-and-forget ordering.",
+                    "type": "integer"
+                },
                 "enabled": {
                     "type": "boolean"
                 },
                 "exponential_backoff": {
                     "type": "boolean"
+                },
+                "file_delete_confirm_seconds": {
+                    "description": "FileDeleteConfirmSeconds bounds how long a repair waits for the ARR to\nreport the deleted file record as unlinked before issuing its search.",
+                    "type": "integer"
                 },
                 "interval_minutes": {
                     "type": "integer"

--- a/docs/static/swagger.yaml
+++ b/docs/static/swagger.yaml
@@ -2247,10 +2247,23 @@ definitions:
     type: object
   config.RepairConfig:
     properties:
+      auto_search_wait_seconds:
+        description: |-
+          AutoSearchWaitSeconds bounds how long a repair waits for the ARR's own
+          automatic redownload search — queued by the ARR the moment a release is
+          blocklisted — to finish before the file record is deleted and AltMount
+          issues its own targeted search. 0 disables the wait and restores the
+          previous fire-and-forget ordering.
+        type: integer
       enabled:
         type: boolean
       exponential_backoff:
         type: boolean
+      file_delete_confirm_seconds:
+        description: |-
+          FileDeleteConfirmSeconds bounds how long a repair waits for the ARR to
+          report the deleted file record as unlinked before issuing its search.
+        type: integer
       interval_minutes:
         type: integer
       max_cooldown_hours:

--- a/frontend/src/components/config/HealthConfigSection.tsx
+++ b/frontend/src/components/config/HealthConfigSection.tsx
@@ -308,6 +308,53 @@ export function HealthConfigSection({
 										Number of repair notification attempts before giving up.
 									</p>
 								</fieldset>
+
+								<fieldset className="fieldset">
+									<legend className="fieldset-legend font-semibold">
+										Auto Search Wait (Seconds)
+									</legend>
+									<input
+										type="number"
+										className="input input-bordered w-full bg-base-100 font-mono text-sm"
+										value={formData.repair?.auto_search_wait_seconds ?? 120}
+										disabled={isReadOnly}
+										onChange={(e) =>
+											handleRepairChange(
+												"auto_search_wait_seconds",
+												Number.parseInt(e.target.value, 10) || 0,
+											)
+										}
+										min="0"
+									/>
+									<p className="label break-words text-[10px] text-base-content/50">
+										How long to wait for the *arr's own automatic re-download search (queued as soon
+										as a release is blocklisted) before deleting the file record and searching. 0
+										disables the wait.
+									</p>
+								</fieldset>
+
+								<fieldset className="fieldset">
+									<legend className="fieldset-legend font-semibold">
+										File Delete Confirm (Seconds)
+									</legend>
+									<input
+										type="number"
+										className="input input-bordered w-full bg-base-100 font-mono text-sm"
+										value={formData.repair?.file_delete_confirm_seconds ?? 15}
+										disabled={isReadOnly}
+										onChange={(e) =>
+											handleRepairChange(
+												"file_delete_confirm_seconds",
+												Number.parseInt(e.target.value, 10) || 0,
+											)
+										}
+										min="0"
+									/>
+									<p className="label break-words text-[10px] text-base-content/50">
+										How long to wait for the *arr to report the deleted file record as unlinked
+										before issuing the replacement search. 0 disables the wait.
+									</p>
+								</fieldset>
 							</div>
 
 							<div className="mt-6 flex items-start justify-between gap-4 rounded-xl border border-base-300/60 bg-base-100/40 p-4">

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -165,6 +165,8 @@ export interface RepairConfig {
 	max_cooldown_hours: number;
 	max_repair_retries: number; // Max repair notification retries
 	exponential_backoff: boolean;
+	auto_search_wait_seconds: number; // Wait for the ARR's own redownload search before deleting the file record; 0 disables
+	file_delete_confirm_seconds: number; // Wait for the ARR to report the deleted file record as unlinked; 0 disables
 }
 
 // Dry run result for library sync

--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -764,22 +764,16 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 		"movie_path", targetMovie.Path,
 		"file_path", filePath)
 
+	failAt := time.Now()
+	blocklisted := false
+
 	// If we found the movie and have a file ID, try to blocklist and delete the file
 	if targetMovieFileID > 0 {
 		// Try to blocklist the release associated with this file
 		if err := m.blocklistRadarrMovieFile(ctx, client, targetMovie.ID, targetMovieFileID, relativePath, sceneName); err != nil {
 			slog.WarnContext(ctx, "Failed to blocklist Radarr release", "error", err)
 		}
-
-		// Delete the existing file from Radarr database
-		err = client.DeleteMovieFilesContext(ctx, targetMovieFileID)
-		if err != nil {
-			slog.WarnContext(ctx, "Failed to delete movie file from Radarr, continuing with search",
-				"instance", instanceName,
-				"movie_id", targetMovie.ID,
-				"file_id", targetMovieFileID,
-				"error", err)
-		}
+		blocklisted = true
 	} else {
 		slog.InfoContext(ctx, "Movie has no specific file ID linked in Radarr, attempting release blocklist using metadata",
 			"movie", targetMovie.Title)
@@ -787,7 +781,26 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 			if err := m.blocklistRadarrMovieFile(ctx, client, targetMovie.ID, 0, relativePath, sceneName); err != nil {
 				slog.WarnContext(ctx, "Failed to blocklist Radarr release using metadata fallback", "error", err)
 			}
+			blocklisted = true
 		}
+	}
+
+	var autoSearch *arrCommand
+	if blocklisted {
+		auto, state, settleErr := m.settleRadarrAutoRedownload(ctx, client, instanceName, radarrRedownloadTarget{
+			movieID:     targetMovie.ID,
+			movieFileID: targetMovieFileID,
+		}, failAt)
+		if settleErr != nil {
+			return settleErr
+		}
+		switch state {
+		case redownloadHandled:
+			return nil
+		case redownloadSatisfied:
+			return model.ErrEpisodeAlreadySatisfied
+		}
+		autoSearch = auto
 	}
 
 	// Failure breaker: every targeted re-search counts one failure-driven action
@@ -799,14 +812,9 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 	}
 
 	// Step 3: Trigger targeted search for the missing movie
-	searchCmd := &radarr.CommandRequest{
-		Name:     "MoviesSearch",
-		MovieIDs: []int64{targetMovie.ID},
-	}
-
-	response, err := client.SendCommandContext(ctx, searchCmd)
+	response, err := m.sendRadarrSearch(ctx, client, instanceName, targetMovie.ID, autoSearch)
 	if err != nil {
-		return fmt.Errorf("failed to trigger Radarr search for movie ID %d: %w", targetMovie.ID, err)
+		return err
 	}
 
 	slog.InfoContext(ctx, "Successfully triggered Radarr targeted search for re-download",
@@ -959,6 +967,7 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 	}
 
 	var episodeIDs []int64
+	var autoSearch *arrCommand
 
 	// Get all episodes for this specific series
 	episodes, err := client.GetSeriesEpisodesContext(ctx, &sonarr.GetEpisode{
@@ -1001,19 +1010,28 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 				"episode_count", len(episodeIDs),
 				"episode_file_id", targetEpisodeFileID)
 
+			failAt := time.Now()
+
 			// Try to blocklist the release associated with this file
 			if err := m.blocklistSonarrEpisodeFile(ctx, client, targetSeriesID, targetEpisodeFileID, relativePath, episodeIDs, sceneName); err != nil {
 				slog.WarnContext(ctx, "Failed to blocklist Sonarr release", "error", err)
 			}
 
-			// Delete the existing episode file from Sonarr database
-			err := client.DeleteEpisodeFileContext(ctx, targetEpisodeFileID)
+			auto, state, err := m.settleSonarrAutoRedownload(ctx, client, instanceName, sonarrRedownloadTarget{
+				seriesID:      targetSeriesID,
+				episodeIDs:    episodeIDs,
+				episodeFileID: targetEpisodeFileID,
+			}, failAt)
 			if err != nil {
-				slog.WarnContext(ctx, "Failed to delete episode file from Sonarr, continuing with search",
-					"instance", instanceName,
-					"episode_file_id", targetEpisodeFileID,
-					"error", err)
+				return err
 			}
+			switch state {
+			case redownloadHandled:
+				return nil
+			case redownloadSatisfied:
+				return model.ErrEpisodeAlreadySatisfied
+			}
+			autoSearch = auto
 		}
 	} else {
 		slog.WarnContext(ctx, "Series found but no matching episode file ID found, attempting queue-based failure",
@@ -1032,10 +1050,27 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 				episodeIDs = append(episodeIDs, ep.Id)
 			}
 
+			failAt := time.Now()
+
 			// Try to blocklist the release associated with these episodes
 			if err := m.blocklistSonarrEpisodeFile(ctx, client, targetSeriesID, 0, relativePath, episodeIDs, sceneName); err != nil {
 				slog.WarnContext(ctx, "Failed to blocklist Sonarr release using metadata fallback", "error", err)
 			}
+
+			auto, state, err := m.settleSonarrAutoRedownload(ctx, client, instanceName, sonarrRedownloadTarget{
+				seriesID:   targetSeriesID,
+				episodeIDs: episodeIDs,
+			}, failAt)
+			if err != nil {
+				return err
+			}
+			switch state {
+			case redownloadHandled:
+				return nil
+			case redownloadSatisfied:
+				return model.ErrEpisodeAlreadySatisfied
+			}
+			autoSearch = auto
 		}
 	}
 
@@ -1053,14 +1088,9 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 	}
 
 	// Trigger targeted episode search for the remaining episodes in this file
-	searchCmd := &sonarr.CommandRequest{
-		Name:       "EpisodeSearch",
-		EpisodeIDs: searchIDs,
-	}
-
-	response, err := client.SendCommandContext(ctx, searchCmd)
+	response, err := m.sendSonarrSearch(ctx, client, instanceName, searchIDs, autoSearch)
 	if err != nil {
-		return fmt.Errorf("failed to trigger Sonarr episode search: %w", err)
+		return err
 	}
 
 	slog.InfoContext(ctx, "Successfully triggered Sonarr targeted episode search for re-download",

--- a/internal/arrs/scanner/redownload.go
+++ b/internal/arrs/scanner/redownload.go
@@ -1,0 +1,778 @@
+package scanner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"golift.io/starr"
+	"golift.io/starr/radarr"
+	"golift.io/starr/sonarr"
+)
+
+const (
+	manualTrigger = "manual"
+	commandURI    = "v3/command"
+
+	autoSearchDetectWindow   = 5 * time.Second
+	autoSearchDetectInterval = 500 * time.Millisecond
+	commandPollInitial       = 500 * time.Millisecond
+	commandPollMax           = 5 * time.Second
+	fileClearPollInterval    = 300 * time.Millisecond
+)
+
+// arrCommand is the subset of a Sonarr/Radarr command record the repair
+// coordination needs, normalised across both apps.
+type arrCommand struct {
+	ID      int64
+	Name    string
+	Status  string
+	Trigger string
+	Queued  time.Time
+	Body    map[string]any
+}
+
+// arrCommandResponse mirrors the /api/v3/command payload. It is declared here
+// rather than reusing starr's per-app response types so one decoder serves both
+// Sonarr and Radarr.
+type arrCommandResponse struct {
+	ID      int64          `json:"id"`
+	Name    string         `json:"name"`
+	Status  string         `json:"status"`
+	Trigger string         `json:"trigger"`
+	Queued  time.Time      `json:"queued"`
+	Body    map[string]any `json:"body"`
+}
+
+func (r *arrCommandResponse) command() *arrCommand {
+	if r == nil {
+		return nil
+	}
+	return &arrCommand{ID: r.ID, Name: r.Name, Status: r.Status, Trigger: r.Trigger, Queued: r.Queued, Body: r.Body}
+}
+
+// sonarrSearchBody and radarrSearchBody carry the manual trigger that starr's
+// CommandRequest types cannot express.
+type sonarrSearchBody struct {
+	Name       string  `json:"name"`
+	EpisodeIDs []int64 `json:"episodeIds,omitempty"`
+	Trigger    string  `json:"trigger"`
+}
+
+type radarrSearchBody struct {
+	Name     string  `json:"name"`
+	MovieIDs []int64 `json:"movieIds,omitempty"`
+	Trigger  string  `json:"trigger"`
+}
+
+var terminalCommandStatuses = map[string]struct{}{
+	"completed": {},
+	"failed":    {},
+	"aborted":   {},
+	"cancelled": {},
+	"orphaned":  {},
+}
+
+func commandIsTerminal(cmd *arrCommand) bool {
+	if cmd == nil {
+		return false
+	}
+	_, ok := terminalCommandStatuses[strings.ToLower(cmd.Status)]
+	return ok
+}
+
+// commandGetter fetches one command by id. Sonarr and Radarr differ only in how
+// the request is issued, so every wait helper takes this closure.
+type commandGetter func(context.Context, int64) (*arrCommand, error)
+
+func sonarrCommandByID(ctx context.Context, client *sonarr.Sonarr, id int64) (*arrCommand, error) {
+	resp, err := client.GetCommandStatusContext(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Sonarr command %d: %w", id, err)
+	}
+	return (&arrCommandResponse{
+		ID:      resp.ID,
+		Name:    resp.Name,
+		Status:  resp.Status,
+		Trigger: resp.Trigger,
+		Queued:  resp.Queued,
+		Body:    resp.Body,
+	}).command(), nil
+}
+
+// radarrCommandByID issues a raw GET because starr's Radarr client exposes no
+// single-command status endpoint.
+func radarrCommandByID(ctx context.Context, client *radarr.Radarr, id int64) (*arrCommand, error) {
+	var out arrCommandResponse
+	req := starr.Request{URI: commandURI + "/" + strconv.FormatInt(id, 10)}
+	if err := client.GetInto(ctx, req, &out); err != nil {
+		return nil, fmt.Errorf("failed to read Radarr command %d: %w", id, err)
+	}
+	return out.command(), nil
+}
+
+func sonarrCommands(ctx context.Context, client *sonarr.Sonarr) ([]*arrCommand, error) {
+	list, err := client.GetCommandsContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Sonarr commands: %w", err)
+	}
+	out := make([]*arrCommand, 0, len(list))
+	for _, c := range list {
+		if c == nil {
+			continue
+		}
+		out = append(out, (&arrCommandResponse{
+			ID:      c.ID,
+			Name:    c.Name,
+			Status:  c.Status,
+			Trigger: c.Trigger,
+			Queued:  c.Queued,
+			Body:    c.Body,
+		}).command())
+	}
+	return out, nil
+}
+
+func radarrCommands(ctx context.Context, client *radarr.Radarr) ([]*arrCommand, error) {
+	list, err := client.GetCommandsContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Radarr commands: %w", err)
+	}
+	out := make([]*arrCommand, 0, len(list))
+	for _, c := range list {
+		if c == nil {
+			continue
+		}
+		out = append(out, (&arrCommandResponse{
+			ID:      c.ID,
+			Name:    c.Name,
+			Status:  c.Status,
+			Trigger: c.Trigger,
+			Queued:  c.Queued,
+			Body:    c.Body,
+		}).command())
+	}
+	return out, nil
+}
+
+// bodyInt64Set collects the integer ids stored under key in a command body.
+// Command bodies arrive as map[string]any, so every number is a float64.
+func bodyInt64Set(body map[string]any, key string) map[int64]struct{} {
+	out := make(map[int64]struct{})
+	raw, ok := body[key]
+	if !ok {
+		return out
+	}
+	add := func(v any) {
+		switch n := v.(type) {
+		case float64:
+			out[int64(n)] = struct{}{}
+		case float32:
+			out[int64(n)] = struct{}{}
+		case int:
+			out[int64(n)] = struct{}{}
+		case int64:
+			out[n] = struct{}{}
+		case json.Number:
+			if parsed, err := n.Int64(); err == nil {
+				out[parsed] = struct{}{}
+			}
+		case string:
+			if parsed, err := strconv.ParseInt(n, 10, 64); err == nil {
+				out[parsed] = struct{}{}
+			}
+		}
+	}
+	if list, ok := raw.([]any); ok {
+		for _, v := range list {
+			add(v)
+		}
+		return out
+	}
+	add(raw)
+	return out
+}
+
+// findAutoRedownloadCommand picks out the search the ARR queued for itself right
+// after a release was blocklisted. targets maps a command-body key to the ids a
+// matching command must reference, so a Sonarr caller can match both the
+// per-episode EpisodeSearch and the whole-season SeasonSearch without confusing
+// series ids for episode ids.
+func findAutoRedownloadCommand(list []*arrCommand, names []string, targets map[string][]int64, since time.Time) *arrCommand {
+	for _, cmd := range list {
+		if cmd == nil || !containsFold(names, cmd.Name) {
+			continue
+		}
+		status := strings.ToLower(cmd.Status)
+		if status != "queued" && status != "started" {
+			continue
+		}
+		if !cmd.Queued.IsZero() && cmd.Queued.Before(since) {
+			continue
+		}
+		for key, ids := range targets {
+			found := bodyInt64Set(cmd.Body, key)
+			for _, id := range ids {
+				if _, ok := found[id]; ok {
+					return cmd
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func containsFold(values []string, want string) bool {
+	for _, v := range values {
+		if strings.EqualFold(v, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// waitCommandTerminal polls a command until it reaches a terminal status. A
+// budget expiry is not an error: the caller degrades to the unsynchronised
+// ordering rather than abandoning the repair.
+func waitCommandTerminal(ctx context.Context, get commandGetter, id int64, budget time.Duration) (*arrCommand, error) {
+	deadline := time.Now().Add(budget)
+	delay := commandPollInitial
+
+	var last *arrCommand
+	var lastErr error
+
+	for {
+		cmd, err := get(ctx, id)
+		if err != nil {
+			lastErr = err
+		} else {
+			last = cmd
+			lastErr = nil
+			if commandIsTerminal(cmd) {
+				return cmd, nil
+			}
+		}
+
+		if time.Now().After(deadline) {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return last, ctx.Err()
+		case <-time.After(delay):
+		}
+
+		if delay < commandPollMax {
+			delay *= 2
+			if delay > commandPollMax {
+				delay = commandPollMax
+			}
+		}
+	}
+
+	if last == nil && lastErr != nil {
+		return nil, lastErr
+	}
+	slog.WarnContext(ctx, "ARR automatic redownload search did not finish within the configured budget, proceeding anyway",
+		"command_id", id, "budget", budget, "status", commandStatus(last))
+	return last, nil
+}
+
+func commandStatus(cmd *arrCommand) string {
+	if cmd == nil {
+		return "unknown"
+	}
+	return cmd.Status
+}
+
+// waitEpisodeFileCleared polls until no target episode still points at a file
+// record, so the search that follows cannot race the deletion.
+func waitEpisodeFileCleared(ctx context.Context, client *sonarr.Sonarr, episodeIDs []int64, budget time.Duration) bool {
+	if len(episodeIDs) == 0 || budget <= 0 {
+		return false
+	}
+	deadline := time.Now().Add(budget)
+	for {
+		episodes, err := client.GetSeriesEpisodesContext(ctx, &sonarr.GetEpisode{EpisodeIDs: episodeIDs})
+		if err == nil {
+			cleared := true
+			for _, ep := range episodes {
+				if ep != nil && ep.EpisodeFileID != 0 {
+					cleared = false
+					break
+				}
+			}
+			if cleared {
+				return true
+			}
+		}
+
+		if time.Now().After(deadline) {
+			slog.WarnContext(ctx, "Sonarr still reports an episode file after deletion, proceeding with the search anyway",
+				"episode_ids", episodeIDs, "budget", budget)
+			return false
+		}
+
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(fileClearPollInterval):
+		}
+	}
+}
+
+// waitMovieFileCleared is the Radarr twin of waitEpisodeFileCleared.
+func waitMovieFileCleared(ctx context.Context, client *radarr.Radarr, movieID int64, budget time.Duration) bool {
+	if movieID == 0 || budget <= 0 {
+		return false
+	}
+	deadline := time.Now().Add(budget)
+	for {
+		movie, err := client.GetMovieByIDContext(ctx, movieID)
+		if err == nil && movieFileID(movie) == 0 {
+			return true
+		}
+
+		if time.Now().After(deadline) {
+			slog.WarnContext(ctx, "Radarr still reports a movie file after deletion, proceeding with the search anyway",
+				"movie_id", movieID, "budget", budget)
+			return false
+		}
+
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(fileClearPollInterval):
+		}
+	}
+}
+
+func movieFileID(movie *radarr.Movie) int64 {
+	if movie == nil || movie.MovieFile == nil {
+		return 0
+	}
+	return movie.MovieFile.ID
+}
+
+// sendSearchCommandWithTrigger posts a search command carrying an explicit
+// manual trigger, which starr's CommandRequest types cannot express. The manual
+// trigger is what makes the ARR treat the search as user-invoked and bypass the
+// release delay profile.
+func sendSearchCommandWithTrigger(ctx context.Context, api starr.APIer, body any) (*arrCommand, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode search command: %w", err)
+	}
+
+	var out arrCommandResponse
+	req := starr.Request{URI: commandURI, Body: bytes.NewReader(payload)}
+	if err := api.PostInto(ctx, req, &out); err != nil {
+		return nil, fmt.Errorf("failed to send search command: %w", err)
+	}
+	return out.command(), nil
+}
+
+// commandWasDeduplicated reports whether the ARR handed back a pre-existing
+// command instead of queueing ours. Its command queue compares only the command
+// payload — the trigger is not part of that comparison — so a search issued
+// while the ARR's own automatic search is still queued silently collapses into
+// it. A response trigger other than manual, or an id matching the automatic
+// search, is therefore proof that our search was never queued.
+func commandWasDeduplicated(resp, auto *arrCommand) bool {
+	if resp == nil {
+		return false
+	}
+	if resp.Trigger != "" && !strings.EqualFold(resp.Trigger, manualTrigger) {
+		return true
+	}
+	return auto != nil && resp.ID == auto.ID
+}
+
+type redownloadState int
+
+const (
+	// redownloadProceed: delete confirmed (or not needed); issue the search.
+	redownloadProceed redownloadState = iota
+	// redownloadHandled: the ARR already grabbed a replacement.
+	redownloadHandled
+	// redownloadSatisfied: a different file is already linked to the target.
+	redownloadSatisfied
+)
+
+func (m *Manager) autoSearchWaitBudget() time.Duration {
+	return m.configGetter().GetRepairAutoSearchWait()
+}
+
+func (m *Manager) fileDeleteConfirmBudget() time.Duration {
+	return m.configGetter().GetRepairFileDeleteConfirm()
+}
+
+type sonarrRedownloadTarget struct {
+	seriesID      int64
+	episodeIDs    []int64
+	episodeFileID int64
+}
+
+// settleSonarrAutoRedownload runs between blocklisting a release and searching
+// for its replacement.
+//
+// Blocklisting makes Sonarr queue an automatic redownload search of its own.
+// Deleting the episode file while that search is running leaves each candidate
+// evaluation holding an episode whose EpisodeFileId is still set but whose lazy
+// EpisodeFile reference no longer resolves, which the delay specification
+// dereferences unconditionally — every candidate is then rejected and the search
+// reports nothing downloaded. Letting the automatic search finish first closes
+// that window.
+func (m *Manager) settleSonarrAutoRedownload(
+	ctx context.Context,
+	client *sonarr.Sonarr,
+	instanceName string,
+	target sonarrRedownloadTarget,
+	failAt time.Time,
+) (*arrCommand, redownloadState, error) {
+	budget := m.autoSearchWaitBudget()
+	if budget <= 0 {
+		m.deleteSonarrEpisodeFile(ctx, client, instanceName, target.episodeFileID)
+		return nil, redownloadProceed, nil
+	}
+
+	baseline := snapshotEpisodeFileIDs(ctx, client, target.episodeIDs)
+
+	auto := m.detectSonarrAutoSearch(ctx, client, target, failAt)
+	if auto != nil {
+		slog.InfoContext(ctx, "Sonarr queued its own redownload search after the blocklist, waiting for it to finish",
+			"instance", instanceName, "command_id", auto.ID, "command", auto.Name, "trigger", auto.Trigger)
+		if _, err := waitCommandTerminal(ctx, sonarrCommandGetter(client), auto.ID, budget); err != nil {
+			return nil, redownloadProceed, err
+		}
+	}
+
+	if queue, err := client.GetQueueContext(ctx, 0, 500); err != nil {
+		slog.WarnContext(ctx, "Failed to read Sonarr queue while checking for an automatic replacement",
+			"instance", instanceName, "error", err)
+	} else if queueHasEpisode(queue, target.episodeIDs) {
+		slog.InfoContext(ctx, "Sonarr's automatic redownload already grabbed a replacement, skipping delete and search",
+			"instance", instanceName, "episode_ids", target.episodeIDs)
+		return nil, redownloadHandled, nil
+	}
+
+	episodes, err := client.GetSeriesEpisodesContext(ctx, &sonarr.GetEpisode{EpisodeIDs: target.episodeIDs})
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to re-read Sonarr episodes after the automatic redownload search",
+			"instance", instanceName, "error", err)
+	} else {
+		if anyEpisodeFileReplaced(episodes, baseline) {
+			slog.InfoContext(ctx, "Sonarr's automatic redownload already imported a replacement file, skipping repair",
+				"instance", instanceName, "episode_ids", target.episodeIDs)
+			return nil, redownloadSatisfied, nil
+		}
+		if target.episodeFileID > 0 && !anyEpisodeLinkedTo(episodes, target.episodeFileID) {
+			return auto, redownloadProceed, nil
+		}
+	}
+
+	if target.episodeFileID > 0 {
+		m.deleteSonarrEpisodeFile(ctx, client, instanceName, target.episodeFileID)
+		waitEpisodeFileCleared(ctx, client, target.episodeIDs, m.fileDeleteConfirmBudget())
+	}
+
+	return auto, redownloadProceed, nil
+}
+
+func (m *Manager) detectSonarrAutoSearch(
+	ctx context.Context,
+	client *sonarr.Sonarr,
+	target sonarrRedownloadTarget,
+	failAt time.Time,
+) *arrCommand {
+	targets := map[string][]int64{"episodeIds": target.episodeIDs}
+	if target.seriesID > 0 {
+		targets["seriesId"] = []int64{target.seriesID}
+	}
+
+	deadline := time.Now().Add(autoSearchDetectWindow)
+	for {
+		list, err := sonarrCommands(ctx, client)
+		if err != nil {
+			slog.DebugContext(ctx, "Failed to list Sonarr commands while detecting the automatic redownload search", "error", err)
+		} else if cmd := findAutoRedownloadCommand(list, []string{"EpisodeSearch", "SeasonSearch"}, targets, failAt); cmd != nil {
+			return cmd
+		}
+
+		if time.Now().After(deadline) {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(autoSearchDetectInterval):
+		}
+	}
+}
+
+func (m *Manager) deleteSonarrEpisodeFile(ctx context.Context, client *sonarr.Sonarr, instanceName string, episodeFileID int64) {
+	if episodeFileID <= 0 {
+		return
+	}
+	if err := client.DeleteEpisodeFileContext(ctx, episodeFileID); err != nil {
+		slog.WarnContext(ctx, "Failed to delete episode file from Sonarr, continuing with search",
+			"instance", instanceName, "episode_file_id", episodeFileID, "error", err)
+	}
+}
+
+// sendSonarrSearch issues the targeted replacement search and retries once if
+// Sonarr collapsed it into an existing command.
+func (m *Manager) sendSonarrSearch(ctx context.Context, client *sonarr.Sonarr, instanceName string, searchIDs []int64, auto *arrCommand) (*arrCommand, error) {
+	body := sonarrSearchBody{Name: "EpisodeSearch", EpisodeIDs: searchIDs, Trigger: manualTrigger}
+
+	resp, err := sendSearchCommandWithTrigger(ctx, client, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to trigger Sonarr episode search: %w", err)
+	}
+
+	budget := m.autoSearchWaitBudget()
+	if budget <= 0 || !commandWasDeduplicated(resp, auto) {
+		return resp, nil
+	}
+
+	slog.InfoContext(ctx, "Sonarr merged the repair search into a running command, retrying once it finishes",
+		"instance", instanceName, "command_id", resp.ID, "trigger", resp.Trigger)
+	if _, err := waitCommandTerminal(ctx, sonarrCommandGetter(client), resp.ID, budget); err != nil {
+		return nil, err
+	}
+
+	resp, err = sendSearchCommandWithTrigger(ctx, client, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to re-trigger Sonarr episode search: %w", err)
+	}
+	return resp, nil
+}
+
+func sonarrCommandGetter(client *sonarr.Sonarr) commandGetter {
+	return func(ctx context.Context, id int64) (*arrCommand, error) {
+		return sonarrCommandByID(ctx, client, id)
+	}
+}
+
+func snapshotEpisodeFileIDs(ctx context.Context, client *sonarr.Sonarr, episodeIDs []int64) map[int64]int64 {
+	out := make(map[int64]int64, len(episodeIDs))
+	if len(episodeIDs) == 0 {
+		return out
+	}
+	episodes, err := client.GetSeriesEpisodesContext(ctx, &sonarr.GetEpisode{EpisodeIDs: episodeIDs})
+	if err != nil {
+		return out
+	}
+	for _, ep := range episodes {
+		if ep != nil {
+			out[ep.ID] = ep.EpisodeFileID
+		}
+	}
+	return out
+}
+
+func anyEpisodeFileReplaced(episodes []*sonarr.Episode, baseline map[int64]int64) bool {
+	for _, ep := range episodes {
+		if ep == nil || ep.EpisodeFileID == 0 {
+			continue
+		}
+		if before, ok := baseline[ep.ID]; !ok || before != ep.EpisodeFileID {
+			return true
+		}
+	}
+	return false
+}
+
+func anyEpisodeLinkedTo(episodes []*sonarr.Episode, episodeFileID int64) bool {
+	for _, ep := range episodes {
+		if ep != nil && ep.EpisodeFileID == episodeFileID {
+			return true
+		}
+	}
+	return false
+}
+
+func queueHasEpisode(queue *sonarr.Queue, episodeIDs []int64) bool {
+	if queue == nil {
+		return false
+	}
+	wanted := make(map[int64]struct{}, len(episodeIDs))
+	for _, id := range episodeIDs {
+		wanted[id] = struct{}{}
+	}
+	for _, record := range queue.Records {
+		if record == nil {
+			continue
+		}
+		if _, ok := wanted[record.EpisodeID]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+type radarrRedownloadTarget struct {
+	movieID     int64
+	movieFileID int64
+}
+
+// settleRadarrAutoRedownload mirrors settleSonarrAutoRedownload. Radarr's delay
+// specification guards the lazy file reference so it does not throw, but its
+// automatic post-blocklist search is still delay-gated and still absorbs the
+// repair search through command deduplication.
+func (m *Manager) settleRadarrAutoRedownload(
+	ctx context.Context,
+	client *radarr.Radarr,
+	instanceName string,
+	target radarrRedownloadTarget,
+	failAt time.Time,
+) (*arrCommand, redownloadState, error) {
+	budget := m.autoSearchWaitBudget()
+	if budget <= 0 {
+		m.deleteRadarrMovieFile(ctx, client, instanceName, target)
+		return nil, redownloadProceed, nil
+	}
+
+	baseline := snapshotMovieFileID(ctx, client, target.movieID)
+
+	auto := m.detectRadarrAutoSearch(ctx, client, target, failAt)
+	if auto != nil {
+		slog.InfoContext(ctx, "Radarr queued its own redownload search after the blocklist, waiting for it to finish",
+			"instance", instanceName, "command_id", auto.ID, "command", auto.Name, "trigger", auto.Trigger)
+		if _, err := waitCommandTerminal(ctx, radarrCommandGetter(client), auto.ID, budget); err != nil {
+			return nil, redownloadProceed, err
+		}
+	}
+
+	if queue, err := client.GetQueueContext(ctx, 0, 500); err != nil {
+		slog.WarnContext(ctx, "Failed to read Radarr queue while checking for an automatic replacement",
+			"instance", instanceName, "error", err)
+	} else if queueHasMovie(queue, target.movieID) {
+		slog.InfoContext(ctx, "Radarr's automatic redownload already grabbed a replacement, skipping delete and search",
+			"instance", instanceName, "movie_id", target.movieID)
+		return nil, redownloadHandled, nil
+	}
+
+	movie, err := client.GetMovieByIDContext(ctx, target.movieID)
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to re-read the Radarr movie after the automatic redownload search",
+			"instance", instanceName, "movie_id", target.movieID, "error", err)
+	} else {
+		current := movieFileID(movie)
+		if current != 0 && current != baseline {
+			slog.InfoContext(ctx, "Radarr's automatic redownload already imported a replacement file, skipping repair",
+				"instance", instanceName, "movie_id", target.movieID, "movie_file_id", current)
+			return nil, redownloadSatisfied, nil
+		}
+		if target.movieFileID > 0 && current != target.movieFileID {
+			return auto, redownloadProceed, nil
+		}
+	}
+
+	if target.movieFileID > 0 {
+		m.deleteRadarrMovieFile(ctx, client, instanceName, target)
+		waitMovieFileCleared(ctx, client, target.movieID, m.fileDeleteConfirmBudget())
+	}
+
+	return auto, redownloadProceed, nil
+}
+
+func (m *Manager) detectRadarrAutoSearch(
+	ctx context.Context,
+	client *radarr.Radarr,
+	target radarrRedownloadTarget,
+	failAt time.Time,
+) *arrCommand {
+	targets := map[string][]int64{"movieIds": {target.movieID}}
+
+	deadline := time.Now().Add(autoSearchDetectWindow)
+	for {
+		list, err := radarrCommands(ctx, client)
+		if err != nil {
+			slog.DebugContext(ctx, "Failed to list Radarr commands while detecting the automatic redownload search", "error", err)
+		} else if cmd := findAutoRedownloadCommand(list, []string{"MoviesSearch"}, targets, failAt); cmd != nil {
+			return cmd
+		}
+
+		if time.Now().After(deadline) {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(autoSearchDetectInterval):
+		}
+	}
+}
+
+func (m *Manager) deleteRadarrMovieFile(ctx context.Context, client *radarr.Radarr, instanceName string, target radarrRedownloadTarget) {
+	if target.movieFileID <= 0 {
+		return
+	}
+	if err := client.DeleteMovieFilesContext(ctx, target.movieFileID); err != nil {
+		slog.WarnContext(ctx, "Failed to delete movie file from Radarr, continuing with search",
+			"instance", instanceName, "movie_id", target.movieID, "file_id", target.movieFileID, "error", err)
+	}
+}
+
+// sendRadarrSearch issues the targeted replacement search and retries once if
+// Radarr collapsed it into an existing command.
+func (m *Manager) sendRadarrSearch(ctx context.Context, client *radarr.Radarr, instanceName string, movieID int64, auto *arrCommand) (*arrCommand, error) {
+	body := radarrSearchBody{Name: "MoviesSearch", MovieIDs: []int64{movieID}, Trigger: manualTrigger}
+
+	resp, err := sendSearchCommandWithTrigger(ctx, client, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to trigger Radarr search for movie ID %d: %w", movieID, err)
+	}
+
+	budget := m.autoSearchWaitBudget()
+	if budget <= 0 || !commandWasDeduplicated(resp, auto) {
+		return resp, nil
+	}
+
+	slog.InfoContext(ctx, "Radarr merged the repair search into a running command, retrying once it finishes",
+		"instance", instanceName, "command_id", resp.ID, "trigger", resp.Trigger)
+	if _, err := waitCommandTerminal(ctx, radarrCommandGetter(client), resp.ID, budget); err != nil {
+		return nil, err
+	}
+
+	resp, err = sendSearchCommandWithTrigger(ctx, client, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to re-trigger Radarr search for movie ID %d: %w", movieID, err)
+	}
+	return resp, nil
+}
+
+func radarrCommandGetter(client *radarr.Radarr) commandGetter {
+	return func(ctx context.Context, id int64) (*arrCommand, error) {
+		return radarrCommandByID(ctx, client, id)
+	}
+}
+
+func snapshotMovieFileID(ctx context.Context, client *radarr.Radarr, movieID int64) int64 {
+	movie, err := client.GetMovieByIDContext(ctx, movieID)
+	if err != nil {
+		return 0
+	}
+	return movieFileID(movie)
+}
+
+func queueHasMovie(queue *radarr.Queue, movieID int64) bool {
+	if queue == nil {
+		return false
+	}
+	for _, record := range queue.Records {
+		if record != nil && record.MovieID == movieID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/arrs/scanner/redownload_test.go
+++ b/internal/arrs/scanner/redownload_test.go
@@ -1,0 +1,617 @@
+package scanner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+	"golift.io/starr"
+	"golift.io/starr/radarr"
+	"golift.io/starr/sonarr"
+)
+
+func testManager(autoSearchWaitSeconds, fileDeleteConfirmSeconds int) *Manager {
+	cfg := &config.Config{}
+	cfg.Health.Repair.AutoSearchWaitSeconds = autoSearchWaitSeconds
+	cfg.Health.Repair.FileDeleteConfirmSeconds = fileDeleteConfirmSeconds
+	return NewManager(func() *config.Config { return cfg }, nil, nil, nil, nil, nil)
+}
+
+// arrStub is a minimal Sonarr/Radarr API double: it serves the command,
+// episode, movie, queue and file-delete endpoints the repair coordination
+// touches and records the order in which they were hit.
+type arrStub struct {
+	mu sync.Mutex
+
+	events       []string
+	postedSonarr []sonarrSearchBody
+	postedRadarr []radarrSearchBody
+	commandLists int
+	deletes      int
+
+	commands    []arrCommandResponse
+	statuses    map[int64][]string
+	postReplies []arrCommandResponse
+
+	episodeFileID int64
+	clearOnDelete bool
+
+	queueEpisodeIDs []int64
+	queueMovieIDs   []int64
+
+	movieFileID int64
+}
+
+func newArrStub() *arrStub {
+	return &arrStub{statuses: map[int64][]string{}, clearOnDelete: true}
+}
+
+func (s *arrStub) record(event string) {
+	s.events = append(s.events, event)
+}
+
+func (s *arrStub) snapshotEvents() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.events...)
+}
+
+// nextStatus pops the scripted status for a command, repeating the last one
+// once the script is exhausted.
+func (s *arrStub) nextStatus(id int64) string {
+	script := s.statuses[id]
+	if len(script) == 0 {
+		return "completed"
+	}
+	status := script[0]
+	if len(script) > 1 {
+		s.statuses[id] = script[1:]
+	}
+	return status
+}
+
+func (s *arrStub) serve() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		path := r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case path == "/api/v3/command" && r.Method == http.MethodGet:
+			s.commandLists++
+			s.record("commands")
+			_ = json.NewEncoder(w).Encode(s.commands)
+
+		case path == "/api/v3/command" && r.Method == http.MethodPost:
+			s.record("post")
+			var raw map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&raw)
+			if _, ok := raw["episodeIds"]; ok {
+				var body sonarrSearchBody
+				remarshal(raw, &body)
+				s.postedSonarr = append(s.postedSonarr, body)
+			} else {
+				var body radarrSearchBody
+				remarshal(raw, &body)
+				s.postedRadarr = append(s.postedRadarr, body)
+			}
+			reply := arrCommandResponse{ID: 99, Name: fmt.Sprint(raw["name"]), Status: "queued", Trigger: manualTrigger}
+			if len(s.postReplies) > 0 {
+				reply = s.postReplies[0]
+				if len(s.postReplies) > 1 {
+					s.postReplies = s.postReplies[1:]
+				}
+			}
+			_ = json.NewEncoder(w).Encode(reply)
+
+		case strings.HasPrefix(path, "/api/v3/command/"):
+			id := int64(0)
+			_, _ = fmt.Sscanf(strings.TrimPrefix(path, "/api/v3/command/"), "%d", &id)
+			status := s.nextStatus(id)
+			s.record("status:" + status)
+			_ = json.NewEncoder(w).Encode(arrCommandResponse{ID: id, Name: "EpisodeSearch", Status: status, Trigger: "unspecified"})
+
+		case path == "/api/v3/episode":
+			s.record(fmt.Sprintf("episodes:%d", s.episodeFileID))
+			_ = json.NewEncoder(w).Encode([]*sonarr.Episode{{ID: 10, EpisodeFileID: s.episodeFileID}})
+
+		case strings.HasPrefix(path, "/api/v3/episodeFile/") && r.Method == http.MethodDelete:
+			s.deletes++
+			s.record("delete")
+			if s.clearOnDelete {
+				s.episodeFileID = 0
+			}
+			w.WriteHeader(http.StatusOK)
+
+		case path == "/api/v3/moviefile/bulk" && r.Method == http.MethodDelete:
+			s.deletes++
+			s.record("delete")
+			if s.clearOnDelete {
+				s.movieFileID = 0
+			}
+			w.WriteHeader(http.StatusOK)
+
+		case strings.HasPrefix(path, "/api/v3/movie/"):
+			s.record(fmt.Sprintf("movie:%d", s.movieFileID))
+			movie := radarr.Movie{ID: 7, HasFile: s.movieFileID != 0}
+			if s.movieFileID != 0 {
+				movie.MovieFile = &radarr.MovieFile{ID: s.movieFileID}
+			}
+			_ = json.NewEncoder(w).Encode(movie)
+
+		case path == "/api/v3/queue":
+			s.record("queue")
+			sonarrRecords := make([]*sonarr.QueueRecord, 0, len(s.queueEpisodeIDs))
+			for _, id := range s.queueEpisodeIDs {
+				sonarrRecords = append(sonarrRecords, &sonarr.QueueRecord{EpisodeID: id})
+			}
+			radarrRecords := make([]*radarr.QueueRecord, 0, len(s.queueMovieIDs))
+			for _, id := range s.queueMovieIDs {
+				radarrRecords = append(radarrRecords, &radarr.QueueRecord{MovieID: id})
+			}
+			if len(radarrRecords) > 0 {
+				_ = json.NewEncoder(w).Encode(radarr.Queue{TotalRecords: len(radarrRecords), Records: radarrRecords})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(sonarr.Queue{TotalRecords: len(sonarrRecords), Records: sonarrRecords})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	return httptest.NewServer(mux)
+}
+
+func remarshal(in any, out any) {
+	data, _ := json.Marshal(in)
+	_ = json.Unmarshal(data, out)
+}
+
+func sonarrClient(t *testing.T, srv *httptest.Server) *sonarr.Sonarr {
+	t.Helper()
+	return sonarr.New(&starr.Config{URL: srv.URL, APIKey: "test", Client: srv.Client()})
+}
+
+func radarrClient(t *testing.T, srv *httptest.Server) *radarr.Radarr {
+	t.Helper()
+	return radarr.New(&starr.Config{URL: srv.URL, APIKey: "test", Client: srv.Client()})
+}
+
+func autoEpisodeSearch(id int64, episodeIDs ...float64) arrCommandResponse {
+	ids := make([]any, 0, len(episodeIDs))
+	for _, epID := range episodeIDs {
+		ids = append(ids, epID)
+	}
+	return arrCommandResponse{
+		ID:      id,
+		Name:    "EpisodeSearch",
+		Status:  "started",
+		Trigger: "unspecified",
+		Queued:  time.Now(),
+		Body:    map[string]any{"episodeIds": ids},
+	}
+}
+
+func indexOf(events []string, want string) int {
+	for i, e := range events {
+		if e == want {
+			return i
+		}
+	}
+	return -1
+}
+
+func lastIndexOf(events []string, want string) int {
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i] == want {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestSettleSonarrAutoRedownload_WaitsForAutoSearchThenDeletesAndSearchesOnce(t *testing.T) {
+	stub := newArrStub()
+	stub.episodeFileID = 500
+	stub.commands = []arrCommandResponse{autoEpisodeSearch(1, 10)}
+	stub.statuses[1] = []string{"started", "completed"}
+
+	srv := stub.serve()
+	defer srv.Close()
+
+	client := sonarrClient(t, srv)
+	m := testManager(10, 5)
+
+	auto, state, err := m.settleSonarrAutoRedownload(context.Background(), client, "sonarr", sonarrRedownloadTarget{
+		seriesID:      3,
+		episodeIDs:    []int64{10},
+		episodeFileID: 500,
+	}, time.Now().Add(-time.Second))
+	if err != nil {
+		t.Fatalf("settle returned error: %v", err)
+	}
+	if state != redownloadProceed {
+		t.Fatalf("state = %v; want redownloadProceed", state)
+	}
+	if auto == nil || auto.ID != 1 {
+		t.Fatalf("auto command not detected: %+v", auto)
+	}
+
+	if _, err := m.sendSonarrSearch(context.Background(), client, "sonarr", []int64{10}, auto); err != nil {
+		t.Fatalf("sendSonarrSearch returned error: %v", err)
+	}
+
+	events := stub.snapshotEvents()
+	if len(stub.postedSonarr) != 1 {
+		t.Fatalf("expected exactly one search command, got %d", len(stub.postedSonarr))
+	}
+	if stub.postedSonarr[0].Trigger != manualTrigger {
+		t.Errorf("search trigger = %q; want %q", stub.postedSonarr[0].Trigger, manualTrigger)
+	}
+	if stub.deletes != 1 {
+		t.Errorf("delete count = %d; want 1", stub.deletes)
+	}
+
+	deleteAt := indexOf(events, "delete")
+	postAt := indexOf(events, "post")
+	clearedAt := lastIndexOf(events, "episodes:0")
+	statusAt := lastIndexOf(events, "status:completed")
+	if statusAt == -1 || deleteAt == -1 || postAt == -1 || clearedAt == -1 {
+		t.Fatalf("missing expected events: %v", events)
+	}
+	if !(statusAt < deleteAt && deleteAt < clearedAt && clearedAt < postAt) {
+		t.Errorf("unexpected ordering %v (status=%d delete=%d cleared=%d post=%d)",
+			events, statusAt, deleteAt, clearedAt, postAt)
+	}
+}
+
+func TestSettleSonarrAutoRedownload_QueueAlreadyHoldsReplacement(t *testing.T) {
+	stub := newArrStub()
+	stub.episodeFileID = 500
+	stub.commands = []arrCommandResponse{autoEpisodeSearch(1, 10)}
+	stub.statuses[1] = []string{"completed"}
+	stub.queueEpisodeIDs = []int64{10}
+
+	srv := stub.serve()
+	defer srv.Close()
+
+	m := testManager(10, 5)
+	_, state, err := m.settleSonarrAutoRedownload(context.Background(), sonarrClient(t, srv), "sonarr", sonarrRedownloadTarget{
+		seriesID:      3,
+		episodeIDs:    []int64{10},
+		episodeFileID: 500,
+	}, time.Now().Add(-time.Second))
+	if err != nil {
+		t.Fatalf("settle returned error: %v", err)
+	}
+	if state != redownloadHandled {
+		t.Fatalf("state = %v; want redownloadHandled", state)
+	}
+	if stub.deletes != 0 {
+		t.Errorf("delete count = %d; want 0", stub.deletes)
+	}
+	if len(stub.postedSonarr) != 0 {
+		t.Errorf("expected no search command, got %d", len(stub.postedSonarr))
+	}
+}
+
+func TestSendSonarrSearch_RetriesOnceWhenDeduplicated(t *testing.T) {
+	stub := newArrStub()
+	stub.episodeFileID = 0
+	stub.statuses[1] = []string{"completed"}
+	stub.postReplies = []arrCommandResponse{
+		{ID: 1, Name: "EpisodeSearch", Status: "started", Trigger: "unspecified"},
+		{ID: 2, Name: "EpisodeSearch", Status: "queued", Trigger: manualTrigger},
+	}
+
+	srv := stub.serve()
+	defer srv.Close()
+
+	m := testManager(10, 5)
+	resp, err := m.sendSonarrSearch(context.Background(), sonarrClient(t, srv), "sonarr", []int64{10}, nil)
+	if err != nil {
+		t.Fatalf("sendSonarrSearch returned error: %v", err)
+	}
+	if resp == nil || resp.ID != 2 {
+		t.Fatalf("expected the retry response, got %+v", resp)
+	}
+	if len(stub.postedSonarr) != 2 {
+		t.Fatalf("expected exactly two search commands (one retry), got %d", len(stub.postedSonarr))
+	}
+
+	events := stub.snapshotEvents()
+	firstPost := indexOf(events, "post")
+	statusAt := indexOf(events, "status:completed")
+	lastPost := lastIndexOf(events, "post")
+	if statusAt == -1 || !(firstPost < statusAt && statusAt < lastPost) {
+		t.Errorf("retry was not issued after the deduplicated command finished: %v", events)
+	}
+}
+
+func TestSettleSonarrAutoRedownload_BudgetExpiryDegradesToDeleteAndSearch(t *testing.T) {
+	stub := newArrStub()
+	stub.episodeFileID = 500
+	stub.commands = []arrCommandResponse{autoEpisodeSearch(1, 10)}
+	stub.statuses[1] = []string{"started"}
+
+	srv := stub.serve()
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	client := sonarrClient(t, srv)
+	m := testManager(1, 1)
+
+	start := time.Now()
+	auto, state, err := m.settleSonarrAutoRedownload(ctx, client, "sonarr", sonarrRedownloadTarget{
+		seriesID:      3,
+		episodeIDs:    []int64{10},
+		episodeFileID: 500,
+	}, time.Now().Add(-time.Second))
+	if err != nil {
+		t.Fatalf("settle returned error: %v", err)
+	}
+	if state != redownloadProceed {
+		t.Fatalf("state = %v; want redownloadProceed", state)
+	}
+	if stub.deletes != 1 {
+		t.Errorf("delete count = %d; want 1", stub.deletes)
+	}
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Errorf("settle took %s; expected it to give up near the 1s budget", elapsed)
+	}
+
+	if _, err := m.sendSonarrSearch(ctx, client, "sonarr", []int64{10}, auto); err != nil {
+		t.Fatalf("sendSonarrSearch returned error: %v", err)
+	}
+	if len(stub.postedSonarr) != 1 {
+		t.Fatalf("expected exactly one search command, got %d", len(stub.postedSonarr))
+	}
+}
+
+func TestSettleSonarrAutoRedownload_ZeroWaitKeepsImmediateBehaviour(t *testing.T) {
+	stub := newArrStub()
+	stub.episodeFileID = 500
+	stub.commands = []arrCommandResponse{autoEpisodeSearch(1, 10)}
+	stub.postReplies = []arrCommandResponse{{ID: 1, Name: "EpisodeSearch", Status: "started", Trigger: "unspecified"}}
+
+	srv := stub.serve()
+	defer srv.Close()
+
+	client := sonarrClient(t, srv)
+	m := testManager(0, 15)
+
+	auto, state, err := m.settleSonarrAutoRedownload(context.Background(), client, "sonarr", sonarrRedownloadTarget{
+		seriesID:      3,
+		episodeIDs:    []int64{10},
+		episodeFileID: 500,
+	}, time.Now().Add(-time.Second))
+	if err != nil {
+		t.Fatalf("settle returned error: %v", err)
+	}
+	if state != redownloadProceed || auto != nil {
+		t.Fatalf("state = %v, auto = %+v; want proceed with no auto command", state, auto)
+	}
+	if stub.deletes != 1 {
+		t.Errorf("delete count = %d; want 1", stub.deletes)
+	}
+	if stub.commandLists != 0 {
+		t.Errorf("command list polled %d times; want 0 with the wait disabled", stub.commandLists)
+	}
+
+	if _, err := m.sendSonarrSearch(context.Background(), client, "sonarr", []int64{10}, auto); err != nil {
+		t.Fatalf("sendSonarrSearch returned error: %v", err)
+	}
+	if len(stub.postedSonarr) != 1 {
+		t.Fatalf("expected exactly one search command with no dedup retry, got %d", len(stub.postedSonarr))
+	}
+
+	events := stub.snapshotEvents()
+	if indexOf(events, "queue") != -1 {
+		t.Errorf("queue must not be polled with the wait disabled: %v", events)
+	}
+}
+
+func TestSettleRadarrAutoRedownload_WaitsThenDeletesAndSearches(t *testing.T) {
+	stub := newArrStub()
+	stub.movieFileID = 800
+	stub.commands = []arrCommandResponse{{
+		ID:      4,
+		Name:    "MoviesSearch",
+		Status:  "queued",
+		Trigger: "unspecified",
+		Queued:  time.Now(),
+		Body:    map[string]any{"movieIds": []any{float64(7)}},
+	}}
+	stub.statuses[4] = []string{"started", "completed"}
+
+	srv := stub.serve()
+	defer srv.Close()
+
+	client := radarrClient(t, srv)
+	m := testManager(10, 5)
+
+	auto, state, err := m.settleRadarrAutoRedownload(context.Background(), client, "radarr", radarrRedownloadTarget{
+		movieID:     7,
+		movieFileID: 800,
+	}, time.Now().Add(-time.Second))
+	if err != nil {
+		t.Fatalf("settle returned error: %v", err)
+	}
+	if state != redownloadProceed {
+		t.Fatalf("state = %v; want redownloadProceed", state)
+	}
+	if auto == nil || auto.ID != 4 {
+		t.Fatalf("auto command not detected: %+v", auto)
+	}
+	if stub.deletes != 1 {
+		t.Errorf("delete count = %d; want 1", stub.deletes)
+	}
+
+	if _, err := m.sendRadarrSearch(context.Background(), client, "radarr", 7, auto); err != nil {
+		t.Fatalf("sendRadarrSearch returned error: %v", err)
+	}
+	if len(stub.postedRadarr) != 1 {
+		t.Fatalf("expected exactly one search command, got %d", len(stub.postedRadarr))
+	}
+	if stub.postedRadarr[0].Trigger != manualTrigger {
+		t.Errorf("search trigger = %q; want %q", stub.postedRadarr[0].Trigger, manualTrigger)
+	}
+
+	events := stub.snapshotEvents()
+	deleteAt := indexOf(events, "delete")
+	postAt := indexOf(events, "post")
+	clearedAt := lastIndexOf(events, "movie:0")
+	if deleteAt == -1 || postAt == -1 || clearedAt == -1 || !(deleteAt < clearedAt && clearedAt < postAt) {
+		t.Errorf("unexpected ordering %v", events)
+	}
+}
+
+func TestBodyInt64Set(t *testing.T) {
+	tests := []struct {
+		name string
+		body map[string]any
+		key  string
+		want []int64
+	}{
+		{
+			name: "json numbers decode as float64",
+			body: map[string]any{"episodeIds": []any{float64(12), float64(13)}},
+			key:  "episodeIds",
+			want: []int64{12, 13},
+		},
+		{
+			name: "scalar body value",
+			body: map[string]any{"seriesId": float64(41), "seasonNumber": float64(2)},
+			key:  "seriesId",
+			want: []int64{41},
+		},
+		{
+			name: "missing key yields empty set",
+			body: map[string]any{"movieIds": []any{float64(9)}},
+			key:  "episodeIds",
+			want: nil,
+		},
+		{
+			name: "nil body yields empty set",
+			body: nil,
+			key:  "episodeIds",
+			want: nil,
+		},
+		{
+			name: "numeric strings are parsed",
+			body: map[string]any{"movieIds": []any{"5", "nope"}},
+			key:  "movieIds",
+			want: []int64{5},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bodyInt64Set(tt.body, tt.key)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v; want %v", got, tt.want)
+			}
+			for _, id := range tt.want {
+				if _, ok := got[id]; !ok {
+					t.Errorf("missing id %d in %v", id, got)
+				}
+			}
+		})
+	}
+}
+
+func TestFindAutoRedownloadCommand(t *testing.T) {
+	since := time.Now()
+	episodeTargets := map[string][]int64{"episodeIds": {12}, "seriesId": {41}}
+
+	episodeSearch := &arrCommand{
+		ID: 1, Name: "EpisodeSearch", Status: "queued", Trigger: "unspecified", Queued: since.Add(time.Second),
+		Body: map[string]any{"episodeIds": []any{float64(12)}},
+	}
+	seasonSearch := &arrCommand{
+		ID: 2, Name: "SeasonSearch", Status: "started", Trigger: "unspecified", Queued: since.Add(time.Second),
+		Body: map[string]any{"seriesId": float64(41), "seasonNumber": float64(2)},
+	}
+	otherSeries := &arrCommand{
+		ID: 3, Name: "EpisodeSearch", Status: "queued", Queued: since.Add(time.Second),
+		Body: map[string]any{"episodeIds": []any{float64(77)}},
+	}
+	stale := &arrCommand{
+		ID: 4, Name: "EpisodeSearch", Status: "queued", Queued: since.Add(-time.Minute),
+		Body: map[string]any{"episodeIds": []any{float64(12)}},
+	}
+	finished := &arrCommand{
+		ID: 5, Name: "EpisodeSearch", Status: "completed", Queued: since.Add(time.Second),
+		Body: map[string]any{"episodeIds": []any{float64(12)}},
+	}
+	unrelatedName := &arrCommand{
+		ID: 6, Name: "RefreshSeries", Status: "queued", Queued: since.Add(time.Second),
+		Body: map[string]any{"seriesId": float64(41)},
+	}
+
+	tests := []struct {
+		name   string
+		list   []*arrCommand
+		want   int64
+		wantOk bool
+	}{
+		{name: "matches an episode search", list: []*arrCommand{otherSeries, episodeSearch}, want: 1, wantOk: true},
+		{name: "matches a season search by series id", list: []*arrCommand{seasonSearch}, want: 2, wantOk: true},
+		{name: "ignores other targets", list: []*arrCommand{otherSeries}},
+		{name: "ignores commands queued before the blocklist", list: []*arrCommand{stale}},
+		{name: "ignores terminal commands", list: []*arrCommand{finished}},
+		{name: "ignores unrelated command names", list: []*arrCommand{unrelatedName}},
+		{name: "ignores nil entries", list: []*arrCommand{nil}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findAutoRedownloadCommand(tt.list, []string{"EpisodeSearch", "SeasonSearch"}, episodeTargets, since)
+			if !tt.wantOk {
+				if got != nil {
+					t.Fatalf("got command %d; want none", got.ID)
+				}
+				return
+			}
+			if got == nil || got.ID != tt.want {
+				t.Fatalf("got %+v; want command %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandWasDeduplicated(t *testing.T) {
+	auto := &arrCommand{ID: 1}
+	tests := []struct {
+		name string
+		resp *arrCommand
+		auto *arrCommand
+		want bool
+	}{
+		{name: "manual trigger is ours", resp: &arrCommand{ID: 9, Trigger: manualTrigger}, auto: auto},
+		{name: "foreign trigger means deduplicated", resp: &arrCommand{ID: 9, Trigger: "unspecified"}, auto: auto, want: true},
+		{name: "matching auto id means deduplicated", resp: &arrCommand{ID: 1, Trigger: manualTrigger}, auto: auto, want: true},
+		{name: "empty trigger with no auto command is ours", resp: &arrCommand{ID: 9}},
+		{name: "nil response", resp: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := commandWasDeduplicated(tt.resp, tt.auto); got != tt.want {
+				t.Errorf("got %v; want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/accessors.go
+++ b/internal/config/accessors.go
@@ -431,6 +431,24 @@ func (c *Config) GetRepairMaxCoolDown() time.Duration {
 	return time.Duration(c.Health.Repair.MaxCoolDownHours) * time.Hour
 }
 
+// GetRepairAutoSearchWait returns how long a repair may wait for the ARR's own
+// automatic redownload search to finish. Zero means "do not wait".
+func (c *Config) GetRepairAutoSearchWait() time.Duration {
+	if c.Health.Repair.AutoSearchWaitSeconds <= 0 {
+		return 0
+	}
+	return time.Duration(c.Health.Repair.AutoSearchWaitSeconds) * time.Second
+}
+
+// GetRepairFileDeleteConfirm returns how long a repair may wait for the ARR to
+// report a deleted file record as unlinked. Zero means "do not wait".
+func (c *Config) GetRepairFileDeleteConfirm() time.Duration {
+	if c.Health.Repair.FileDeleteConfirmSeconds <= 0 {
+		return 0
+	}
+	return time.Duration(c.Health.Repair.FileDeleteConfirmSeconds) * time.Second
+}
+
 // GetRepairExponentialBackoff returns whether exponential backoff is enabled for repairs
 func (c *Config) GetRepairExponentialBackoff() bool {
 	if c.Health.Repair.ExponentialBackoff == nil {

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -683,6 +683,16 @@ type RepairConfig struct {
 	MaxRepairRetries int   `yaml:"max_repair_retries" mapstructure:"max_repair_retries" json:"max_repair_retries"`
 
 	ExponentialBackoff *bool `yaml:"exponential_backoff" mapstructure:"exponential_backoff" json:"exponential_backoff,omitempty"`
+
+	// AutoSearchWaitSeconds bounds how long a repair waits for the ARR's own
+	// automatic redownload search — queued by the ARR the moment a release is
+	// blocklisted — to finish before the file record is deleted and AltMount
+	// issues its own targeted search. 0 disables the wait and restores the
+	// previous fire-and-forget ordering.
+	AutoSearchWaitSeconds int `yaml:"auto_search_wait_seconds" mapstructure:"auto_search_wait_seconds" json:"auto_search_wait_seconds"`
+	// FileDeleteConfirmSeconds bounds how long a repair waits for the ARR to
+	// report the deleted file record as unlinked before issuing its search.
+	FileDeleteConfirmSeconds int `yaml:"file_delete_confirm_seconds" mapstructure:"file_delete_confirm_seconds" json:"file_delete_confirm_seconds"`
 }
 
 // HealthConfig represents health checker configuration
@@ -1265,6 +1275,12 @@ func (c *Config) Validate() error {
 	}
 	if c.Health.CorruptedRetentionDays != nil && *c.Health.CorruptedRetentionDays < 0 {
 		return fmt.Errorf("health corrupted_retention_days must be zero (keep forever) or greater")
+	}
+	if c.Health.Repair.AutoSearchWaitSeconds < 0 {
+		return fmt.Errorf("health repair auto_search_wait_seconds must be zero (no wait) or greater")
+	}
+	if c.Health.Repair.FileDeleteConfirmSeconds < 0 {
+		return fmt.Errorf("health repair file_delete_confirm_seconds must be zero (no wait) or greater")
 	}
 
 	// Validate health configuration - requires library_dir when enabled and using a strategy other than NONE
@@ -2198,10 +2214,12 @@ func DefaultConfig(configDir ...string) *Config {
 			VerifyContentTimeoutSeconds:         &healthVerifyContentTimeoutSeconds, // Default: 15s per-file content probe timeout
 			CorruptedRetentionDays:              &healthCorruptedRetentionDays,      // Default: keep corrupted safety copies forever
 			Repair: RepairConfig{
-				Enabled:            &repairEnabled,
-				IntervalMinutes:    60,
-				MaxCoolDownHours:   24,
-				ExponentialBackoff: &repairExponentialBackoff,
+				Enabled:                  &repairEnabled,
+				IntervalMinutes:          60,
+				MaxCoolDownHours:         24,
+				ExponentialBackoff:       &repairExponentialBackoff,
+				AutoSearchWaitSeconds:    120,
+				FileDeleteConfirmSeconds: 15,
 			},
 		},
 		Par2Repair: Par2RepairConfig{


### PR DESCRIPTION
Repairs downloaded nothing whenever a non-zero Usenet delay profile applied.

Marking a release failed makes Sonarr immediately queue its *own* `EpisodeSearch` with `trigger: unspecified`. AltMount then deleted the episode-file record while that search was running, opening a window where the episode still has a non-zero `EpisodeFileId` but a null lazy-loaded `EpisodeFile` — a `NullReferenceException` in `DelaySpecification` for every candidate.

Sending `trigger: "manual"` alone cannot fix this (why #857 was closed): `CommandQueueManager.Push` deduplicates against the running command and returns *it*, discarding our trigger.

- wait for the ARR's automatic search to finish **before** touching the file record
- bail out if it already grabbed a replacement
- confirm the file record actually cleared before searching
- send our own search with a manual trigger, and detect deduplication from the response (a non-manual trigger back is a definitive "you were deduped" signal) — one bounded retry
- Radarr kept symmetric: no exception there, but the same dedup and delay gating apply

New `auto_search_wait_seconds` (default 120, `0` = today's behaviour) and `file_delete_confirm_seconds` (default 15).

**Residual limitation:** the automatic `unspecified` search still runs and still burns an indexer query. It cannot be suppressed until Sonarr's `HistoryController.MarkAsFailed` exposes `skipRedownload` — verified still absent on current develop.

**Stack 8/8** — base: `fix/content-verify-transient-errors`

Closes #847