### PR TITLE
chore(deps): bump nntppool to v4.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/javi11/gopar-turbo v0.2.1
-	github.com/javi11/nntppool/v4 v4.22.3-0.20260905181219-f59773674c9b
+	github.com/javi11/nntppool/v4 v4.23.0
 	github.com/javi11/nxg v0.1.0
 	github.com/javi11/nzbparser v0.5.5
 	github.com/javi11/rardecode/v2 v2.2.4

--- a/go.sum
+++ b/go.sum
@@ -378,14 +378,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/javi11/gopar-turbo v0.2.1 h1:0xUZtofwBcjxle6QIl9EZAwxmLtWkECMM69tQhmc9iA=
 github.com/javi11/gopar-turbo v0.2.1/go.mod h1:fOQZIbPz+ADJ8vGAzVLXvQhsOsE08hvAcev8nQvBFfY=
-github.com/javi11/nntppool/v4 v4.22.2 h1:JHE+78M3yqJp1AGbJQhFKglB0l4cm45XwwetskJQS+A=
-github.com/javi11/nntppool/v4 v4.22.2/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
-github.com/javi11/nntppool/v4 v4.22.3-0.20260905174153-b41f86bcc694 h1:+JMpLDUMTlbOulcR8oI4WPSlBmNaHacpomGqvc+M0JQ=
-github.com/javi11/nntppool/v4 v4.22.3-0.20260905174153-b41f86bcc694/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
-github.com/javi11/nntppool/v4 v4.22.3-0.20260905180010-2b928c3f6a9a h1:EF8NVzeaN/at+6ZO/51yNwLDsbFIWWtw54yW16J3qTA=
-github.com/javi11/nntppool/v4 v4.22.3-0.20260905180010-2b928c3f6a9a/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
-github.com/javi11/nntppool/v4 v4.22.3-0.20260905181219-f59773674c9b h1:FRcY+c9I9oy6Fy9U0Z2vfxIwFwHdIXWUlCkbjpDBweU=
-github.com/javi11/nntppool/v4 v4.22.3-0.20260905181219-f59773674c9b/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
+github.com/javi11/nntppool/v4 v4.23.0 h1:lpVYJo6eKlT/tkU/+uUwOoaK8Bven6NiGCMNMx3t4qI=
+github.com/javi11/nntppool/v4 v4.23.0/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
 github.com/javi11/nxg v0.1.0 h1:CTThldYlaVIPIhpkrMw0HcTD0NLrW1uYMoDILjjEOtM=
 github.com/javi11/nxg v0.1.0/go.mod h1:+GvYpp+y1oq+qBOWxFMvfTjtin/0zCeomWfjiPkiu8A=
 github.com/javi11/nzbparser v0.5.5 h1:kMKyX0xNO7bIeIlQvSPGzdWs71MG2Krf+yojOj+FuUc=


### PR DESCRIPTION
## Summary

Moves the `nntppool` dependency off an unmerged branch head and onto a tagged release.

`go.mod` was pinned to `v4.22.3-0.20260905181219-f59773674c9b` — the head of `feat/background-lane` (nntppool#101), which was never on `main`. That branch was 4 ahead / 1 behind, so the pin also left out nntppool#102 (connection write buffer grown from 4 KiB to 64 KiB).

nntppool#101 is now merged (`83b7774`) and released as **v4.23.0**, so this switches to the tag.

- `github.com/javi11/nntppool/v4` `v4.22.3-0.20260905181219-f59773674c9b` → `v4.23.0`
- Picks up nntppool#102's 64 KiB write buffer
- No source changes needed: `BodyBackground` and `StatManyOptions.Background` are identical in the tagged release

The background lane is what `internal/par2repair` fetches through (`fetch.go:362` `BodyBackground`, `fetch.go:279` `StatManyOptions{Background: true}`) so repair stays behind playback and imports.

## Test plan

- [x] `go mod tidy` — clean
- [x] `go build ./...` — exit 0
- [x] `go vet ./...` — exit 0
- [x] `go test ./...` — exit 0, 0 failures (incl. `internal/par2repair`, `internal/pool`, `internal/testsupport/fakepool`)
- [x] Upstream: nntppool full suite `ok` + `-race` on lane/priority/background tests exit 0 after the rebase