### PR TITLE
fix(arrs): match ARR root folders on path boundaries and prefer the longest

### DIFF
--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -56,17 +56,29 @@ func (m *Manager) findInstanceForFilePath(ctx context.Context, filePath string, 
 
 	allInstances := m.instances.GetAllInstances()
 
-	// Strategy 1: Fast Path - Check Root Folders
+	// Strategy 1: Fast Path - Check Root Folders.
+	//
+	// Every instance is scored and the most specific (longest) matching root
+	// folder wins. First-match-wins sent files under "/media/tv-4k" to the
+	// instance rooted at "/media/tv" whenever that one happened to be listed
+	// first, and the same applies to a nested root such as "/media/tv/anime"
+	// (issue #749).
+	bestScore, bestType, bestName := 0, "", ""
 	for _, instance := range allInstances {
 		if !instance.Enabled {
 			continue
 		}
 
 		if client, err := m.clients.GetOrCreateClient(instance); err == nil {
-			if m.managesFile(ctx, instance.Type, client, filePath) {
-				return instance.Type, instance.Name, nil
+			if score := m.managesFile(ctx, instance.Type, client, filePath); score > bestScore {
+				bestScore, bestType, bestName = score, instance.Type, instance.Name
 			}
 		}
+	}
+	if bestScore > 0 {
+		slog.DebugContext(ctx, "Found managing instance by root folder",
+			"instance", bestName, "type", bestType, "root_len", bestScore)
+		return bestType, bestName, nil
 	}
 
 	// Strategy 2: Category Match - Check if file is in the staging/complete folder
@@ -120,40 +132,63 @@ func (m *Manager) findInstanceForFilePath(ctx context.Context, filePath string, 
 	return "", "", fmt.Errorf("no ARR instance found managing file path: %s", filePath)
 }
 
-func (m *Manager) managesFile(ctx context.Context, instanceType string, client any, filePath string) bool {
+// rootFolderScore reports how specifically rootPath claims filePath: the
+// length of the normalized root folder when filePath is that folder or lives
+// inside it, else 0. Bigger means more specific.
+//
+// Matching is on path-segment boundaries. A raw strings.HasPrefix made
+// "/media/tv" claim "/media/tv-4k/..." — sending repairs to an ARR that owns
+// no such series (issue #749).
+func rootFolderScore(filePath, rootPath string) int {
+	root := strings.TrimRight(filepath.ToSlash(rootPath), "/")
+	file := strings.TrimRight(filepath.ToSlash(filePath), "/")
+	if root == "" || file == "" {
+		return 0
+	}
+	if file == root || strings.HasPrefix(file, root+"/") {
+		return len(root)
+	}
+	return 0
+}
+
+// managesFile reports how specifically instanceType's root folders claim
+// filePath: the length of the longest matching root folder, or 0 when none
+// matches. Callers compare scores across instances so the most specific root
+// wins (see findInstanceForFilePath).
+func (m *Manager) managesFile(ctx context.Context, instanceType string, client any, filePath string) int {
 	switch instanceType {
 	case "radarr":
 		rc, ok := client.(*radarr.Radarr)
 		if !ok {
-			return false
+			return 0
 		}
 		return m.radarrManagesFile(ctx, rc, filePath)
 	case "sonarr":
 		sc, ok := client.(*sonarr.Sonarr)
 		if !ok {
-			return false
+			return 0
 		}
 		return m.sonarrManagesFile(ctx, sc, filePath)
 	case "lidarr":
 		lc, ok := client.(*lidarr.Lidarr)
 		if !ok {
-			return false
+			return 0
 		}
 		return m.lidarrManagesFile(ctx, lc, filePath)
 	case "readarr":
 		rc, ok := client.(*readarr.Readarr)
 		if !ok {
-			return false
+			return 0
 		}
 		return m.readarrManagesFile(ctx, rc, filePath)
 	case "whisparr":
 		wc, ok := client.(*sonarr.Sonarr)
 		if !ok {
-			return false
+			return 0
 		}
 		return m.sonarrManagesFile(ctx, wc, filePath)
 	default:
-		return false
+		return 0
 	}
 }
 
@@ -180,8 +215,9 @@ func (m *Manager) hasFile(ctx context.Context, instanceType string, client any, 
 	}
 }
 
-// radarrManagesFile checks if Radarr manages the given file path using root folders (checkrr approach)
-func (m *Manager) radarrManagesFile(ctx context.Context, client *radarr.Radarr, filePath string) bool {
+// radarrManagesFile scores how specifically Radarr's root folders claim
+// filePath (checkrr approach). See rootFolderScore for the match rule.
+func (m *Manager) radarrManagesFile(ctx context.Context, client *radarr.Radarr, filePath string) int {
 	slog.DebugContext(ctx, "Checking Radarr root folders for file ownership",
 		"file_path", filePath)
 
@@ -189,25 +225,27 @@ func (m *Manager) radarrManagesFile(ctx context.Context, client *radarr.Radarr, 
 	rootFolders, err := client.GetRootFoldersContext(ctx)
 	if err != nil {
 		slog.DebugContext(ctx, "Failed to get root folders from Radarr for file check", "error", err)
-		return false
+		return 0
 	}
 
-	// Check if file path starts with any root folder path
+	best := 0
 	for _, folder := range rootFolders {
 		slog.DebugContext(ctx, "Checking Radarr root folder", "folder_path", folder.Path, "file_path", filePath)
-		// Check for direct prefix match or if the filePath contains the folder.Path (common in Docker/Remote setups)
-		if strings.HasPrefix(filePath, folder.Path) {
+		if score := rootFolderScore(filePath, folder.Path); score > best {
 			slog.DebugContext(ctx, "File matches Radarr root folder", "folder_path", folder.Path)
-			return true
+			best = score
 		}
 	}
 
-	slog.DebugContext(ctx, "File does not match any Radarr root folders")
-	return false
+	if best == 0 {
+		slog.DebugContext(ctx, "File does not match any Radarr root folders")
+	}
+	return best
 }
 
-// sonarrManagesFile checks if Sonarr manages the given file path using root folders (checkrr approach)
-func (m *Manager) sonarrManagesFile(ctx context.Context, client *sonarr.Sonarr, filePath string) bool {
+// sonarrManagesFile scores how specifically Sonarr's root folders claim
+// filePath (checkrr approach). See rootFolderScore for the match rule.
+func (m *Manager) sonarrManagesFile(ctx context.Context, client *sonarr.Sonarr, filePath string) int {
 	slog.DebugContext(ctx, "Checking Sonarr root folders for file ownership",
 		"file_path", filePath)
 
@@ -215,52 +253,56 @@ func (m *Manager) sonarrManagesFile(ctx context.Context, client *sonarr.Sonarr, 
 	rootFolders, err := client.GetRootFoldersContext(ctx)
 	if err != nil {
 		slog.DebugContext(ctx, "Failed to get root folders from Sonarr for file check", "error", err)
-		return false
+		return 0
 	}
 
-	// Check if file path starts with any root folder path
+	best := 0
 	for _, folder := range rootFolders {
 		slog.DebugContext(ctx, "Checking Sonarr root folder", "folder_path", folder.Path, "file_path", filePath)
-		if strings.HasPrefix(filePath, folder.Path) {
+		if score := rootFolderScore(filePath, folder.Path); score > best {
 			slog.DebugContext(ctx, "File matches Sonarr root folder", "folder_path", folder.Path)
-			return true
+			best = score
 		}
 	}
 
-	slog.DebugContext(ctx, "File does not match any Sonarr root folders")
-	return false
+	if best == 0 {
+		slog.DebugContext(ctx, "File does not match any Sonarr root folders")
+	}
+	return best
 }
 
-// lidarrManagesFile checks if Lidarr manages the given file path using root folders
-func (m *Manager) lidarrManagesFile(ctx context.Context, client *lidarr.Lidarr, filePath string) bool {
+// lidarrManagesFile scores how specifically Lidarr's root folders claim filePath.
+func (m *Manager) lidarrManagesFile(ctx context.Context, client *lidarr.Lidarr, filePath string) int {
 	slog.DebugContext(ctx, "Checking Lidarr root folders for file ownership", "file_path", filePath)
 	rootFolders, err := client.GetRootFoldersContext(ctx)
 	if err != nil {
 		slog.DebugContext(ctx, "Failed to get root folders from Lidarr", "error", err)
-		return false
+		return 0
 	}
+	best := 0
 	for _, folder := range rootFolders {
-		if strings.HasPrefix(filePath, folder.Path) {
-			return true
+		if score := rootFolderScore(filePath, folder.Path); score > best {
+			best = score
 		}
 	}
-	return false
+	return best
 }
 
-// readarrManagesFile checks if Readarr manages the given file path using root folders
-func (m *Manager) readarrManagesFile(ctx context.Context, client *readarr.Readarr, filePath string) bool {
+// readarrManagesFile scores how specifically Readarr's root folders claim filePath.
+func (m *Manager) readarrManagesFile(ctx context.Context, client *readarr.Readarr, filePath string) int {
 	slog.DebugContext(ctx, "Checking Readarr root folders for file ownership", "file_path", filePath)
 	rootFolders, err := client.GetRootFoldersContext(ctx)
 	if err != nil {
 		slog.DebugContext(ctx, "Failed to get root folders from Readarr", "error", err)
-		return false
+		return 0
 	}
+	best := 0
 	for _, folder := range rootFolders {
-		if strings.HasPrefix(filePath, folder.Path) {
-			return true
+		if score := rootFolderScore(filePath, folder.Path); score > best {
+			best = score
 		}
 	}
-	return false
+	return best
 }
 
 // radarrHasFile checks if any movie in the instance contains the given relative path

--- a/internal/arrs/scanner/root_folder_match_test.go
+++ b/internal/arrs/scanner/root_folder_match_test.go
@@ -1,0 +1,142 @@
+package scanner
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kipsilabs/altmount/internal/arrs/clients"
+	"github.com/kipsilabs/altmount/internal/arrs/instances"
+	"github.com/kipsilabs/altmount/internal/config"
+)
+
+// fakeArr serves just enough of the Sonarr/Radarr v3 API for root-folder
+// ownership checks: GET /api/v3/rootFolder returning the supplied paths.
+func fakeArr(t *testing.T, rootPaths ...string) string {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/rootFolder", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body := "["
+		for i, p := range rootPaths {
+			if i > 0 {
+				body += ","
+			}
+			body += `{"id":` + string(rune('1'+i)) + `,"path":"` + p + `","accessible":true}`
+		}
+		body += "]"
+		_, _ = w.Write([]byte(body))
+	})
+	// Every other endpoint (series, movies, ...) answers with an empty list so
+	// the later fallback strategies find nothing and cannot mask a Strategy 1
+	// regression.
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// TestFindInstanceForFilePath_RootFolderBoundary pins that root-folder
+// ownership is decided on path-segment boundaries and that the most specific
+// (longest) matching root wins.
+//
+// Before the fix, root folders were matched with a raw strings.HasPrefix and
+// the first matching instance won, so a file under "/mnt/media/tv-4k" was
+// claimed by the instance rooted at "/mnt/media/tv" — sending the repair to an
+// ARR that owns no such series (issue #749).
+func TestFindInstanceForFilePath_RootFolderBoundary(t *testing.T) {
+	enabled := true
+
+	tests := []struct {
+		name     string
+		roots    map[string][]string // instance name -> root folders
+		order    []string            // config order of the sonarr instances
+		filePath string
+		wantName string
+	}{
+		{
+			name: "sibling root sharing a prefix does not claim the file",
+			roots: map[string][]string{
+				"sonarr":    {"/mnt/media/tv"},
+				"sonarr-4k": {"/mnt/media/tv-4k"},
+			},
+			order:    []string{"sonarr", "sonarr-4k"},
+			filePath: "/mnt/media/tv-4k/Show (2024)/Season 1/Show - S01E03.mkv",
+			wantName: "sonarr-4k",
+		},
+		{
+			name: "exact root still matches its own instance",
+			roots: map[string][]string{
+				"sonarr":    {"/mnt/media/tv"},
+				"sonarr-4k": {"/mnt/media/tv-4k"},
+			},
+			order:    []string{"sonarr", "sonarr-4k"},
+			filePath: "/mnt/media/tv/Show (2024)/Season 1/Show - S01E03.mkv",
+			wantName: "sonarr",
+		},
+		{
+			name: "nested root wins over its parent regardless of config order",
+			roots: map[string][]string{
+				"sonarr":       {"/mnt/media/tv"},
+				"sonarr-anime": {"/mnt/media/tv/anime"},
+			},
+			order:    []string{"sonarr", "sonarr-anime"},
+			filePath: "/mnt/media/tv/anime/Show (2024)/Season 1/Show - S01E03.mkv",
+			wantName: "sonarr-anime",
+		},
+		{
+			name: "trailing slash on the configured root is tolerated",
+			roots: map[string][]string{
+				"sonarr":    {"/mnt/media/tv/"},
+				"sonarr-4k": {"/mnt/media/tv-4k/"},
+			},
+			order:    []string{"sonarr", "sonarr-4k"},
+			filePath: "/mnt/media/tv-4k/Show (2024)/Season 1/Show - S01E03.mkv",
+			wantName: "sonarr-4k",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sonarrInstances := make([]config.ArrsInstanceConfig, 0, len(tt.order))
+			for _, name := range tt.order {
+				sonarrInstances = append(sonarrInstances, config.ArrsInstanceConfig{
+					Name:    name,
+					Enabled: &enabled,
+					URL:     fakeArr(t, tt.roots[name]...),
+					APIKey:  "test",
+				})
+			}
+
+			cfg := &config.Config{
+				MountPath: "/mnt/media",
+				Arrs:      config.ArrsConfig{SonarrInstances: sonarrInstances},
+			}
+			configGetter := func() *config.Config { return cfg }
+
+			mgr := NewManager(
+				configGetter,
+				instances.NewManager(configGetter, nil),
+				clients.NewManager(nil),
+				nil, nil, nil,
+			)
+
+			gotType, gotName, err := mgr.findInstanceForFilePath(context.Background(), tt.filePath, "")
+			if err != nil {
+				t.Fatalf("findInstanceForFilePath returned error: %v", err)
+			}
+			if gotType != "sonarr" {
+				t.Errorf("gotType = %q; want %q", gotType, "sonarr")
+			}
+			if gotName != tt.wantName {
+				t.Errorf("gotName = %q; want %q", gotName, tt.wantName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Stack 1 of 4** · base `main` · refs #749

`findInstanceForFilePath` scored root-folder ownership with a raw `strings.HasPrefix` and returned the **first** instance that matched. With a `Sonarr` rooted at `/mnt/media/tv` and a `Sonarr-4k` rooted at `/mnt/media/tv-4k`, `/mnt/media/tv-4k/...` prefix-matches `/mnt/media/tv`, so the 1080p instance claimed the file, found no such series, and the repair died with:

```
No series found in Sonarr matching file path in library, attempting queue-based failure  instance=Sonarr
Failed to re-trigger ARR rescan  error="no series found containing file path in library or queue: ..."
```

That is verbatim from #749. The import log in the same report shows the real owner was `Sonarr-4k`.

## Change

Root folders are matched on path-segment boundaries (`rootFolderScore`) and scored by length, with the most specific root winning across all instances. That also makes a nested root (`/media/tv/anime`) beat its parent regardless of config order.

The four `*ManagesFile` helpers and `managesFile` return an `int` score instead of a `bool`; `managesFile` has exactly one caller.

## Trade-offs

- Strategy 1 now queries every enabled instance's root folders before deciding rather than stopping at the first match — inherent to longest-match, at one extra API round-trip per additional configured instance.
- A path that only matched the old loose prefix (root `/media/tv`, file `/media/tv2/x`) no longer matches Strategy 1. Those fall through to the existing Strategy 2 (category) and Strategy 3 (relative-path) fallbacks rather than being silently misrouted.

## Tests

`internal/arrs/scanner/root_folder_match_test.go` — sibling roots sharing a prefix, exact root, nested-root precedence, trailing-slash tolerance. Uses real starr clients against `httptest` ARR servers. Confirmed failing against the old behaviour first (`gotName = "sonarr"; want "sonarr-4k"`).

`make test`: 62/62 packages pass on this commit alone.
