### PR TITLE
feat(health): report the content-verification outcome on health results

### DIFF
--- a/frontend/src/pages/HealthPage/components/HealthTable/ContentVerificationBadge.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/ContentVerificationBadge.tsx
@@ -1,0 +1,47 @@
+import { ShieldAlert, ShieldCheck, ShieldQuestion } from "lucide-react";
+import type { HealthErrorDetails } from "../../../../types/api";
+
+interface ContentVerificationBadgeProps {
+	details: HealthErrorDetails;
+}
+
+// ContentVerificationBadge reports the media-container header probe. It exists
+// because a health result that says nothing about content is ambiguous: a file
+// verified clean and one never probed both look identical otherwise. An
+// "unavailable" probe is the important case — the file is unproven, not good.
+export function ContentVerificationBadge({ details }: ContentVerificationBadgeProps) {
+	switch (details.content_verification) {
+		case "passed":
+			return (
+				<span
+					className="badge badge-ghost badge-xs gap-1"
+					title="The file's header carries a recognized media container signature"
+				>
+					<ShieldCheck className="h-3 w-3" aria-hidden="true" />
+					Content verified
+				</span>
+			);
+		case "failed":
+			return (
+				<span
+					className="badge badge-error badge-xs gap-1"
+					title={details.message || "Content verification failed"}
+				>
+					<ShieldAlert className="h-3 w-3" aria-hidden="true" />
+					Content invalid
+				</span>
+			);
+		case "unavailable":
+			return (
+				<span
+					className="badge badge-warning badge-xs gap-1"
+					title={details.message || "The content probe could not complete"}
+				>
+					<ShieldQuestion className="h-3 w-3" aria-hidden="true" />
+					Content unverified
+				</span>
+			);
+		default:
+			return null;
+	}
+}

--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthItemCard.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthItemCard.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../../../lib/utils";
 import { type FileHealth, HealthPriority } from "../../../../types/api";
 import { parseRepairReason } from "../par2RepairReason";
+import { ContentVerificationBadge } from "./ContentVerificationBadge";
 import { HealthItemActionsMenu } from "./HealthItemActionsMenu";
 import { PartialCheckBadge } from "./PartialCheckBadge";
 import { PlaybackImpactBadge } from "./PlaybackImpactBadge";
@@ -142,6 +143,7 @@ export const HealthItemCard = memo(function HealthItemCard({
 							<HealthBadge status={item.status} isMasked={item.is_masked} />
 							{playbackImpact && <PlaybackImpactBadge impact={playbackImpact} />}
 							{errorDetails && <PartialCheckBadge details={errorDetails} />}
+							{errorDetails && <ContentVerificationBadge details={errorDetails} />}
 
 							<button
 								type="button"
@@ -212,7 +214,9 @@ export const HealthItemCard = memo(function HealthItemCard({
 					</div>
 				)}
 
-				{item.error_details && item.error_details !== item.last_error && (
+				{/* Gated on an actual error: a healthy record now carries a
+				    content-verification envelope, which the badge above renders. */}
+				{item.last_error && item.error_details && item.error_details !== item.last_error && (
 					<div className="alert alert-warning px-3 py-2">
 						<AlertCircle className="h-4 w-4 shrink-0" />
 						<span className="text-xs">Technical: {truncateText(item.error_details, 80)}</span>

--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthTableRow.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthTableRow.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../../../lib/utils";
 import { type FileHealth, HealthPriority } from "../../../../types/api";
 import { parseRepairReason } from "../par2RepairReason";
+import { ContentVerificationBadge } from "./ContentVerificationBadge";
 import { HealthItemActionsMenu } from "./HealthItemActionsMenu";
 import { PartialCheckBadge } from "./PartialCheckBadge";
 import { PlaybackImpactBadge } from "./PlaybackImpactBadge";
@@ -190,6 +191,7 @@ export const HealthTableRow = memo(function HealthTableRow({
 					<HealthBadge status={item.status} isMasked={item.is_masked} />
 					{playbackImpact && <PlaybackImpactBadge impact={playbackImpact} />}
 					{errorDetails && <PartialCheckBadge details={errorDetails} />}
+					{errorDetails && <ContentVerificationBadge details={errorDetails} />}
 				</div>
 				{/* Show last_error for repair failures and general errors. PAR2
 				    repair verdicts land here when a repair proved impossible;
@@ -206,8 +208,10 @@ export const HealthTableRow = memo(function HealthTableRow({
 						<div className="mt-1 break-all text-error text-xs">{item.last_error}</div>
 					)
 				)}
-				{/* Show error_details for additional technical details */}
-				{item.error_details && item.error_details !== item.last_error && (
+				{/* Show error_details for additional technical details. Gated on an
+				    actual error: a healthy record now carries a content-verification
+				    envelope, which the badge above already renders. */}
+				{item.last_error && item.error_details && item.error_details !== item.last_error && (
 					<div className="mt-1 break-all text-warning text-xs">Technical: {item.error_details}</div>
 				)}
 			</td>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -289,7 +289,16 @@ export interface HealthErrorDetails {
 	// makes `sampled` a partial count and the missing-segment map incomplete.
 	terminated_early?: boolean;
 	termination_reason?: string;
+	// Outcome of the media-container header probe. Absent when verification
+	// never ran (feature off, or the file is not an eligible media type), and
+	// the one field a healthy record still carries.
+	content_verification?: ContentVerificationStatus;
 }
+
+// Outcome of the media-container header probe, recorded on both healthy and
+// corrupted results. "unavailable" means the probe itself could not complete,
+// so the content is unproven rather than bad.
+export type ContentVerificationStatus = "passed" | "failed" | "unavailable";
 
 export interface HealthCleanupRequest {
 	older_than?: string;

--- a/internal/database/error_details.go
+++ b/internal/database/error_details.go
@@ -11,7 +11,7 @@ import (
 // the frontend parses it to render playback-impact information. Legacy rows may
 // contain other ad-hoc JSON shapes or plain strings — parsers must tolerate that.
 type HealthErrorDetails struct {
-	ErrorType       string        `json:"error_type"`
+	ErrorType       string        `json:"error_type,omitempty"`
 	Message         string        `json:"message,omitempty"`
 	MissingArticles int           `json:"missing_articles,omitempty"`
 	TotalArticles   int           `json:"total_articles,omitempty"`
@@ -30,7 +30,28 @@ type HealthErrorDetails struct {
 
 	// TerminationReason explains why the check stopped early.
 	TerminationReason string `json:"termination_reason,omitempty"`
+
+	// ContentVerification records what the media-container header probe
+	// concluded, and is the one field also written on an otherwise-healthy
+	// record: without it a clean result is indistinguishable from a file that
+	// was never probed at all. Empty means verification did not run — the
+	// feature is off, or the file is not an eligible media type.
+	ContentVerification string `json:"content_verification,omitempty"`
 }
+
+// ContentVerification values for HealthErrorDetails.ContentVerification.
+const (
+	// ContentVerificationPassed: a recognized media container signature was
+	// found in the file's header.
+	ContentVerificationPassed = "passed"
+	// ContentVerificationFailed: the probe definitively rejected the file —
+	// no recognized signature, or its head article is missing.
+	ContentVerificationFailed = "failed"
+	// ContentVerificationUnavailable: the probe could not complete (transient
+	// provider, timeout, or connection error), so the file's content is
+	// unproven rather than bad.
+	ContentVerificationUnavailable = "unavailable"
+)
 
 // Marshal renders the envelope for storage, returning nil on the (practically
 // impossible) marshal error so callers can assign it directly to *string fields.

--- a/internal/database/health_content_verification_test.go
+++ b/internal/database/health_content_verification_test.go
@@ -1,0 +1,65 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A healthy result normally clears error_details. The content-verification
+// outcome is the exception: without it a verified-clean file is
+// indistinguishable from one that was never probed.
+func TestUpdateHealthStatusBulk_HealthyPersistsContentVerification(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, last_error, error_details)
+		VALUES ('verified.mkv', 'pending', 'stale error', '{"error_type":"missing_segments"}')
+	`)
+	require.NoError(t, err)
+
+	details := HealthErrorDetails{ContentVerification: ContentVerificationPassed}
+	err = repo.UpdateHealthStatusBulk(ctx, []HealthStatusUpdate{{
+		Type:             UpdateTypeHealthy,
+		FilePath:         "verified.mkv",
+		ScheduledCheckAt: time.Now().UTC(),
+		ErrorDetails:     details.Marshal(),
+	}})
+	require.NoError(t, err)
+
+	fh, err := repo.GetFileHealth(ctx, "verified.mkv")
+	require.NoError(t, err)
+	assert.Equal(t, HealthStatusHealthy, fh.Status)
+	assert.Nil(t, fh.LastError, "a healthy record must not keep a stale error message")
+	require.NotNil(t, fh.ErrorDetails)
+	assert.JSONEq(t, `{"content_verification":"passed"}`, *fh.ErrorDetails)
+}
+
+// Without a verification outcome the healthy write must clear the column
+// exactly as it always did.
+func TestUpdateHealthStatusBulk_HealthyClearsDetailsWhenUnverified(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, last_error, error_details)
+		VALUES ('plain.mkv', 'pending', 'stale error', '{"error_type":"missing_segments"}')
+	`)
+	require.NoError(t, err)
+
+	err = repo.UpdateHealthStatusBulk(ctx, []HealthStatusUpdate{{
+		Type:             UpdateTypeHealthy,
+		FilePath:         "plain.mkv",
+		ScheduledCheckAt: time.Now().UTC(),
+	}})
+	require.NoError(t, err)
+
+	fh, err := repo.GetFileHealth(ctx, "plain.mkv")
+	require.NoError(t, err)
+	assert.Equal(t, HealthStatusHealthy, fh.Status)
+	assert.Nil(t, fh.ErrorDetails, "a healthy result with nothing to report must clear error_details")
+}

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -1317,7 +1317,7 @@ func (r *HealthRepository) UpdateHealthStatusBulk(ctx context.Context, updates [
 	stmtHealthy, err := tx.PrepareContext(ctx, `
 		UPDATE file_health
 		SET status = 'healthy', scheduled_check_at = ?, retry_count = 0,
-		    repair_retry_count = 0, last_error = NULL, error_details = NULL,
+		    repair_retry_count = 0, last_error = NULL, error_details = ?,
 		    updated_at = datetime('now'), last_checked = datetime('now')
 		WHERE file_path = ? AND (status = ? OR ? = '')
 	`)
@@ -1418,7 +1418,10 @@ func (r *HealthRepository) UpdateHealthStatusBulk(ctx context.Context, updates [
 		}
 		switch update.Type {
 		case UpdateTypeHealthy:
-			_, err = stmtHealthy.ExecContext(ctx, update.ScheduledCheckAt, filePath, expected, expected)
+			// error_details is normally nil here (clearing the column as a
+			// healthy result always did); a content-verification outcome is
+			// the one payload a healthy record keeps.
+			_, err = stmtHealthy.ExecContext(ctx, update.ScheduledCheckAt, update.ErrorDetails, filePath, expected, expected)
 		case UpdateTypeRetry:
 			_, err = stmtRetry.ExecContext(ctx, update.ErrorMessage, update.ErrorDetails, update.ScheduledCheckAt, filePath, expected, expected)
 		case UpdateTypeRepairTrigger:

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -324,9 +324,13 @@ func (hc *HealthChecker) judgeValidation(ctx context.Context, prep preparedCheck
 	}
 
 	if hc.shouldVerifyContent(prep) {
-		if verified := hc.judgeContentVerification(ctx, prep); verified != nil {
-			return *verified
+		corrupted, healthyDetails := hc.judgeContentVerification(ctx, prep)
+		if corrupted != nil {
+			return *corrupted
 		}
+		// A healthy record's details would otherwise be wiped, leaving no
+		// record that the probe ran (or that it could not).
+		event.Details = healthyDetails
 	}
 
 	// All checked segments are available - record will be deleted.
@@ -343,26 +347,32 @@ func (hc *HealthChecker) judgeValidation(ctx context.Context, prep preparedCheck
 // (Pending) check is probed, so repeated repair-recheck cycles on an
 // already-flagged file don't re-probe on every pass.
 func (hc *HealthChecker) shouldVerifyContent(prep preparedCheck) bool {
+	if hc.contentVerifyFS == nil {
+		// Probing through a nil Opener panics, so the wiring check comes
+		// first — an API-forced override must not be able to reach it.
+		return false
+	}
 	if prep.verifyContentOverride != nil {
 		return *prep.verifyContentOverride
 	}
-	if hc.contentVerifyFS == nil || !hc.configGetter().GetHealthVerifyContent() {
+	if !hc.configGetter().GetHealthVerifyContent() {
 		return false
 	}
 	return prep.currentStatus == database.HealthStatusPending
 }
 
-// judgeContentVerification probes prep.filePath's content signature and, if
-// the result is definitive, returns a Corrupted event. A nil return means
-// either verification is not eligible for this file (not a verifiable media
-// type), passed, or failed only transiently — in all three cases the caller
-// proceeds to the normal healthy branch, since a transient probe error must
-// never mark a file corrupted. A transient failure is logged, because a
-// healthy record is deleted and would otherwise leave no trace that
-// verification never actually ran.
-func (hc *HealthChecker) judgeContentVerification(ctx context.Context, prep preparedCheck) *HealthEvent {
+// judgeContentVerification probes prep.filePath's content signature. It
+// returns a Corrupted event when the result is definitive, and otherwise the
+// error_details to attach to the healthy event: a nil event with non-nil
+// details records that the probe ran and passed, or that it could not
+// complete. Both returns are nil when the file is not an eligible media type
+// and no probe happened at all. A transient probe error must never mark a
+// file corrupted, so it stays on the healthy path — but it is recorded there
+// rather than only logged, because a healthy record that says nothing cannot
+// be told apart from one that was verified clean.
+func (hc *HealthChecker) judgeContentVerification(ctx context.Context, prep preparedCheck) (*HealthEvent, *string) {
 	if !fileinfo.IsVerifiableMediaFile(prep.filePath) {
-		return nil
+		return nil, nil
 	}
 
 	cfg := hc.configGetter()
@@ -371,12 +381,17 @@ func (hc *HealthChecker) judgeContentVerification(ctx context.Context, prep prep
 	var errType, message string
 	switch result.Result {
 	case contentverify.ContentValid:
-		return nil
+		details := database.HealthErrorDetails{ContentVerification: database.ContentVerificationPassed}
+		return nil, details.Marshal()
 	case contentverify.ContentProbeError:
 		slog.WarnContext(ctx, "Content verification could not complete",
 			"file_path", prep.filePath,
 			"error", result.Err)
-		return nil
+		details := database.HealthErrorDetails{
+			ContentVerification: database.ContentVerificationUnavailable,
+			Message:             probeErrorMessage(result.Err),
+		}
+		return nil, details.Marshal()
 	case contentverify.ContentInvalid:
 		errType = "content_invalid"
 		message = "no recognized media container signature was found in the file's header"
@@ -384,16 +399,29 @@ func (hc *HealthChecker) judgeContentVerification(ctx context.Context, prep prep
 		errType = "content_segment_missing"
 		message = "the article needed to read the file's header is missing from your Usenet provider"
 	default:
-		return nil
+		return nil, nil
 	}
 
 	event := baseResultEvent(prep.filePath, prep.sourceNzbPath)
 	event.Type = EventTypeFileCorrupted
 	event.Status = database.HealthStatusCorrupted
 	event.Error = fmt.Errorf("content verification failed: %s", message)
-	details := database.HealthErrorDetails{ErrorType: errType, Message: message}
+	details := database.HealthErrorDetails{
+		ErrorType:           errType,
+		Message:             message,
+		ContentVerification: database.ContentVerificationFailed,
+	}
 	event.Details = details.Marshal()
-	return &event
+	return &event, nil
+}
+
+// probeErrorMessage renders why a probe could not complete, so the UI can
+// explain an unproven file instead of just flagging it as unverified.
+func probeErrorMessage(err error) string {
+	if err == nil {
+		return "the content probe could not complete"
+	}
+	return fmt.Sprintf("the content probe could not complete: %s", err)
 }
 
 // CheckFile checks the health of a specific file

--- a/internal/health/content_verify_report_test.go
+++ b/internal/health/content_verify_report_test.go
@@ -1,0 +1,147 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/stretchr/testify/require"
+)
+
+func matroskaHeader() []byte {
+	data := append([]byte{0x1A, 0x45, 0xDF, 0xA3, 0x42, 0x82, 0x88}, []byte("matroska")...)
+	return append(data, make([]byte, 512-len(data))...)
+}
+
+// A healthy file that was actually probed must say so, otherwise the UI
+// cannot distinguish "verified clean" from "never verified".
+func TestJudgeValidation_HealthyRecordsContentVerificationPassed(t *testing.T) {
+	hc := newTestHealthCheckerWithVerifyContentEnabled(&fakeContentOpener{data: matroskaHeader()})
+	prep := preparedCheck{filePath: "/movie.mkv", currentStatus: database.HealthStatusPending}
+
+	event := hc.judgeValidation(context.Background(), prep, allPresentResult(), nil)
+
+	if event.Type != EventTypeFileHealthy {
+		t.Fatalf("got event type %v, want EventTypeFileHealthy", event.Type)
+	}
+	if got := parseDetails(t, event).ContentVerification; got != database.ContentVerificationPassed {
+		t.Errorf("got content_verification %q, want %q", got, database.ContentVerificationPassed)
+	}
+}
+
+// A probe that could not complete leaves the file healthy, but the result
+// must record that verification did not actually run.
+func TestJudgeValidation_HealthyRecordsContentVerificationUnavailable(t *testing.T) {
+	hc := newTestHealthCheckerWithVerifyContentEnabled(&fakeContentOpener{err: errors.New("connection reset")})
+	prep := preparedCheck{filePath: "/movie.mkv", currentStatus: database.HealthStatusPending}
+
+	event := hc.judgeValidation(context.Background(), prep, allPresentResult(), nil)
+
+	if event.Type != EventTypeFileHealthy {
+		t.Fatalf("got event type %v, want EventTypeFileHealthy", event.Type)
+	}
+	details := parseDetails(t, event)
+	if details.ContentVerification != database.ContentVerificationUnavailable {
+		t.Errorf("got content_verification %q, want %q", details.ContentVerification, database.ContentVerificationUnavailable)
+	}
+	if details.Message == "" {
+		t.Error("expected the transient probe error to be recorded in message")
+	}
+}
+
+// A file that was never eligible for probing must carry no verification
+// claim at all.
+func TestJudgeValidation_NonMediaFileRecordsNoContentVerification(t *testing.T) {
+	hc := newTestHealthCheckerWithVerifyContentEnabled(&fakeContentOpener{data: make([]byte, 512)})
+	prep := preparedCheck{filePath: "/release.nfo", currentStatus: database.HealthStatusPending}
+
+	event := hc.judgeValidation(context.Background(), prep, allPresentResult(), nil)
+
+	if event.Details != nil {
+		t.Errorf("expected no details for a file that was never probed, got %q", *event.Details)
+	}
+}
+
+func TestJudgeValidation_CorruptedRecordsContentVerificationFailed(t *testing.T) {
+	hc := newTestHealthCheckerWithVerifyContentEnabled(&fakeContentOpener{data: make([]byte, 512)})
+	prep := preparedCheck{filePath: "/movie.mkv", currentStatus: database.HealthStatusPending}
+
+	event := hc.judgeValidation(context.Background(), prep, allPresentResult(), nil)
+
+	if event.Status != database.HealthStatusCorrupted {
+		t.Fatalf("got status %v, want Corrupted", event.Status)
+	}
+	if got := parseDetails(t, event).ContentVerification; got != database.ContentVerificationFailed {
+		t.Errorf("got content_verification %q, want %q", got, database.ContentVerificationFailed)
+	}
+}
+
+// A forced override must not probe through a checker that has no
+// filesystem wired: calling OpenFile on a nil Opener panics.
+func TestShouldVerifyContent_OverrideWithoutFilesystemDoesNotProbe(t *testing.T) {
+	force := true
+	enabled := true
+	cfg := &config.Config{Health: config.HealthConfig{VerifyContent: &enabled}}
+	hc := &HealthChecker{configGetter: func() *config.Config { return cfg }}
+	prep := preparedCheck{filePath: "/movie.mkv", currentStatus: database.HealthStatusPending, verifyContentOverride: &force}
+
+	if hc.shouldVerifyContent(prep) {
+		t.Fatal("expected no probe when contentVerifyFS is nil, even with the override forced on")
+	}
+
+	event := hc.judgeValidation(context.Background(), prep, allPresentResult(), nil)
+	if event.Type != EventTypeFileHealthy {
+		t.Errorf("got event type %v, want EventTypeFileHealthy", event.Type)
+	}
+}
+
+// End-to-end proof that a passing probe survives all the way to the stored
+// record: the healthy write clears last_error and every stale detail, but must
+// keep the verification outcome, which is the only thing that distinguishes a
+// verified-clean file from an unprobed one.
+func TestPerformBackgroundCheck_HealthyRecordKeepsContentVerification(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+
+	client := fakepool.New()
+	env := newBatchTestEnv(t, t.TempDir(), client)
+
+	enabled := true
+	cfg := env.hw.configGetter()
+	cfg.Health.VerifyContent = &enabled
+	env.healthChecker.contentVerifyFS = &fakeContentOpener{data: matroskaHeader()}
+
+	path := "complete/movie.mkv"
+	writeHealthyFile(t, env, path)
+
+	_, err := env.db.Exec(`
+		INSERT INTO file_health (file_path, status, retry_count, max_retries, repair_retry_count, max_repair_retries, scheduled_check_at)
+		VALUES (?, 'pending', 0, 3, 0, 3, datetime('now', '-1 second'))
+	`, path)
+	require.NoError(t, err)
+
+	env.hw.mu.Lock()
+	env.hw.running = true
+	env.hw.mu.Unlock()
+
+	require.NoError(t, env.hw.PerformBackgroundCheck(context.Background(), path, database.HealthStatusPending, nil))
+
+	require.Eventually(t, func() bool {
+		fh, err := env.healthRepo.GetFileHealth(context.Background(), path)
+		return err == nil && fh != nil &&
+			fh.Status == database.HealthStatusHealthy &&
+			fh.ErrorDetails != nil &&
+			strings.Contains(*fh.ErrorDetails, `"content_verification":"passed"`)
+	}, 2*time.Second, 10*time.Millisecond, "a healthy record must retain the content-verification outcome")
+
+	fh, err := env.healthRepo.GetFileHealth(context.Background(), path)
+	require.NoError(t, err)
+	require.Nil(t, fh.LastError, "a healthy record must not keep an error message")
+}

--- a/internal/health/content_verify_test.go
+++ b/internal/health/content_verify_test.go
@@ -95,8 +95,12 @@ func TestJudgeContentVerification_ProbeErrorReturnsNoEvent(t *testing.T) {
 	hc := newTestHealthCheckerWithVerifyContentEnabled(&fakeContentOpener{err: errors.New("connection reset")})
 	prep := preparedCheck{filePath: "/movie.mkv", currentStatus: database.HealthStatusPending}
 
-	if event := hc.judgeContentVerification(context.Background(), prep); event != nil {
+	event, healthyDetails := hc.judgeContentVerification(context.Background(), prep)
+	if event != nil {
 		t.Errorf("a transient probe error must produce no event, got %+v", *event)
+	}
+	if healthyDetails == nil {
+		t.Error("a transient probe error must still be recorded on the healthy result")
 	}
 }
 

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -486,6 +486,9 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 		update.Type = database.UpdateTypeHealthy
 		update.Status = database.HealthStatusHealthy
 		update.ScheduledCheckAt = nextCheck
+		// Normally nil, which clears the column as before. A content-verification
+		// outcome is the one thing a healthy record still carries.
+		update.ErrorDetails = event.Details
 
 		sideEffect = func() error {
 			slog.InfoContext(ctx, "File is healthy", "file_path", fh.FilePath)


### PR DESCRIPTION
Closes #851.

## Problem

The media content verification feature (#860) reports a health result only when the probe *definitively* fails. A passing probe returns the file to the normal healthy branch, which clears `error_details`; a probe that could not complete is only `slog.Warn`-ed. Both leave a health record that looks identical to one that was never probed, so the UI cannot answer the question the issue asks for — whether verification was performed, and whether it passed, failed, or could not be completed.

Separately, `shouldVerifyContent` returned the API-forced `verify_content` override *before* checking that `contentVerifyFS` was wired. A forced manual recheck against a checker built without a filesystem would call `OpenFile` on a nil `Opener` and panic. Unreachable from `serve.go` today (the filesystem is always wired), but it is guarded only by that wiring.

## Change

- `HealthErrorDetails` gains `content_verification`: `passed`, `failed`, or `unavailable` (absent when no probe ran). `error_type` gained `omitempty` so a healthy envelope is exactly `{"content_verification":"passed"}`.
- `judgeContentVerification` now returns `(*HealthEvent, *string)` — the definitive Corrupted event, or the details to attach to the healthy event. A transient probe error is recorded with its reason instead of only logged.
- `UpdateTypeHealthy` forced `error_details = NULL`, which erased the outcome. It now binds the column; `nil` still clears it, exactly as before, so nothing changes for a healthy result with nothing to report. `last_error` is still cleared.
- `shouldVerifyContent` checks the filesystem wiring first, so the override cannot reach a nil `Opener`.
- Health table row and mobile card render the outcome as a badge (`Content verified` / `Content invalid` / `Content unverified`, with the probe error in the tooltip). The raw `Technical: {error_details}` dump is now gated on `last_error`, so healthy rows do not spill JSON.

## Tests

7 added:

- checker: healthy result records `passed`; healthy result records `unavailable` plus the reason; corrupted result records `failed`; a non-media file records no claim at all.
- the nil-filesystem override guard (no probe, no panic).
- repository: a healthy write persists the verification outcome, and still clears `error_details` when there is none.
- end-to-end `PerformBackgroundCheck`: `content_verification: passed` survives to the stored row with `last_error` cleared.

## Verification

`go build ./...`, the full `go test ./...` suite, `go test -race` on health/database/api/importer/contentverify, `bun run check`, and `bun run build` all pass.

`make` stops at `golangci-lint`, but that is a pre-existing toolchain mismatch unrelated to this branch — its bundled typechecker cannot read Go 1.27 export data and fails in `internal/encryption`, which this PR does not touch.