### PR TITLE
fix: ARR instance routing, SABnzbd history ghosts and transient article misses

### DIFF
--- a/docs/docs/3. Configuration/streaming.md
+++ b/docs/docs/3. Configuration/streaming.md
@@ -19,12 +19,12 @@ _Streaming settings in the system configuration_
 
 | Parameter              | Description                                           | Default |
 | ---------------------- | ----------------------------------------------------- | ------- |
-| `max_prefetch`         | Number of segments to prefetch ahead during streaming | `30`    |
+| `max_prefetch`         | Number of segments to prefetch ahead during streaming | `60`    |
 | `read_timeout_seconds` | Maximum duration of a single read before it fails     | `120`   |
 
 ```yaml
 streaming:
-  max_prefetch: 30 # Number of segments prefetched ahead (default: 30)
+  max_prefetch: 60 # Number of segments prefetched ahead (default: 60; also capped at 96 MB)
   read_timeout_seconds: 120 # Fail a read that stalls this long (0 = default, -1 = disabled)
   failure_masking:
     enabled: true # Automatically hide files from mounts after repeated failures

--- a/docs/docs/5. Troubleshooting/common-issues.md
+++ b/docs/docs/5. Troubleshooting/common-issues.md
@@ -359,7 +359,7 @@ _[Screenshot placeholder: WebDAV client successfully connecting after authentica
 
    ```yaml
    streaming:
-     max_prefetch: 45 # Increase prefetch for better throughput
+     max_prefetch: 80 # Increase prefetch for better throughput
    ```
 
 2. **Provider Optimization**:

--- a/docs/docs/5. Troubleshooting/performance.md
+++ b/docs/docs/5. Troubleshooting/performance.md
@@ -27,7 +27,7 @@ The streaming system has a single tuning parameter: `max_prefetch`, which contro
 
 ```yaml
 streaming:
-  max_prefetch: 60 # More prefetch for high-bandwidth setups
+  max_prefetch: 90 # More prefetch for high-bandwidth setups
 
 import:
   max_processor_workers: 4 # Multiple NZB processors
@@ -38,7 +38,7 @@ import:
 
 ```yaml
 streaming:
-  max_prefetch: 30 # Default — good balance
+  max_prefetch: 60 # Default — good balance
 
 import:
   max_processor_workers: 2 # Standard processing
@@ -119,7 +119,7 @@ If media playback freezes or buffers frequently:
 
    ```yaml
    streaming:
-     max_prefetch: 45 # Increase from default 30
+     max_prefetch: 80 # Increase from default 60
    ```
 
 3. **Tune rclone VFS settings** (if using rclone mount): Playback freezing is often caused by rclone VFS settings rather than AltMount itself. See the [Streaming Configuration rclone section](../3.%20Configuration/streaming.md#rclone-vfs-recommended-settings) for recommended settings. Key parameters:

--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -56,17 +56,29 @@ func (m *Manager) findInstanceForFilePath(ctx context.Context, filePath string, 
 
 	allInstances := m.instances.GetAllInstances()
 
-	// Strategy 1: Fast Path - Check Root Folders
+	// Strategy 1: Fast Path - Check Root Folders.
+	//
+	// Every instance is scored and the most specific (longest) matching root
+	// folder wins. First-match-wins sent files under "/media/tv-4k" to the
+	// instance rooted at "/media/tv" whenever that one happened to be listed
+	// first, and the same applies to a nested root such as "/media/tv/anime"
+	// (issue #749).
+	bestScore, bestType, bestName := 0, "", ""
 	for _, instance := range allInstances {
 		if !instance.Enabled {
 			continue
 		}
 
 		if client, err := m.clients.GetOrCreateClient(instance); err == nil {
-			if m.managesFile(ctx, instance.Type, client, filePath) {
-				return instance.Type, instance.Name, nil
+			if score := m.managesFile(ctx, instance.Type, client, filePath); score > bestScore {
+				bestScore, bestType, bestName = score, instance.Type, instance.Name
 			}
 		}
+	}
+	if bestScore > 0 {
+		slog.DebugContext(ctx, "Found managing instance by root folder",
+			"instance", bestName, "type", bestType, "root_len", bestScore)
+		return bestType, bestName, nil
 	}
 
 	// Strategy 2: Category Match - Check if file is in the staging/complete folder
@@ -120,40 +132,63 @@ func (m *Manager) findInstanceForFilePath(ctx context.Context, filePath string, 
 	return "", "", fmt.Errorf("no ARR instance found managing file path: %s", filePath)
 }
 
-func (m *Manager) managesFile(ctx context.Context, instanceType string, client any, filePath string) bool {
+// rootFolderScore reports how specifically rootPath claims filePath: the
+// length of the normalized root folder when filePath is that folder or lives
+// inside it, else 0. Bigger means more specific.
+//
+// Matching is on path-segment boundaries. A raw strings.HasPrefix made
+// "/media/tv" claim "/media/tv-4k/..." — sending repairs to an ARR that owns
+// no such series (issue #749).
+func rootFolderScore(filePath, rootPath string) int {
+	root := strings.TrimRight(filepath.ToSlash(rootPath), "/")
+	file := strings.TrimRight(filepath.ToSlash(filePath), "/")
+	if root == "" || file == "" {
+		return 0
+	}
+	if file == root || strings.HasPrefix(file, root+"/") {
+		return len(root)
+	}
+	return 0
+}
+
+// managesFile reports how specifically instanceType's root folders claim
+// filePath: the length of the longest matching root folder, or 0 when none
+// matches. Callers compare scores across instances so the most specific root
+// wins (see findInstanceForFilePath).
+func (m *Manager) managesFile(ctx context.Context, instanceType string, client any, filePath string) int {
 	switch instanceType {
 	case "radarr":
 		rc, ok := client.(*radarr.Radarr)
 		if !ok {
-			return false
+			return 0
 		}
 		return m.radarrManagesFile(ctx, rc, filePath)
 	case "sonarr":
 		sc, ok := client.(*sonarr.Sonarr)
 		if !ok {
-			return false
+			return 0
 		}
 		return m.sonarrManagesFile(ctx, sc, filePath)
 	case "lidarr":
 		lc, ok := client.(*lidarr.Lidarr)
 		if !ok {
-			return false
+			return 0
 		}
 		return m.lidarrManagesFile(ctx, lc, filePath)
 	case "readarr":
 		rc, ok := client.(*readarr.Readarr)
 		if !ok {
-			return false
+			return 0
 		}
 		return m.readarrManagesFile(ctx, rc, filePath)
 	case "whisparr":
 		wc, ok := client.(*sonarr.Sonarr)
 		if !ok {
-			return false
+			return 0
 		}
 		return m.sonarrManagesFile(ctx, wc, filePath)
 	default:
-		return false
+		return 0
 	}
 }
 
@@ -180,8 +215,9 @@ func (m *Manager) hasFile(ctx context.Context, instanceType string, client any, 
 	}
 }
 
-// radarrManagesFile checks if Radarr manages the given file path using root folders (checkrr approach)
-func (m *Manager) radarrManagesFile(ctx context.Context, client *radarr.Radarr, filePath string) bool {
+// radarrManagesFile scores how specifically Radarr's root folders claim
+// filePath (checkrr approach). See rootFolderScore for the match rule.
+func (m *Manager) radarrManagesFile(ctx context.Context, client *radarr.Radarr, filePath string) int {
 	slog.DebugContext(ctx, "Checking Radarr root folders for file ownership",
 		"file_path", filePath)
 
@@ -189,25 +225,27 @@ func (m *Manager) radarrManagesFile(ctx context.Context, client *radarr.Radarr, 
 	rootFolders, err := client.GetRootFoldersContext(ctx)
 	if err != nil {
 		slog.DebugContext(ctx, "Failed to get root folders from Radarr for file check", "error", err)
-		return false
+		return 0
 	}
 
-	// Check if file path starts with any root folder path
+	best := 0
 	for _, folder := range rootFolders {
 		slog.DebugContext(ctx, "Checking Radarr root folder", "folder_path", folder.Path, "file_path", filePath)
-		// Check for direct prefix match or if the filePath contains the folder.Path (common in Docker/Remote setups)
-		if strings.HasPrefix(filePath, folder.Path) {
+		if score := rootFolderScore(filePath, folder.Path); score > best {
 			slog.DebugContext(ctx, "File matches Radarr root folder", "folder_path", folder.Path)
-			return true
+			best = score
 		}
 	}
 
-	slog.DebugContext(ctx, "File does not match any Radarr root folders")
-	return false
+	if best == 0 {
+		slog.DebugContext(ctx, "File does not match any Radarr root folders")
+	}
+	return best
 }
 
-// sonarrManagesFile checks if Sonarr manages the given file path using root folders (checkrr approach)
-func (m *Manager) sonarrManagesFile(ctx context.Context, client *sonarr.Sonarr, filePath string) bool {
+// sonarrManagesFile scores how specifically Sonarr's root folders claim
+// filePath (checkrr approach). See rootFolderScore for the match rule.
+func (m *Manager) sonarrManagesFile(ctx context.Context, client *sonarr.Sonarr, filePath string) int {
 	slog.DebugContext(ctx, "Checking Sonarr root folders for file ownership",
 		"file_path", filePath)
 
@@ -215,52 +253,56 @@ func (m *Manager) sonarrManagesFile(ctx context.Context, client *sonarr.Sonarr, 
 	rootFolders, err := client.GetRootFoldersContext(ctx)
 	if err != nil {
 		slog.DebugContext(ctx, "Failed to get root folders from Sonarr for file check", "error", err)
-		return false
+		return 0
 	}
 
-	// Check if file path starts with any root folder path
+	best := 0
 	for _, folder := range rootFolders {
 		slog.DebugContext(ctx, "Checking Sonarr root folder", "folder_path", folder.Path, "file_path", filePath)
-		if strings.HasPrefix(filePath, folder.Path) {
+		if score := rootFolderScore(filePath, folder.Path); score > best {
 			slog.DebugContext(ctx, "File matches Sonarr root folder", "folder_path", folder.Path)
-			return true
+			best = score
 		}
 	}
 
-	slog.DebugContext(ctx, "File does not match any Sonarr root folders")
-	return false
+	if best == 0 {
+		slog.DebugContext(ctx, "File does not match any Sonarr root folders")
+	}
+	return best
 }
 
-// lidarrManagesFile checks if Lidarr manages the given file path using root folders
-func (m *Manager) lidarrManagesFile(ctx context.Context, client *lidarr.Lidarr, filePath string) bool {
+// lidarrManagesFile scores how specifically Lidarr's root folders claim filePath.
+func (m *Manager) lidarrManagesFile(ctx context.Context, client *lidarr.Lidarr, filePath string) int {
 	slog.DebugContext(ctx, "Checking Lidarr root folders for file ownership", "file_path", filePath)
 	rootFolders, err := client.GetRootFoldersContext(ctx)
 	if err != nil {
 		slog.DebugContext(ctx, "Failed to get root folders from Lidarr", "error", err)
-		return false
+		return 0
 	}
+	best := 0
 	for _, folder := range rootFolders {
-		if strings.HasPrefix(filePath, folder.Path) {
-			return true
+		if score := rootFolderScore(filePath, folder.Path); score > best {
+			best = score
 		}
 	}
-	return false
+	return best
 }
 
-// readarrManagesFile checks if Readarr manages the given file path using root folders
-func (m *Manager) readarrManagesFile(ctx context.Context, client *readarr.Readarr, filePath string) bool {
+// readarrManagesFile scores how specifically Readarr's root folders claim filePath.
+func (m *Manager) readarrManagesFile(ctx context.Context, client *readarr.Readarr, filePath string) int {
 	slog.DebugContext(ctx, "Checking Readarr root folders for file ownership", "file_path", filePath)
 	rootFolders, err := client.GetRootFoldersContext(ctx)
 	if err != nil {
 		slog.DebugContext(ctx, "Failed to get root folders from Readarr", "error", err)
-		return false
+		return 0
 	}
+	best := 0
 	for _, folder := range rootFolders {
-		if strings.HasPrefix(filePath, folder.Path) {
-			return true
+		if score := rootFolderScore(filePath, folder.Path); score > best {
+			best = score
 		}
 	}
-	return false
+	return best
 }
 
 // radarrHasFile checks if any movie in the instance contains the given relative path

--- a/internal/arrs/scanner/root_folder_match_test.go
+++ b/internal/arrs/scanner/root_folder_match_test.go
@@ -1,0 +1,142 @@
+package scanner
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kipsilabs/altmount/internal/arrs/clients"
+	"github.com/kipsilabs/altmount/internal/arrs/instances"
+	"github.com/kipsilabs/altmount/internal/config"
+)
+
+// fakeArr serves just enough of the Sonarr/Radarr v3 API for root-folder
+// ownership checks: GET /api/v3/rootFolder returning the supplied paths.
+func fakeArr(t *testing.T, rootPaths ...string) string {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/rootFolder", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body := "["
+		for i, p := range rootPaths {
+			if i > 0 {
+				body += ","
+			}
+			body += `{"id":` + string(rune('1'+i)) + `,"path":"` + p + `","accessible":true}`
+		}
+		body += "]"
+		_, _ = w.Write([]byte(body))
+	})
+	// Every other endpoint (series, movies, ...) answers with an empty list so
+	// the later fallback strategies find nothing and cannot mask a Strategy 1
+	// regression.
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// TestFindInstanceForFilePath_RootFolderBoundary pins that root-folder
+// ownership is decided on path-segment boundaries and that the most specific
+// (longest) matching root wins.
+//
+// Before the fix, root folders were matched with a raw strings.HasPrefix and
+// the first matching instance won, so a file under "/mnt/media/tv-4k" was
+// claimed by the instance rooted at "/mnt/media/tv" — sending the repair to an
+// ARR that owns no such series (issue #749).
+func TestFindInstanceForFilePath_RootFolderBoundary(t *testing.T) {
+	enabled := true
+
+	tests := []struct {
+		name     string
+		roots    map[string][]string // instance name -> root folders
+		order    []string            // config order of the sonarr instances
+		filePath string
+		wantName string
+	}{
+		{
+			name: "sibling root sharing a prefix does not claim the file",
+			roots: map[string][]string{
+				"sonarr":    {"/mnt/media/tv"},
+				"sonarr-4k": {"/mnt/media/tv-4k"},
+			},
+			order:    []string{"sonarr", "sonarr-4k"},
+			filePath: "/mnt/media/tv-4k/Show (2024)/Season 1/Show - S01E03.mkv",
+			wantName: "sonarr-4k",
+		},
+		{
+			name: "exact root still matches its own instance",
+			roots: map[string][]string{
+				"sonarr":    {"/mnt/media/tv"},
+				"sonarr-4k": {"/mnt/media/tv-4k"},
+			},
+			order:    []string{"sonarr", "sonarr-4k"},
+			filePath: "/mnt/media/tv/Show (2024)/Season 1/Show - S01E03.mkv",
+			wantName: "sonarr",
+		},
+		{
+			name: "nested root wins over its parent regardless of config order",
+			roots: map[string][]string{
+				"sonarr":       {"/mnt/media/tv"},
+				"sonarr-anime": {"/mnt/media/tv/anime"},
+			},
+			order:    []string{"sonarr", "sonarr-anime"},
+			filePath: "/mnt/media/tv/anime/Show (2024)/Season 1/Show - S01E03.mkv",
+			wantName: "sonarr-anime",
+		},
+		{
+			name: "trailing slash on the configured root is tolerated",
+			roots: map[string][]string{
+				"sonarr":    {"/mnt/media/tv/"},
+				"sonarr-4k": {"/mnt/media/tv-4k/"},
+			},
+			order:    []string{"sonarr", "sonarr-4k"},
+			filePath: "/mnt/media/tv-4k/Show (2024)/Season 1/Show - S01E03.mkv",
+			wantName: "sonarr-4k",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sonarrInstances := make([]config.ArrsInstanceConfig, 0, len(tt.order))
+			for _, name := range tt.order {
+				sonarrInstances = append(sonarrInstances, config.ArrsInstanceConfig{
+					Name:    name,
+					Enabled: &enabled,
+					URL:     fakeArr(t, tt.roots[name]...),
+					APIKey:  "test",
+				})
+			}
+
+			cfg := &config.Config{
+				MountPath: "/mnt/media",
+				Arrs:      config.ArrsConfig{SonarrInstances: sonarrInstances},
+			}
+			configGetter := func() *config.Config { return cfg }
+
+			mgr := NewManager(
+				configGetter,
+				instances.NewManager(configGetter, nil),
+				clients.NewManager(nil),
+				nil, nil, nil,
+			)
+
+			gotType, gotName, err := mgr.findInstanceForFilePath(context.Background(), tt.filePath, "")
+			if err != nil {
+				t.Fatalf("findInstanceForFilePath returned error: %v", err)
+			}
+			if gotType != "sonarr" {
+				t.Errorf("gotType = %q; want %q", gotType, "sonarr")
+			}
+			if gotName != tt.wantName {
+				t.Errorf("gotName = %q; want %q", gotName, tt.wantName)
+			}
+		})
+	}
+}

--- a/internal/database/migrations/postgres/040_index_import_history_nzb_id.sql
+++ b/internal/database/migrations/postgres/040_index_import_history_nzb_id.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Deleting a queue item now also deletes its import_history copy, so the
+-- SABnzbd history view cannot resurrect a job the user removed. Those deletes
+-- filter on import_history.nzb_id, which had no index — every single, bulk and
+-- "clear completed" delete scanned the whole history table.
+CREATE INDEX IF NOT EXISTS idx_import_history_nzb_id ON import_history(nzb_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_import_history_nzb_id;
+-- +goose StatementEnd

--- a/internal/database/migrations/sqlite/040_index_import_history_nzb_id.sql
+++ b/internal/database/migrations/sqlite/040_index_import_history_nzb_id.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Deleting a queue item now also deletes its import_history copy, so the
+-- SABnzbd history view cannot resurrect a job the user removed. Those deletes
+-- filter on import_history.nzb_id, which had no index — every single, bulk and
+-- "clear completed" delete scanned the whole history table.
+CREATE INDEX IF NOT EXISTS idx_import_history_nzb_id ON import_history(nzb_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_import_history_nzb_id;
+-- +goose StatementEnd

--- a/internal/database/queue_delete_history_test.go
+++ b/internal/database/queue_delete_history_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -105,4 +106,21 @@ func TestRemoveFromQueue_LeavesUnlinkedHistoryAlone(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	assert.Equal(t, int64(101), rows[0].ID)
+}
+
+// Deleting an id that is not in the queue must still report sql.ErrNoRows (the
+// API turns that into a 404) and must not touch unrelated history rows.
+func TestRemoveFromQueue_MissingIDStillReportsNoRows(t *testing.T) {
+	repo, db := newSABHistoryRepo(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertH(t, db, 100, 42, "movies", base) // history for a queue row that is long gone
+
+	err := repo.RemoveFromQueue(ctx, 42)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+
+	rows, listErr := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, listErr)
+	assert.Len(t, rows, 1, "a failed delete must leave the history row alone")
 }

--- a/internal/database/queue_delete_history_test.go
+++ b/internal/database/queue_delete_history_test.go
@@ -1,0 +1,108 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Removing a completed import from AltMount's queue must also drop its
+// import_history copy. The SABnzbd history view is a UNION whose history arm is
+// suppressed by an anti-join only while the live completed queue row exists, so
+// deleting just the queue row resurrects the job as a fresh "Completed" slot
+// pointing at a path the ARR already imported and deleted — which makes Radarr
+// re-run DownloadedMovieImportService and fail with "path does not exist"
+// (issue #586).
+func TestRemoveFromQueue_DropsHistoryCopy(t *testing.T) {
+	repo, db := newSABHistoryRepo(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertQ(t, db, 5, "completed", "movies", base, false)
+	insertH(t, db, 100, 5, "movies", base)
+
+	// Deduped to a single slot while both rows exist.
+	total, err := repo.CountSABnzbdHistory(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, 1, total)
+
+	require.NoError(t, repo.RemoveFromQueue(ctx, 5))
+
+	total, err = repo.CountSABnzbdHistory(ctx, "")
+	require.NoError(t, err)
+	assert.Equal(t, 0, total, "history copy must not resurface after the queue row is deleted")
+
+	rows, err := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+// The same must hold for the bulk delete used by the web UI's multi-select.
+func TestRemoveFromQueueBulk_DropsHistoryCopies(t *testing.T) {
+	repo, db := newSABHistoryRepo(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertQ(t, db, 5, "completed", "movies", base, false)
+	insertH(t, db, 100, 5, "movies", base)
+	insertQ(t, db, 6, "completed", "movies", base, false)
+	insertH(t, db, 101, 6, "movies", base)
+	// An unrelated import that is not being deleted must survive untouched.
+	insertQ(t, db, 7, "completed", "tv", base, false)
+	insertH(t, db, 102, 7, "tv", base)
+
+	res, err := repo.RemoveFromQueueBulk(ctx, []int64{5, 6})
+	require.NoError(t, err)
+	require.Equal(t, 2, res.DeletedCount)
+
+	rows, err := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "only the untouched import may remain")
+	assert.Equal(t, int64(7), rows[0].ID)
+}
+
+// ...and for "Clear completed", which wipes the whole completed queue at once.
+func TestClearCompletedQueueItems_DropsHistoryCopies(t *testing.T) {
+	repo, db := newSABHistoryRepo(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertQ(t, db, 5, "completed", "movies", base, false)
+	insertH(t, db, 100, 5, "movies", base)
+	// A failed item and its (nonexistent) history must be left alone.
+	insertQ(t, db, 6, "failed", "movies", base, false)
+
+	_, count, err := repo.ClearCompletedQueueItems(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	rows, err := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "only the failed queue item may remain")
+	assert.Equal(t, int64(6), rows[0].ID)
+	assert.Equal(t, "failed_queue", rows[0].Source)
+}
+
+// A history row that was never linked to this queue id must not be collateral
+// damage: import_history rows with a NULL nzb_id are long-term history for jobs
+// whose queue rows aged out and belong to no live queue item.
+func TestRemoveFromQueue_LeavesUnlinkedHistoryAlone(t *testing.T) {
+	repo, db := newSABHistoryRepo(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertQ(t, db, 5, "completed", "movies", base, false)
+	insertH(t, db, 100, 5, "movies", base)
+	insertH(t, db, 101, 0, "movies", base) // NULL nzb_id — unrelated history
+
+	require.NoError(t, repo.RemoveFromQueue(ctx, 5))
+
+	rows, err := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, int64(101), rows[0].ID)
+}

--- a/internal/database/queue_delete_history_test.go
+++ b/internal/database/queue_delete_history_test.go
@@ -124,3 +124,20 @@ func TestRemoveFromQueue_MissingIDStillReportsNoRows(t *testing.T) {
 	require.NoError(t, listErr)
 	assert.Len(t, rows, 1, "a failed delete must leave the history row alone")
 }
+
+// The queue-delete history cleanup filters on import_history.nzb_id, which had
+// no index — every single, bulk and "clear completed" delete scanned the whole
+// history table. Migration 040 adds it.
+func TestMigration040_IndexesImportHistoryNzbID(t *testing.T) {
+	db, err := sql.Open("sqlite3", "file:mig040?mode=memory&cache=shared")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	require.NoError(t, runMigrations(db, DialectSQLite))
+
+	var n int
+	require.NoError(t, db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_import_history_nzb_id'`,
+	).Scan(&n))
+	assert.Equal(t, 1, n, "migration 040 must create the nzb_id index")
+}

--- a/internal/database/queue_repository.go
+++ b/internal/database/queue_repository.go
@@ -42,12 +42,25 @@ func NewQueueRepository(db *sql.DB, d Dialect) *QueueRepository {
 	}
 }
 
-// RemoveFromQueue removes an item from the queue
+// RemoveFromQueue removes an item from the queue together with its
+// import_history copy.
+//
+// The two rows go together: the SABnzbd history view suppresses the history
+// copy only while the live completed queue row exists, so deleting the queue
+// row alone resurrects the job as a fresh "Completed" slot pointing at a path
+// the ARR already imported and deleted (issue #586). They are deleted in one
+// transaction so a half-applied delete cannot strand a ghost that no retry can
+// reach.
 func (r *QueueRepository) RemoveFromQueue(ctx context.Context, id int64) error {
-	query := `DELETE FROM import_queue WHERE id = ?`
-	_, err := r.db.ExecContext(ctx, query, id)
-
-	return err
+	return r.withQueueTransaction(ctx, func(txRepo *QueueRepository) error {
+		if _, err := txRepo.db.ExecContext(ctx, `DELETE FROM import_queue WHERE id = ?`, id); err != nil {
+			return fmt.Errorf("failed to remove from queue: %w", err)
+		}
+		if _, err := txRepo.db.ExecContext(ctx, `DELETE FROM import_history WHERE nzb_id = ?`, id); err != nil {
+			return fmt.Errorf("failed to remove import history for queue item %d: %w", id, err)
+		}
+		return nil
+	})
 }
 
 // RemoveFromQueueBulk removes multiple items from the queue in bulk
@@ -112,6 +125,16 @@ func (r *QueueRepository) RemoveFromQueueBulk(ctx context.Context, ids []int64) 
 
 			if len(deleteIDs) == 0 {
 				continue
+			}
+
+			// Drop the import_history copies in the same transaction, or the
+			// SABnzbd history view resurrects the deleted jobs (issue #586).
+			historyQuery := fmt.Sprintf(
+				`DELETE FROM import_history WHERE nzb_id IN (%s)`,
+				inPlaceholders(len(deleteIDs)),
+			)
+			if _, err := txRepo.db.ExecContext(ctx, historyQuery, deleteIDs...); err != nil {
+				return fmt.Errorf("failed to bulk delete import history: %w", err)
 			}
 
 			// One query: delete all eligible ids in the chunk.

--- a/internal/database/queue_repository_history_test.go
+++ b/internal/database/queue_repository_history_test.go
@@ -1,0 +1,83 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// QueueRepository is the second, older type exposing RemoveFromQueue /
+// RemoveFromQueueBulk (DB.Repository is one of these, and the importer calls
+// through it). It must give the same "queue row and its history copy go
+// together" guarantee as Repository, or the SABnzbd history view resurrects the
+// job exactly as in issue #586.
+func newQueueRepoWithHistory(t *testing.T) (*QueueRepository, *Repository, *sql.DB) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	setupQueueSchema(t, db)
+	setupImportHistorySchema(t, db)
+	t.Cleanup(func() { _ = db.Close() })
+	return NewQueueRepository(db, DialectSQLite), NewRepository(db, DialectSQLite), db
+}
+
+func TestQueueRepository_RemoveFromQueue_DropsHistoryCopy(t *testing.T) {
+	qrepo, repo, db := newQueueRepoWithHistory(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertQ(t, db, 5, "completed", "movies", base, false)
+	insertH(t, db, 100, 5, "movies", base)
+
+	require.NoError(t, qrepo.RemoveFromQueue(ctx, 5))
+
+	rows, err := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, err)
+	assert.Empty(t, rows, "history copy must not resurface after the queue row is deleted")
+}
+
+func TestQueueRepository_RemoveFromQueueBulk_DropsHistoryCopies(t *testing.T) {
+	qrepo, repo, db := newQueueRepoWithHistory(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertQ(t, db, 5, "completed", "movies", base, false)
+	insertH(t, db, 100, 5, "movies", base)
+	insertQ(t, db, 6, "completed", "movies", base, false)
+	insertH(t, db, 101, 6, "movies", base)
+	// Untouched import must survive.
+	insertQ(t, db, 7, "completed", "tv", base, false)
+	insertH(t, db, 102, 7, "tv", base)
+
+	res, err := qrepo.RemoveFromQueueBulk(ctx, []int64{5, 6})
+	require.NoError(t, err)
+	require.Equal(t, 2, res.DeletedCount)
+
+	rows, err := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "only the untouched import may remain")
+	assert.Equal(t, int64(7), rows[0].ID)
+}
+
+// A processing item is refused, and its history copy must be left alone too.
+func TestQueueRepository_RemoveFromQueueBulk_SkipsProcessingAndItsHistory(t *testing.T) {
+	qrepo, repo, db := newQueueRepoWithHistory(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertQ(t, db, 8, "processing", "movies", base, false)
+	insertH(t, db, 103, 8, "movies", base)
+
+	res, _ := qrepo.RemoveFromQueueBulk(ctx, []int64{8})
+	require.Equal(t, 0, res.DeletedCount)
+	require.Equal(t, 1, res.ProcessingCount)
+
+	rows, err := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, err)
+	assert.Len(t, rows, 1, "a refused delete must leave the history row in place")
+}

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -605,32 +605,36 @@ func (r *Repository) RemoveFromQueueBulk(ctx context.Context, ids []int64) (*Bul
 		}, fmt.Errorf("cannot delete %d items that are currently being processed", processingCount)
 	}
 
-	// Drop the import_history copies of the same jobs before their queue rows
-	// go away, or the SABnzbd history view resurrects them (issue #586).
+	// The history copies and the queue rows go together, in one transaction:
+	// a half-applied delete either resurrects the job in the SABnzbd history
+	// view or drops history with no queue cleanup to match (issue #586).
 	historyQuery := fmt.Sprintf(
 		`DELETE FROM import_history WHERE nzb_id IN (SELECT id FROM import_queue WHERE id IN (%s) AND status != ?)`,
 		strings.Join(placeholders, ","))
-	historyArgs := make([]any, 0, len(args)+1)
-	historyArgs = append(historyArgs, args...)
-	historyArgs = append(historyArgs, QueueStatusProcessing)
-	if _, err := r.db.ExecContext(ctx, historyQuery, historyArgs...); err != nil {
-		return nil, fmt.Errorf("failed to remove import history for queue items: %w", err)
-	}
-
-	// Delete items that are not processing
 	deleteQuery := fmt.Sprintf(`DELETE FROM import_queue WHERE id IN (%s) AND status != ?`, strings.Join(placeholders, ","))
-	deleteArgs := make([]any, 0, len(args)+1)
-	deleteArgs = append(deleteArgs, args...)
-	deleteArgs = append(deleteArgs, QueueStatusProcessing)
 
-	result, err := r.db.ExecContext(ctx, deleteQuery, deleteArgs...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to remove items from queue: %w", err)
-	}
+	txArgs := make([]any, 0, len(args)+1)
+	txArgs = append(txArgs, args...)
+	txArgs = append(txArgs, QueueStatusProcessing)
 
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get rows affected: %w", err)
+	var rowsAffected int64
+	if err := r.WithTransaction(ctx, func(tx *Repository) error {
+		if _, err := tx.db.ExecContext(ctx, historyQuery, txArgs...); err != nil {
+			return fmt.Errorf("failed to remove import history for queue items: %w", err)
+		}
+
+		result, err := tx.db.ExecContext(ctx, deleteQuery, txArgs...)
+		if err != nil {
+			return fmt.Errorf("failed to remove items from queue: %w", err)
+		}
+
+		rowsAffected, err = result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to get rows affected: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return &BulkOperationResult{
@@ -1028,43 +1032,57 @@ func (r *Repository) clearQueueItemsByStatus(ctx context.Context, statuses ...Qu
 		args = append(args, s)
 	}
 
-	paths := []string{}
+	// The path listing and both deletes run in one transaction. Reading the
+	// paths outside it let a row that entered the target status in between be
+	// deleted without its nzb_path ever reaching the caller for on-disk
+	// cleanup, and splitting the two deletes could leave history dropped with
+	// the queue rows still present (issue #586).
 	selectQuery := fmt.Sprintf(`SELECT nzb_path FROM import_queue WHERE status IN (%s)`, placeholders)
-	rows, err := r.db.QueryContext(ctx, selectQuery, args...)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to list queue paths: %w", err)
-	}
-	for rows.Next() {
-		var p string
-		if err := rows.Scan(&p); err != nil {
-			rows.Close()
-			return nil, 0, fmt.Errorf("failed to scan queue path: %w", err)
-		}
-		if p != "" {
-			paths = append(paths, p)
-		}
-	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
-		return nil, 0, err
-	}
-
-	// Drop the import_history copies of the same jobs before their queue rows
-	// go away, or the SABnzbd history view resurrects them (issue #586).
 	historyQuery := fmt.Sprintf(
 		`DELETE FROM import_history WHERE nzb_id IN (SELECT id FROM import_queue WHERE status IN (%s))`, placeholders)
-	if _, err := r.db.ExecContext(ctx, historyQuery, args...); err != nil {
-		return nil, 0, fmt.Errorf("failed to clear import history for queue items: %w", err)
-	}
-
 	deleteQuery := fmt.Sprintf(`DELETE FROM import_queue WHERE status IN (%s)`, placeholders)
-	result, err := r.db.ExecContext(ctx, deleteQuery, args...)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to clear queue items: %w", err)
-	}
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get rows affected: %w", err)
+
+	paths := []string{}
+	var rowsAffected int64
+	if err := r.WithTransaction(ctx, func(tx *Repository) error {
+		rows, err := tx.db.QueryContext(ctx, selectQuery, args...)
+		if err != nil {
+			return fmt.Errorf("failed to list queue paths: %w", err)
+		}
+		func() {
+			defer rows.Close()
+			for rows.Next() {
+				var p string
+				if err = rows.Scan(&p); err != nil {
+					return
+				}
+				if p != "" {
+					paths = append(paths, p)
+				}
+			}
+			if err == nil {
+				err = rows.Err()
+			}
+		}()
+		if err != nil {
+			return fmt.Errorf("failed to scan queue paths: %w", err)
+		}
+
+		if _, err := tx.db.ExecContext(ctx, historyQuery, args...); err != nil {
+			return fmt.Errorf("failed to clear import history for queue items: %w", err)
+		}
+
+		result, err := tx.db.ExecContext(ctx, deleteQuery, args...)
+		if err != nil {
+			return fmt.Errorf("failed to clear queue items: %w", err)
+		}
+		rowsAffected, err = result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to get rows affected: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, 0, err
 	}
 	return paths, int(rowsAffected), nil
 }

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -512,6 +512,14 @@ func (r *Repository) RemoveFromQueue(ctx context.Context, id int64) error {
 		return sql.ErrNoRows
 	}
 
+	// Drop the import_history copy of the same job. The SABnzbd history view
+	// suppresses that copy only while the live completed queue row exists, so
+	// leaving it behind resurrects the job as a fresh "Completed" slot pointing
+	// at a path the ARR already imported and deleted (issue #586).
+	if _, err := r.db.ExecContext(ctx, `DELETE FROM import_history WHERE nzb_id = ?`, id); err != nil {
+		return fmt.Errorf("failed to remove import history for queue item %d: %w", id, err)
+	}
+
 	return nil
 }
 
@@ -595,9 +603,23 @@ func (r *Repository) RemoveFromQueueBulk(ctx context.Context, ids []int64) (*Bul
 		}, fmt.Errorf("cannot delete %d items that are currently being processed", processingCount)
 	}
 
+	// Drop the import_history copies of the same jobs before their queue rows
+	// go away, or the SABnzbd history view resurrects them (issue #586).
+	historyQuery := fmt.Sprintf(
+		`DELETE FROM import_history WHERE nzb_id IN (SELECT id FROM import_queue WHERE id IN (%s) AND status != ?)`,
+		strings.Join(placeholders, ","))
+	historyArgs := make([]any, 0, len(args)+1)
+	historyArgs = append(historyArgs, args...)
+	historyArgs = append(historyArgs, QueueStatusProcessing)
+	if _, err := r.db.ExecContext(ctx, historyQuery, historyArgs...); err != nil {
+		return nil, fmt.Errorf("failed to remove import history for queue items: %w", err)
+	}
+
 	// Delete items that are not processing
 	deleteQuery := fmt.Sprintf(`DELETE FROM import_queue WHERE id IN (%s) AND status != ?`, strings.Join(placeholders, ","))
-	deleteArgs := append(args, QueueStatusProcessing)
+	deleteArgs := make([]any, 0, len(args)+1)
+	deleteArgs = append(deleteArgs, args...)
+	deleteArgs = append(deleteArgs, QueueStatusProcessing)
 
 	result, err := r.db.ExecContext(ctx, deleteQuery, deleteArgs...)
 	if err != nil {
@@ -1023,6 +1045,14 @@ func (r *Repository) clearQueueItemsByStatus(ctx context.Context, statuses ...Qu
 	rows.Close()
 	if err := rows.Err(); err != nil {
 		return nil, 0, err
+	}
+
+	// Drop the import_history copies of the same jobs before their queue rows
+	// go away, or the SABnzbd history view resurrects them (issue #586).
+	historyQuery := fmt.Sprintf(
+		`DELETE FROM import_history WHERE nzb_id IN (SELECT id FROM import_queue WHERE status IN (%s))`, placeholders)
+	if _, err := r.db.ExecContext(ctx, historyQuery, args...); err != nil {
+		return nil, 0, fmt.Errorf("failed to clear import history for queue items: %w", err)
 	}
 
 	deleteQuery := fmt.Sprintf(`DELETE FROM import_queue WHERE status IN (%s)`, placeholders)

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -496,31 +496,33 @@ func (r *Repository) DeleteQueueItemsByPath(ctx context.Context, path string) er
 
 // RemoveFromQueue removes an item from the queue
 func (r *Repository) RemoveFromQueue(ctx context.Context, id int64) error {
-	query := `DELETE FROM import_queue WHERE id = ?`
+	// The queue row and its import_history copy go together: the SABnzbd
+	// history view suppresses the history copy only while the live completed
+	// queue row exists, so a half-applied delete resurrects the job as a fresh
+	// "Completed" slot pointing at a path the ARR already imported and deleted
+	// (issue #586). Deleting the queue row alone would also be unrecoverable —
+	// a retry can no longer find the item to clean up after.
+	return r.WithTransaction(ctx, func(tx *Repository) error {
+		result, err := tx.db.ExecContext(ctx, `DELETE FROM import_queue WHERE id = ?`, id)
+		if err != nil {
+			return fmt.Errorf("failed to remove from queue: %w", err)
+		}
 
-	result, err := r.db.ExecContext(ctx, query, id)
-	if err != nil {
-		return fmt.Errorf("failed to remove from queue: %w", err)
-	}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to get rows affected: %w", err)
+		}
 
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
-	}
+		if rowsAffected == 0 {
+			return sql.ErrNoRows
+		}
 
-	if rowsAffected == 0 {
-		return sql.ErrNoRows
-	}
+		if _, err := tx.db.ExecContext(ctx, `DELETE FROM import_history WHERE nzb_id = ?`, id); err != nil {
+			return fmt.Errorf("failed to remove import history for queue item %d: %w", id, err)
+		}
 
-	// Drop the import_history copy of the same job. The SABnzbd history view
-	// suppresses that copy only while the live completed queue row exists, so
-	// leaving it behind resurrects the job as a fresh "Completed" slot pointing
-	// at a path the ARR already imported and deleted (issue #586).
-	if _, err := r.db.ExecContext(ctx, `DELETE FROM import_history WHERE nzb_id = ?`, id); err != nil {
-		return fmt.Errorf("failed to remove import history for queue item %d: %w", id, err)
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // RemoveFromHistoryByDownloadID removes a record from import_history by its DownloadID

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -2378,28 +2378,6 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 	cfg := mvf.configGetter()
 	healthEnabled := cfg.GetHealthEnabled()
 
-	// A 430 mid-stream is not proof the article is gone. The reader never
-	// retries ErrArticleNotFound, so one provider answering 430 transiently
-	// (backend desync) was enough to move a healthy file's metadata into the
-	// corrupted folder and make the ARR redownload it, while re-importing the
-	// same NZB minutes later verified clean (issue #749). Re-STAT the segment
-	// once and bail out when it turns out to be reachable.
-	//
-	// Only a proven-present article stops the repair. An unresolved re-check
-	// (transport error, no pool) falls through to the previous behaviour, so a
-	// briefly unhealthy pool cannot silently suppress repairs — the same
-	// direction validation.go takes for sweep results (#861).
-	//
-	// The debounce token taken above stays spent: a genuine failure on this
-	// path can be delayed by at most one debounce window, and the read itself
-	// has already failed, so the next attempt re-triggers.
-	if !mvf.confirmSegmentMissing(ctx, dataCorruptionErr) {
-		slog.WarnContext(ctx, "Streaming failure not confirmed on re-check, skipping repair",
-			"file", mvf.name,
-			"segment_id", dataCorruptionErr.SegmentID)
-		return
-	}
-
 	// Classify playback impact via the hole model — the verdict decides
 	// whether this failure triggers a repair at all. Note that with hole
 	// hooks wired, within-caps misses are zero-filled and never reach this
@@ -2407,6 +2385,49 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 	classification := mvf.classifyStreamingFailure(dataCorruptionErr)
 	isDegraded := healthEnabled && classification != nil &&
 		classification.Verdict == holes.VerdictDegraded
+
+	// A 430 mid-stream is not proof the article is gone. The reader never
+	// retries ErrArticleNotFound, so one provider answering 430 transiently
+	// (backend desync) was enough to hide a healthy file behind
+	// FILE_STATUS_CORRUPTED and make the ARR redownload it, while re-importing
+	// the same NZB minutes later verified clean (issue #749). Re-STAT the
+	// segment once and stop here when it turns out to be reachable.
+	//
+	// This runs while the caller holds mvf.mu, so it must not be paid on reads
+	// that would not act on it anyway: a degraded verdict is zero-filled and
+	// still playable, and takes no destructive action below. Everything past
+	// this point does — even with the health system disabled the file is marked
+	// corrupted, which hides it from listings and blocks opens.
+	//
+	// Only a proven-present article stops the repair. An unresolved re-check
+	// (transport error, no pool) falls through to the previous behaviour, so a
+	// briefly unhealthy pool cannot silently suppress repairs — the same
+	// direction validation.go takes for sweep results (#861).
+	//
+	// The failure is still recorded as pending rather than dropped, so a
+	// segment that is only intermittently reachable is re-checked properly by
+	// the health worker instead of stalling playback forever with no repair.
+	// The debounce token taken above stays spent: a genuine failure here can be
+	// delayed by at most one debounce window, and the read has already failed,
+	// so the next attempt re-triggers.
+	if !isDegraded && !mvf.confirmSegmentMissing(ctx, dataCorruptionErr) {
+		slog.WarnContext(ctx, "Streaming failure not confirmed on re-check, deferring to the health worker",
+			"file", mvf.name,
+			"segment_id", dataCorruptionErr.SegmentID)
+
+		errMsg := dataCorruptionErr.Error()
+		sourceNzb := &mvf.meta.SourceNzbPath
+		if *sourceNzb == "" {
+			sourceNzb = nil
+		}
+		if err := mvf.healthRepository.UpdateFileHealthScheduled(ctx,
+			mvf.name, database.HealthStatusPending, &errMsg, sourceNzb, nil, true, time.Now().UTC(),
+		); err != nil {
+			slog.WarnContext(ctx, "Failed to schedule health re-check after an unconfirmed streaming failure",
+				"file", mvf.name, "error", err)
+		}
+		return
+	}
 
 	// A missing article is PAR2-repairable regardless of eligibility for
 	// zero-fill (RAR/AES streams fail here instead of padding). Queue a
@@ -2574,9 +2595,10 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 }
 
 // missRecheckTimeout bounds the single re-STAT that confirms a mid-stream
-// article miss. A 430 answer can take about a second on some providers, so this
-// is generous enough to get a verdict without eating the caller's 5 s budget.
-const missRecheckTimeout = 3 * time.Second
+// article miss. A 430 answer takes about a second on some providers, so this
+// leaves headroom for one while capping how long the caller's mvf.mu is held
+// against a provider that never answers.
+const missRecheckTimeout = 1500 * time.Millisecond
 
 // confirmSegmentMissing re-checks a segment that a stream read reported as
 // missing, returning false only when the article is provably still there.

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -2378,6 +2378,28 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 	cfg := mvf.configGetter()
 	healthEnabled := cfg.GetHealthEnabled()
 
+	// A 430 mid-stream is not proof the article is gone. The reader never
+	// retries ErrArticleNotFound, so one provider answering 430 transiently
+	// (backend desync) was enough to move a healthy file's metadata into the
+	// corrupted folder and make the ARR redownload it, while re-importing the
+	// same NZB minutes later verified clean (issue #749). Re-STAT the segment
+	// once and bail out when it turns out to be reachable.
+	//
+	// Only a proven-present article stops the repair. An unresolved re-check
+	// (transport error, no pool) falls through to the previous behaviour, so a
+	// briefly unhealthy pool cannot silently suppress repairs — the same
+	// direction validation.go takes for sweep results (#861).
+	//
+	// The debounce token taken above stays spent: a genuine failure on this
+	// path can be delayed by at most one debounce window, and the read itself
+	// has already failed, so the next attempt re-triggers.
+	if !mvf.confirmSegmentMissing(ctx, dataCorruptionErr) {
+		slog.WarnContext(ctx, "Streaming failure not confirmed on re-check, skipping repair",
+			"file", mvf.name,
+			"segment_id", dataCorruptionErr.SegmentID)
+		return
+	}
+
 	// Classify playback impact via the hole model — the verdict decides
 	// whether this failure triggers a repair at all. Note that with hole
 	// hooks wired, within-caps misses are zero-filled and never reach this
@@ -2549,6 +2571,37 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 	); err != nil {
 		slog.WarnContext(ctx, "Failed to update health database for streaming failure", "file", mvf.name, "error", err)
 	}
+}
+
+// missRecheckTimeout bounds the single re-STAT that confirms a mid-stream
+// article miss. A 430 answer can take about a second on some providers, so this
+// is generous enough to get a verdict without eating the caller's 5 s budget.
+const missRecheckTimeout = 3 * time.Second
+
+// confirmSegmentMissing re-checks a segment that a stream read reported as
+// missing, returning false only when the article is provably still there.
+//
+// Anything else — a confirmed 430, a transport error, no pool, no segment id,
+// or a failure that was never an article-not-found in the first place — returns
+// true so the caller proceeds exactly as it did before. See the call site for
+// why "unresolved" must not stop a repair.
+func (mvf *MetadataVirtualFile) confirmSegmentMissing(ctx context.Context, dcErr *usenet.DataCorruptionError) bool {
+	if !usenet.IsArticleNotFound(dcErr.UnderlyingErr) || dcErr.SegmentID == "" || mvf.poolManager == nil {
+		return true
+	}
+
+	usenetPool, err := mvf.poolManager.GetPool()
+	if err != nil || usenetPool == nil {
+		return true
+	}
+
+	statCtx, cancel := context.WithTimeout(ctx, missRecheckTimeout)
+	defer cancel()
+
+	if _, err := usenetPool.Stat(statCtx, dcErr.SegmentID); err != nil {
+		return true
+	}
+	return false
 }
 
 // readFullContext reads exactly len(buf) bytes from r, but returns early

--- a/internal/nzbfilesystem/streaming_miss_reverify_test.go
+++ b/internal/nzbfilesystem/streaming_miss_reverify_test.go
@@ -1,0 +1,173 @@
+package nzbfilesystem
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/javi11/nntppool/v4"
+	"github.com/kipsilabs/altmount/internal/config"
+	"github.com/kipsilabs/altmount/internal/database"
+	"github.com/kipsilabs/altmount/internal/metadata"
+	metapb "github.com/kipsilabs/altmount/internal/metadata/proto"
+	"github.com/kipsilabs/altmount/internal/testsupport/fakepool"
+	"github.com/kipsilabs/altmount/internal/usenet"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const reverifySegmentID = "a@b.example.com"
+
+// newImportedStreamFile wires an mvf whose file is already imported (health row
+// carries a library_path), so the repair branch would move its metadata to the
+// corrupted safety folder.
+func newImportedStreamFile(
+	t *testing.T, ctx context.Context, filePath string,
+	repo *database.HealthRepository, db *sql.DB, ms *metadata.MetadataService,
+	seg []*metapb.SegmentData, fp *fakepool.Client,
+) *MetadataVirtualFile {
+	t.Helper()
+
+	_, err := db.Exec(
+		`INSERT INTO file_health (file_path, library_path, status, scheduled_check_at) VALUES (?, ?, 'healthy', datetime('now'))`,
+		filePath, "/media/library/"+filePath,
+	)
+	require.NoError(t, err)
+
+	enabled := true
+	cfg := config.DefaultConfig()
+	cfg.Health.Enabled = &enabled
+	cfg.MountPath = ""
+
+	mvf := newStreamFailureMVF(ctx, filePath, repo, ms, seg, cfg)
+	if fp != nil {
+		mvf.poolManager = newFakePoolManager(fp)
+	}
+	return mvf
+}
+
+// A single 430 mid-stream is not proof the article is gone: providers return it
+// transiently (backend desync), and the reader never retries an
+// ErrArticleNotFound. Condemning on that evidence moved a healthy file's
+// metadata into the corrupted folder and made the ARR redownload it, while
+// re-importing the very same NZB minutes later verified clean (issue #749).
+func TestUpdateFileHealthOnError_TransientMissIsNotCondemned(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	repo, db, ms := setupStreamHealthEnv(t)
+	ctx := context.Background()
+
+	filePath := "series/stream.s01e10.mkv"
+	seg := writeStreamMeta(t, ms, filePath)
+
+	// The re-check finds the article present: the 430 was transient.
+	fp := fakepool.New()
+	fp.SetBehavior(reverifySegmentID, fakepool.SegmentBehavior{Bytes: []byte("present")})
+
+	mvf := newImportedStreamFile(t, ctx, filePath, repo, db, ms, seg, fp)
+	mvf.updateFileHealthOnError(&usenet.DataCorruptionError{
+		UnderlyingErr: nntppool.ErrArticleNotFound,
+		SegmentID:     reverifySegmentID,
+		NoRetry:       true,
+		FileOffset:    -1,
+	}, true)
+
+	fh, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	if fh != nil {
+		assert.NotEqual(t, database.HealthStatusRepairTriggered, fh.Status,
+			"a re-check that finds the article present must not trigger a repair")
+	}
+
+	original, readErr := ms.ReadFileMetadata(filePath)
+	require.NoError(t, readErr)
+	assert.NotNil(t, original, "metadata must stay put when the miss is not confirmed")
+	assert.False(t, mvf.metadataGone.Load(), "handle must not latch closed on an unconfirmed miss")
+}
+
+// A re-check that confirms the 430 keeps the existing repair behavior.
+func TestUpdateFileHealthOnError_ConfirmedMissStillTriggersRepair(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	repo, db, ms := setupStreamHealthEnv(t)
+	ctx := context.Background()
+
+	filePath := "series/stream.s01e11.mkv"
+	seg := writeStreamMeta(t, ms, filePath)
+
+	fp := fakepool.New()
+	fp.SetBehavior(reverifySegmentID, fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+	mvf := newImportedStreamFile(t, ctx, filePath, repo, db, ms, seg, fp)
+	mvf.updateFileHealthOnError(&usenet.DataCorruptionError{
+		UnderlyingErr: nntppool.ErrArticleNotFound,
+		SegmentID:     reverifySegmentID,
+		NoRetry:       true,
+		FileOffset:    -1,
+	}, true)
+
+	fh, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	assert.Equal(t, database.HealthStatusRepairTriggered, fh.Status,
+		"a confirmed miss must still trigger the repair")
+
+	original, readErr := ms.ReadFileMetadata(filePath)
+	require.NoError(t, readErr)
+	assert.Nil(t, original, "a confirmed miss must still move the metadata away")
+}
+
+// When the re-check cannot resolve the question — transport error, no pool —
+// behaviour is unchanged: the failure is treated as before rather than newly
+// suppressing repairs whenever the pool is briefly unhealthy.
+func TestUpdateFileHealthOnError_UnresolvedRecheckKeepsPreviousBehaviour(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+
+	tests := []struct {
+		name string
+		pool func() *fakepool.Client
+	}{
+		{
+			name: "transport error during re-check",
+			pool: func() *fakepool.Client {
+				fp := fakepool.New()
+				fp.SetBehavior(reverifySegmentID, fakepool.SegmentBehavior{Err: errors.New("connection reset")})
+				return fp
+			},
+		},
+		{
+			name: "no pool configured",
+			pool: func() *fakepool.Client { return nil },
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, db, ms := setupStreamHealthEnv(t)
+			ctx := context.Background()
+
+			filePath := "series/stream.s01e2" + string(rune('0'+i)) + ".mkv"
+			seg := writeStreamMeta(t, ms, filePath)
+
+			mvf := newImportedStreamFile(t, ctx, filePath, repo, db, ms, seg, tt.pool())
+			mvf.updateFileHealthOnError(&usenet.DataCorruptionError{
+				UnderlyingErr: nntppool.ErrArticleNotFound,
+				SegmentID:     reverifySegmentID,
+				NoRetry:       true,
+				FileOffset:    -1,
+			}, true)
+
+			fh, err := repo.GetFileHealth(ctx, filePath)
+			require.NoError(t, err)
+			require.NotNil(t, fh)
+			assert.Equal(t, database.HealthStatusRepairTriggered, fh.Status)
+		})
+	}
+}

--- a/internal/nzbfilesystem/streaming_miss_reverify_test.go
+++ b/internal/nzbfilesystem/streaming_miss_reverify_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"runtime"
 	"testing"
 
@@ -20,6 +21,36 @@ import (
 )
 
 const reverifySegmentID = "a@b.example.com"
+
+// writeStreamMetaN writes metadata for a file of n equally sized segments, the
+// first of which carries reverifySegmentID. A single missing segment out of n
+// stays under every hole threshold, so it classifies as degraded rather than
+// failed — which writeStreamMeta's single-segment file cannot do.
+func writeStreamMetaN(t *testing.T, ms *metadata.MetadataService, filePath string, n int) []*metapb.SegmentData {
+	t.Helper()
+
+	const segSize = 1024
+	segs := make([]*metapb.SegmentData, n)
+	for i := range segs {
+		id := fmt.Sprintf("seg%d@example.com", i)
+		if i == 0 {
+			id = reverifySegmentID
+		}
+		segs[i] = &metapb.SegmentData{
+			Id:          id,
+			SegmentSize: segSize,
+			StartOffset: 0,
+			EndOffset:   segSize - 1,
+		}
+	}
+
+	meta := ms.CreateFileMetadata(
+		int64(n)*segSize, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		segs, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	require.NoError(t, ms.WriteFileMetadata(filePath, meta))
+	return meta.SegmentData
+}
 
 // newImportedStreamFile wires an mvf whose file is already imported (health row
 // carries a library_path), so the repair branch would move its metadata to the
@@ -78,15 +109,50 @@ func TestUpdateFileHealthOnError_TransientMissIsNotCondemned(t *testing.T) {
 
 	fh, err := repo.GetFileHealth(ctx, filePath)
 	require.NoError(t, err)
-	if fh != nil {
-		assert.NotEqual(t, database.HealthStatusRepairTriggered, fh.Status,
-			"a re-check that finds the article present must not trigger a repair")
-	}
+	require.NotNil(t, fh)
+	assert.Equal(t, database.HealthStatusPending, fh.Status,
+		"an unconfirmed miss must be handed to the health worker, not repaired and not forgotten")
 
 	original, readErr := ms.ReadFileMetadata(filePath)
 	require.NoError(t, readErr)
 	assert.NotNil(t, original, "metadata must stay put when the miss is not confirmed")
 	assert.False(t, mvf.metadataGone.Load(), "handle must not latch closed on an unconfirmed miss")
+}
+
+// The re-check costs a network round-trip while the caller holds mvf.mu, which
+// a concurrent foreground read on the same handle would block on. It must
+// therefore only run when something destructive would otherwise follow: a
+// degraded verdict is zero-filled and still playable, so it must not pay for a
+// STAT at all.
+func TestUpdateFileHealthOnError_DegradedMissSkipsTheRecheck(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	repo, db, ms := setupStreamHealthEnv(t)
+	ctx := context.Background()
+
+	filePath := "series/stream.s01e12.mkv"
+	seg := writeStreamMetaN(t, ms, filePath, 512)
+
+	fp := fakepool.New()
+	fp.SetBehavior(reverifySegmentID, fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+	mvf := newImportedStreamFile(t, ctx, filePath, repo, db, ms, seg, fp)
+	// A single missing segment in a large file classifies as degraded.
+	mvf.updateFileHealthOnError(&usenet.DataCorruptionError{
+		UnderlyingErr: nntppool.ErrArticleNotFound,
+		SegmentID:     reverifySegmentID,
+		NoRetry:       true,
+		FileOffset:    0,
+	}, true)
+
+	fh, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	require.Equal(t, database.HealthStatusDegraded, fh.Status,
+		"precondition: this failure must classify as degraded")
+	assert.Zero(t, fp.StatCalls(),
+		"a degraded (still playable) failure must not pay for a re-check on the read path")
 }
 
 // A re-check that confirms the 430 keeps the existing repair behavior.


### PR DESCRIPTION
Three independent bugs found while triaging the open issue list, each with a confirmed root cause in code, plus the docs fix for #676.

## 1. ARR repairs went to the wrong instance — `fix(arrs)` · refs #749

`findInstanceForFilePath` scored root-folder ownership with a raw `strings.HasPrefix` and returned the **first** instance that matched. With a `Sonarr` rooted at `/mnt/media/tv` and a `Sonarr-4k` rooted at `/mnt/media/tv-4k`, `/mnt/media/tv-4k/...` prefix-matches `/mnt/media/tv`, so the 1080p instance claimed the file, found no such series, and the repair died with `no series found containing file path` — exactly the log in #749. The import log in that same report shows the real owner was `Sonarr-4k`.

Root folders are now matched on path-segment boundaries and scored by length, with the most specific root winning across all instances. That also makes a nested root (`/media/tv/anime`) beat its parent regardless of config order.

The four `*ManagesFile` helpers and `managesFile` return an `int` score instead of a `bool`; `managesFile` has exactly one caller.

Strategy 1 now queries every enabled instance's root folders before deciding, rather than stopping at the first match — inherent to longest-match, at the cost of one extra API round-trip per additional configured instance.

**Behaviour change to be aware of:** a path that only matched the old loose prefix (e.g. root `/media/tv`, file `/media/tv2/x`) no longer matches Strategy 1. Those fall through to the existing Strategy 2 (category) and Strategy 3 (relative-path) fallbacks rather than being silently misrouted.

## 2. Removing a completed item made Radarr re-import it — `fix(queue)` · fixes #586

The SABnzbd history view is a UNION whose `import_history` arm is suppressed by an anti-join **only while the live completed queue row exists**:

```sql
LEFT JOIN import_queue q ON q.id = h.nzb_id AND q.status = 'completed' ...
WHERE q.id IS NULL
```

The SABnzbd-side delete already removed both rows — its comment literally says *"Also remove from history if it existed there (to prevent ghost items)"* — but the web UI's delete, bulk delete and clear-completed paths removed only the queue row. Deleting from the UI therefore resurrected the job as a fresh `Completed` slot pointing at a path Radarr had already imported and deleted, so Radarr re-ran `DownloadedMovieImportService` and failed with *"Import failed, path does not exist"*.

The history cleanup now lives in the repository, so every caller is consistent, and `RemoveFromQueue` is wrapped in a transaction — a half-applied delete is unrecoverable, since a retry can no longer find the item to clean up after.

Audited every caller of the three delete paths: the importer's rollback (no history row exists yet), the SABnzbd-fallback transfer and the Stremio cleanup all *want* the history row gone. `sql.ErrNoRows` still propagates unchanged (pinned by a test).

Two types expose these methods and had to be fixed together: `database.Repository` (what the API handlers and Stremio cleanup hold) and `database.QueueRepository` (reachable as `DB.Repository`, what the importer uses). Fixing only the first left them silently divergent, so the next caller added to the importer's completion path would have reproduced this bug while looking correct.

All three paths are now transactional. `clearQueueItemsByStatus` also moved its `SELECT nzb_path` inside the transaction — reading it outside let a row that entered the target status in between be deleted without its path ever reaching the caller for on-disk cleanup.

Migration 040 adds `idx_import_history_nzb_id` (sqlite + postgres): every one of these deletes filters on that column, which had no index.

Also removed an `append(args, ...)` aliasing hazard between the count and delete queries in `RemoveFromQueueBulk`.

**Deliberate trade-off, please sanity-check:** because `/api/import/history` (the recent-imports list in the UI) reads the same `import_history` table, deleting or clearing completed queue items now also drops those entries from that list. For a single delete this already happened via the SABnzbd path; the new exposure is bulk delete and clear-completed. I think "delete the job → it's gone everywhere" is the coherent reading, but the alternative is a schema column marking a history row as hidden-from-SAB rather than deleting it. Happy to switch if you'd rather keep the import history intact.

## 3. A single 430 condemned a healthy file mid-playback — `fix(streaming)` · refs #749

The reader never retries `ErrArticleNotFound` (`usenet_reader.go`, `retry.RetryIf`), and the failure handler treated one 430 as definitive — *"we skip the re-verification phase because a streaming failure is a definitive indicator of corruption"* — moving the file's metadata into the corrupted safety folder and triggering an ARR redownload. Providers return 430 transiently, which is why the reporter's file verified clean when the same NZB was re-imported minutes later.

The failing segment is now re-STATed once before any destructive action. **Only a proven-present article stops the repair**; an unresolved re-check (transport error, no pool, no segment id) falls through to the previous behaviour, so a briefly unhealthy pool cannot silently suppress repairs. That matches the direction `validation.go` already takes for sweep results (#861) and the importer took in #921 — this was the last path still trusting a single 430.

The check is deliberately placed *after* the hole classification and gated on `!isDegraded`, because it runs while the caller holds `mvf.mu` and `internal/fuse/backend/asyncbuffer.go` calls `ReadAtContext` on the same handle from both its foreground and read-ahead paths — an unguarded check could stall an active playback read. A degraded verdict is zero-filled and still playable and takes no destructive action, so it now pays nothing. It is *not* gated on `healthEnabled`: that path still sets `FILE_STATUS_CORRUPTED`, which hides the file from listings and blocks opens.

It sits before `IncrementStreamingFailureCount` on purpose. That counter is cumulative and its UPDATE latches `is_masked`, which makes a file return `fs.ErrNotExist` — so letting transient misses accumulate would hide a healthy file from the mount after `threshold` (3, per `config.sample.yaml`) transient 430s. Same bug class, slower.

An unconfirmed miss is recorded as `pending` with immediate scheduling rather than dropped, so a segment that is only intermittently reachable is verified by the health worker instead of failing playback forever with no repair.

Bounded at 1.5 s, and the existing 30 s per-path repair debounce caps it at once per file per window — on the exception path only, since with hole hooks wired most misses are zero-filled and never reach this function.

## 4. Documented prefetch default — `docs(streaming)` · fixes #676

Code has defaulted `max_prefetch` to 60 for a while (`config.sample.yaml` already said so) but the config table and the performance/troubleshooting guides still said 30, and told users to "increase" it to 45 — *below* what they were actually running.

---

## Verification

- `make test` (the exact CI target) — all 62 packages pass
- `go test -race ./internal/nzbfilesystem/` — clean
- `cd docs && bun run build` — passes
- `make lint` fails identically at base commit `f4ddaeda` (local Go 1.27 vs the pinned golangci-lint: `export data version 4 is greater than maximum supported version 2`). Unrelated to this branch; CI pins Go 1.27.0 and runs `make test`, not lint.

Every fix was written test-first and each test was confirmed to fail against the old behaviour for the right reason:

- `internal/arrs/scanner/root_folder_match_test.go` — sibling roots sharing a prefix, exact root, nested-root precedence, trailing-slash tolerance. Uses real starr clients against `httptest` ARR servers.
- `internal/database/queue_delete_history_test.go` — single/bulk/clear-completed history cleanup, unrelated history left alone, `ErrNoRows` contract.
- `internal/nzbfilesystem/streaming_miss_reverify_test.go` — transient miss deferred to the health worker, confirmed miss still repairs, unresolved re-check keeps previous behaviour, degraded miss pays no STAT (`fp.StatCalls() == 0`).
- `internal/database/queue_repository_history_test.go` — the same guarantees on `QueueRepository`, including the processing-item refusal leaving history intact.
- `TestMigration040_IndexesImportHistoryNzbID` — pins the new index.

## Not changed — flagging for a decision

`calculateHistoryStoragePath` (`internal/api/sabnzbd_handlers.go`) declares `exists := true`, logs when the reported path is missing, and **never assigns `false`** — so the whole #596 mitigation (`markHistorySlotMissing`) is unreachable today.

I deliberately left it alone. Naively flipping it on would be harmful: after an ARR imports a file the source path is legitimately gone, so those rows would start reporting `Failed` and Radarr would blocklist and re-download media it already has. Making it work as #596 intended needs an extra "and was never imported" condition (no `file_health.library_path`), which changes ARR-visible behaviour for every user and deserves its own PR.

## Remaining open issues

#838, #798, #568 and #510 need replies rather than code — happy to post those separately.
