### PR TITLE
fix(queue): drop the import_history copy when a queue item is deleted

### DIFF
--- a/internal/database/clear_queue_lock_test.go
+++ b/internal/database/clear_queue_lock_test.go
@@ -1,0 +1,80 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+)
+
+// clearQueueItemsByStatus lists the nzb_paths it is about to delete and then
+// deletes, all inside one transaction. SQLite opens transactions in DEFERRED
+// mode, so if that transaction's FIRST statement is the SELECT, the connection
+// takes a read snapshot and only later tries to upgrade to a write. Under WAL,
+// an upgrade whose snapshot another connection has already invalidated returns
+// SQLITE_BUSY_SNAPSHOT, which busy_timeout deliberately does NOT retry — the
+// clear fails outright with "database is locked".
+//
+// A "clear completed" fired while the importer is committing queue updates is
+// exactly that race, so the transaction has to start with a write.
+func TestClearCompletedQueueItems_SurvivesConcurrentWriter(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "clear.db")
+	db, err := sql.Open("sqlite3", fmt.Sprintf(
+		"file:%s?_journal_mode=WAL&_synchronous=NORMAL&_busy_timeout=5000", dbPath))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(4)
+
+	setupQueueSchema(t, db)
+	setupImportHistorySchema(t, db)
+
+	repo := NewRepository(db, DialectSQLite)
+	ctx := context.Background()
+
+	// A row the concurrent writer keeps touching, so every one of its commits
+	// invalidates any read snapshot taken before it.
+	_, err = db.Exec(`INSERT INTO import_queue (id, nzb_path, status, priority) VALUES (1, 'busy.nzb', 'pending', 1)`)
+	require.NoError(t, err)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// Each UPDATE is its own committed write transaction.
+			_, _ = db.Exec(`UPDATE import_queue SET updated_at = datetime('now') WHERE id = 1`)
+		}
+	}()
+	t.Cleanup(func() {
+		close(stop)
+		wg.Wait()
+	})
+
+	base := time.Now().UTC()
+	for i := range 200 {
+		id := int64(1000 + i)
+		insertQ(t, db, id, "completed", "movies", base, false)
+		insertH(t, db, id, id, "movies", base)
+
+		paths, deleted, err := repo.ClearCompletedQueueItems(ctx)
+		if err != nil && strings.Contains(err.Error(), "locked") {
+			t.Fatalf("iteration %d: clear failed under a concurrent writer: %v", i, err)
+		}
+		require.NoErrorf(t, err, "iteration %d", i)
+		require.Equalf(t, 1, deleted, "iteration %d", i)
+		require.Lenf(t, paths, 1, "iteration %d: the deleted row's path must reach the caller for on-disk cleanup", i)
+	}
+}

--- a/internal/database/migrations/postgres/040_index_import_history_nzb_id.sql
+++ b/internal/database/migrations/postgres/040_index_import_history_nzb_id.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Deleting a queue item now also deletes its import_history copy, so the
+-- SABnzbd history view cannot resurrect a job the user removed. Those deletes
+-- filter on import_history.nzb_id, which had no index — every single, bulk and
+-- "clear completed" delete scanned the whole history table.
+CREATE INDEX IF NOT EXISTS idx_import_history_nzb_id ON import_history(nzb_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_import_history_nzb_id;
+-- +goose StatementEnd

--- a/internal/database/migrations/sqlite/040_index_import_history_nzb_id.sql
+++ b/internal/database/migrations/sqlite/040_index_import_history_nzb_id.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Deleting a queue item now also deletes its import_history copy, so the
+-- SABnzbd history view cannot resurrect a job the user removed. Those deletes
+-- filter on import_history.nzb_id, which had no index — every single, bulk and
+-- "clear completed" delete scanned the whole history table.
+CREATE INDEX IF NOT EXISTS idx_import_history_nzb_id ON import_history(nzb_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_import_history_nzb_id;
+-- +goose StatementEnd

--- a/internal/database/queue_delete_history_test.go
+++ b/internal/database/queue_delete_history_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -105,4 +106,21 @@ func TestRemoveFromQueue_LeavesUnlinkedHistoryAlone(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	assert.Equal(t, int64(101), rows[0].ID)
+}
+
+// Deleting an id that is not in the queue must still report sql.ErrNoRows (the
+// API turns that into a 404) and must not touch unrelated history rows.
+func TestRemoveFromQueue_MissingIDStillReportsNoRows(t *testing.T) {
+	repo, db := newSABHistoryRepo(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertH(t, db, 100, 42, "movies", base) // history for a queue row that is long gone
+
+	err := repo.RemoveFromQueue(ctx, 42)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+
+	rows, listErr := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, listErr)
+	assert.Len(t, rows, 1, "a failed delete must leave the history row alone")
 }

--- a/internal/database/queue_delete_history_test.go
+++ b/internal/database/queue_delete_history_test.go
@@ -1,0 +1,108 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Removing a completed import from AltMount's queue must also drop its
+// import_history copy. The SABnzbd history view is a UNION whose history arm is
+// suppressed by an anti-join only while the live completed queue row exists, so
+// deleting just the queue row resurrects the job as a fresh "Completed" slot
+// pointing at a path the ARR already imported and deleted — which makes Radarr
+// re-run DownloadedMovieImportService and fail with "path does not exist"
+// (issue #586).
+func TestRemoveFromQueue_DropsHistoryCopy(t *testing.T) {
+	repo, db := newSABHistoryRepo(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertQ(t, db, 5, "completed", "movies", base, false)
+	insertH(t, db, 100, 5, "movies", base)
+
+	// Deduped to a single slot while both rows exist.
+	total, err := repo.CountSABnzbdHistory(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, 1, total)
+
+	require.NoError(t, repo.RemoveFromQueue(ctx, 5))
+
+	total, err = repo.CountSABnzbdHistory(ctx, "")
+	require.NoError(t, err)
+	assert.Equal(t, 0, total, "history copy must not resurface after the queue row is deleted")
+
+	rows, err := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+// The same must hold for the bulk delete used by the web UI's multi-select.
+func TestRemoveFromQueueBulk_DropsHistoryCopies(t *testing.T) {
+	repo, db := newSABHistoryRepo(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertQ(t, db, 5, "completed", "movies", base, false)
+	insertH(t, db, 100, 5, "movies", base)
+	insertQ(t, db, 6, "completed", "movies", base, false)
+	insertH(t, db, 101, 6, "movies", base)
+	// An unrelated import that is not being deleted must survive untouched.
+	insertQ(t, db, 7, "completed", "tv", base, false)
+	insertH(t, db, 102, 7, "tv", base)
+
+	res, err := repo.RemoveFromQueueBulk(ctx, []int64{5, 6})
+	require.NoError(t, err)
+	require.Equal(t, 2, res.DeletedCount)
+
+	rows, err := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "only the untouched import may remain")
+	assert.Equal(t, int64(7), rows[0].ID)
+}
+
+// ...and for "Clear completed", which wipes the whole completed queue at once.
+func TestClearCompletedQueueItems_DropsHistoryCopies(t *testing.T) {
+	repo, db := newSABHistoryRepo(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertQ(t, db, 5, "completed", "movies", base, false)
+	insertH(t, db, 100, 5, "movies", base)
+	// A failed item and its (nonexistent) history must be left alone.
+	insertQ(t, db, 6, "failed", "movies", base, false)
+
+	_, count, err := repo.ClearCompletedQueueItems(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	rows, err := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "only the failed queue item may remain")
+	assert.Equal(t, int64(6), rows[0].ID)
+	assert.Equal(t, "failed_queue", rows[0].Source)
+}
+
+// A history row that was never linked to this queue id must not be collateral
+// damage: import_history rows with a NULL nzb_id are long-term history for jobs
+// whose queue rows aged out and belong to no live queue item.
+func TestRemoveFromQueue_LeavesUnlinkedHistoryAlone(t *testing.T) {
+	repo, db := newSABHistoryRepo(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertQ(t, db, 5, "completed", "movies", base, false)
+	insertH(t, db, 100, 5, "movies", base)
+	insertH(t, db, 101, 0, "movies", base) // NULL nzb_id — unrelated history
+
+	require.NoError(t, repo.RemoveFromQueue(ctx, 5))
+
+	rows, err := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, int64(101), rows[0].ID)
+}

--- a/internal/database/queue_delete_history_test.go
+++ b/internal/database/queue_delete_history_test.go
@@ -124,3 +124,20 @@ func TestRemoveFromQueue_MissingIDStillReportsNoRows(t *testing.T) {
 	require.NoError(t, listErr)
 	assert.Len(t, rows, 1, "a failed delete must leave the history row alone")
 }
+
+// The queue-delete history cleanup filters on import_history.nzb_id, which had
+// no index — every single, bulk and "clear completed" delete scanned the whole
+// history table. Migration 040 adds it.
+func TestMigration040_IndexesImportHistoryNzbID(t *testing.T) {
+	db, err := sql.Open("sqlite3", "file:mig040?mode=memory&cache=shared")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	require.NoError(t, runMigrations(db, DialectSQLite))
+
+	var n int
+	require.NoError(t, db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_import_history_nzb_id'`,
+	).Scan(&n))
+	assert.Equal(t, 1, n, "migration 040 must create the nzb_id index")
+}

--- a/internal/database/queue_repository.go
+++ b/internal/database/queue_repository.go
@@ -42,12 +42,25 @@ func NewQueueRepository(db *sql.DB, d Dialect) *QueueRepository {
 	}
 }
 
-// RemoveFromQueue removes an item from the queue
+// RemoveFromQueue removes an item from the queue together with its
+// import_history copy.
+//
+// The two rows go together: the SABnzbd history view suppresses the history
+// copy only while the live completed queue row exists, so deleting the queue
+// row alone resurrects the job as a fresh "Completed" slot pointing at a path
+// the ARR already imported and deleted (issue #586). They are deleted in one
+// transaction so a half-applied delete cannot strand a ghost that no retry can
+// reach.
 func (r *QueueRepository) RemoveFromQueue(ctx context.Context, id int64) error {
-	query := `DELETE FROM import_queue WHERE id = ?`
-	_, err := r.db.ExecContext(ctx, query, id)
-
-	return err
+	return r.withQueueTransaction(ctx, func(txRepo *QueueRepository) error {
+		if _, err := txRepo.db.ExecContext(ctx, `DELETE FROM import_queue WHERE id = ?`, id); err != nil {
+			return fmt.Errorf("failed to remove from queue: %w", err)
+		}
+		if _, err := txRepo.db.ExecContext(ctx, `DELETE FROM import_history WHERE nzb_id = ?`, id); err != nil {
+			return fmt.Errorf("failed to remove import history for queue item %d: %w", id, err)
+		}
+		return nil
+	})
 }
 
 // RemoveFromQueueBulk removes multiple items from the queue in bulk
@@ -112,6 +125,16 @@ func (r *QueueRepository) RemoveFromQueueBulk(ctx context.Context, ids []int64) 
 
 			if len(deleteIDs) == 0 {
 				continue
+			}
+
+			// Drop the import_history copies in the same transaction, or the
+			// SABnzbd history view resurrects the deleted jobs (issue #586).
+			historyQuery := fmt.Sprintf(
+				`DELETE FROM import_history WHERE nzb_id IN (%s)`,
+				inPlaceholders(len(deleteIDs)),
+			)
+			if _, err := txRepo.db.ExecContext(ctx, historyQuery, deleteIDs...); err != nil {
+				return fmt.Errorf("failed to bulk delete import history: %w", err)
 			}
 
 			// One query: delete all eligible ids in the chunk.

--- a/internal/database/queue_repository_history_test.go
+++ b/internal/database/queue_repository_history_test.go
@@ -1,0 +1,83 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// QueueRepository is the second, older type exposing RemoveFromQueue /
+// RemoveFromQueueBulk (DB.Repository is one of these, and the importer calls
+// through it). It must give the same "queue row and its history copy go
+// together" guarantee as Repository, or the SABnzbd history view resurrects the
+// job exactly as in issue #586.
+func newQueueRepoWithHistory(t *testing.T) (*QueueRepository, *Repository, *sql.DB) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	setupQueueSchema(t, db)
+	setupImportHistorySchema(t, db)
+	t.Cleanup(func() { _ = db.Close() })
+	return NewQueueRepository(db, DialectSQLite), NewRepository(db, DialectSQLite), db
+}
+
+func TestQueueRepository_RemoveFromQueue_DropsHistoryCopy(t *testing.T) {
+	qrepo, repo, db := newQueueRepoWithHistory(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertQ(t, db, 5, "completed", "movies", base, false)
+	insertH(t, db, 100, 5, "movies", base)
+
+	require.NoError(t, qrepo.RemoveFromQueue(ctx, 5))
+
+	rows, err := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, err)
+	assert.Empty(t, rows, "history copy must not resurface after the queue row is deleted")
+}
+
+func TestQueueRepository_RemoveFromQueueBulk_DropsHistoryCopies(t *testing.T) {
+	qrepo, repo, db := newQueueRepoWithHistory(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertQ(t, db, 5, "completed", "movies", base, false)
+	insertH(t, db, 100, 5, "movies", base)
+	insertQ(t, db, 6, "completed", "movies", base, false)
+	insertH(t, db, 101, 6, "movies", base)
+	// Untouched import must survive.
+	insertQ(t, db, 7, "completed", "tv", base, false)
+	insertH(t, db, 102, 7, "tv", base)
+
+	res, err := qrepo.RemoveFromQueueBulk(ctx, []int64{5, 6})
+	require.NoError(t, err)
+	require.Equal(t, 2, res.DeletedCount)
+
+	rows, err := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "only the untouched import may remain")
+	assert.Equal(t, int64(7), rows[0].ID)
+}
+
+// A processing item is refused, and its history copy must be left alone too.
+func TestQueueRepository_RemoveFromQueueBulk_SkipsProcessingAndItsHistory(t *testing.T) {
+	qrepo, repo, db := newQueueRepoWithHistory(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	insertQ(t, db, 8, "processing", "movies", base, false)
+	insertH(t, db, 103, 8, "movies", base)
+
+	res, _ := qrepo.RemoveFromQueueBulk(ctx, []int64{8})
+	require.Equal(t, 0, res.DeletedCount)
+	require.Equal(t, 1, res.ProcessingCount)
+
+	rows, err := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, err)
+	assert.Len(t, rows, 1, "a refused delete must leave the history row in place")
+}

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -605,32 +605,36 @@ func (r *Repository) RemoveFromQueueBulk(ctx context.Context, ids []int64) (*Bul
 		}, fmt.Errorf("cannot delete %d items that are currently being processed", processingCount)
 	}
 
-	// Drop the import_history copies of the same jobs before their queue rows
-	// go away, or the SABnzbd history view resurrects them (issue #586).
+	// The history copies and the queue rows go together, in one transaction:
+	// a half-applied delete either resurrects the job in the SABnzbd history
+	// view or drops history with no queue cleanup to match (issue #586).
 	historyQuery := fmt.Sprintf(
 		`DELETE FROM import_history WHERE nzb_id IN (SELECT id FROM import_queue WHERE id IN (%s) AND status != ?)`,
 		strings.Join(placeholders, ","))
-	historyArgs := make([]any, 0, len(args)+1)
-	historyArgs = append(historyArgs, args...)
-	historyArgs = append(historyArgs, QueueStatusProcessing)
-	if _, err := r.db.ExecContext(ctx, historyQuery, historyArgs...); err != nil {
-		return nil, fmt.Errorf("failed to remove import history for queue items: %w", err)
-	}
-
-	// Delete items that are not processing
 	deleteQuery := fmt.Sprintf(`DELETE FROM import_queue WHERE id IN (%s) AND status != ?`, strings.Join(placeholders, ","))
-	deleteArgs := make([]any, 0, len(args)+1)
-	deleteArgs = append(deleteArgs, args...)
-	deleteArgs = append(deleteArgs, QueueStatusProcessing)
 
-	result, err := r.db.ExecContext(ctx, deleteQuery, deleteArgs...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to remove items from queue: %w", err)
-	}
+	txArgs := make([]any, 0, len(args)+1)
+	txArgs = append(txArgs, args...)
+	txArgs = append(txArgs, QueueStatusProcessing)
 
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get rows affected: %w", err)
+	var rowsAffected int64
+	if err := r.WithTransaction(ctx, func(tx *Repository) error {
+		if _, err := tx.db.ExecContext(ctx, historyQuery, txArgs...); err != nil {
+			return fmt.Errorf("failed to remove import history for queue items: %w", err)
+		}
+
+		result, err := tx.db.ExecContext(ctx, deleteQuery, txArgs...)
+		if err != nil {
+			return fmt.Errorf("failed to remove items from queue: %w", err)
+		}
+
+		rowsAffected, err = result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to get rows affected: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return &BulkOperationResult{
@@ -1028,43 +1032,57 @@ func (r *Repository) clearQueueItemsByStatus(ctx context.Context, statuses ...Qu
 		args = append(args, s)
 	}
 
-	paths := []string{}
+	// The path listing and both deletes run in one transaction. Reading the
+	// paths outside it let a row that entered the target status in between be
+	// deleted without its nzb_path ever reaching the caller for on-disk
+	// cleanup, and splitting the two deletes could leave history dropped with
+	// the queue rows still present (issue #586).
 	selectQuery := fmt.Sprintf(`SELECT nzb_path FROM import_queue WHERE status IN (%s)`, placeholders)
-	rows, err := r.db.QueryContext(ctx, selectQuery, args...)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to list queue paths: %w", err)
-	}
-	for rows.Next() {
-		var p string
-		if err := rows.Scan(&p); err != nil {
-			rows.Close()
-			return nil, 0, fmt.Errorf("failed to scan queue path: %w", err)
-		}
-		if p != "" {
-			paths = append(paths, p)
-		}
-	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
-		return nil, 0, err
-	}
-
-	// Drop the import_history copies of the same jobs before their queue rows
-	// go away, or the SABnzbd history view resurrects them (issue #586).
 	historyQuery := fmt.Sprintf(
 		`DELETE FROM import_history WHERE nzb_id IN (SELECT id FROM import_queue WHERE status IN (%s))`, placeholders)
-	if _, err := r.db.ExecContext(ctx, historyQuery, args...); err != nil {
-		return nil, 0, fmt.Errorf("failed to clear import history for queue items: %w", err)
-	}
-
 	deleteQuery := fmt.Sprintf(`DELETE FROM import_queue WHERE status IN (%s)`, placeholders)
-	result, err := r.db.ExecContext(ctx, deleteQuery, args...)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to clear queue items: %w", err)
-	}
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get rows affected: %w", err)
+
+	paths := []string{}
+	var rowsAffected int64
+	if err := r.WithTransaction(ctx, func(tx *Repository) error {
+		rows, err := tx.db.QueryContext(ctx, selectQuery, args...)
+		if err != nil {
+			return fmt.Errorf("failed to list queue paths: %w", err)
+		}
+		func() {
+			defer rows.Close()
+			for rows.Next() {
+				var p string
+				if err = rows.Scan(&p); err != nil {
+					return
+				}
+				if p != "" {
+					paths = append(paths, p)
+				}
+			}
+			if err == nil {
+				err = rows.Err()
+			}
+		}()
+		if err != nil {
+			return fmt.Errorf("failed to scan queue paths: %w", err)
+		}
+
+		if _, err := tx.db.ExecContext(ctx, historyQuery, args...); err != nil {
+			return fmt.Errorf("failed to clear import history for queue items: %w", err)
+		}
+
+		result, err := tx.db.ExecContext(ctx, deleteQuery, args...)
+		if err != nil {
+			return fmt.Errorf("failed to clear queue items: %w", err)
+		}
+		rowsAffected, err = result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to get rows affected: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, 0, err
 	}
 	return paths, int(rowsAffected), nil
 }

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -512,6 +512,14 @@ func (r *Repository) RemoveFromQueue(ctx context.Context, id int64) error {
 		return sql.ErrNoRows
 	}
 
+	// Drop the import_history copy of the same job. The SABnzbd history view
+	// suppresses that copy only while the live completed queue row exists, so
+	// leaving it behind resurrects the job as a fresh "Completed" slot pointing
+	// at a path the ARR already imported and deleted (issue #586).
+	if _, err := r.db.ExecContext(ctx, `DELETE FROM import_history WHERE nzb_id = ?`, id); err != nil {
+		return fmt.Errorf("failed to remove import history for queue item %d: %w", id, err)
+	}
+
 	return nil
 }
 
@@ -595,9 +603,23 @@ func (r *Repository) RemoveFromQueueBulk(ctx context.Context, ids []int64) (*Bul
 		}, fmt.Errorf("cannot delete %d items that are currently being processed", processingCount)
 	}
 
+	// Drop the import_history copies of the same jobs before their queue rows
+	// go away, or the SABnzbd history view resurrects them (issue #586).
+	historyQuery := fmt.Sprintf(
+		`DELETE FROM import_history WHERE nzb_id IN (SELECT id FROM import_queue WHERE id IN (%s) AND status != ?)`,
+		strings.Join(placeholders, ","))
+	historyArgs := make([]any, 0, len(args)+1)
+	historyArgs = append(historyArgs, args...)
+	historyArgs = append(historyArgs, QueueStatusProcessing)
+	if _, err := r.db.ExecContext(ctx, historyQuery, historyArgs...); err != nil {
+		return nil, fmt.Errorf("failed to remove import history for queue items: %w", err)
+	}
+
 	// Delete items that are not processing
 	deleteQuery := fmt.Sprintf(`DELETE FROM import_queue WHERE id IN (%s) AND status != ?`, strings.Join(placeholders, ","))
-	deleteArgs := append(args, QueueStatusProcessing)
+	deleteArgs := make([]any, 0, len(args)+1)
+	deleteArgs = append(deleteArgs, args...)
+	deleteArgs = append(deleteArgs, QueueStatusProcessing)
 
 	result, err := r.db.ExecContext(ctx, deleteQuery, deleteArgs...)
 	if err != nil {
@@ -1023,6 +1045,14 @@ func (r *Repository) clearQueueItemsByStatus(ctx context.Context, statuses ...Qu
 	rows.Close()
 	if err := rows.Err(); err != nil {
 		return nil, 0, err
+	}
+
+	// Drop the import_history copies of the same jobs before their queue rows
+	// go away, or the SABnzbd history view resurrects them (issue #586).
+	historyQuery := fmt.Sprintf(
+		`DELETE FROM import_history WHERE nzb_id IN (SELECT id FROM import_queue WHERE status IN (%s))`, placeholders)
+	if _, err := r.db.ExecContext(ctx, historyQuery, args...); err != nil {
+		return nil, 0, fmt.Errorf("failed to clear import history for queue items: %w", err)
 	}
 
 	deleteQuery := fmt.Sprintf(`DELETE FROM import_queue WHERE status IN (%s)`, placeholders)

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -496,31 +496,33 @@ func (r *Repository) DeleteQueueItemsByPath(ctx context.Context, path string) er
 
 // RemoveFromQueue removes an item from the queue
 func (r *Repository) RemoveFromQueue(ctx context.Context, id int64) error {
-	query := `DELETE FROM import_queue WHERE id = ?`
+	// The queue row and its import_history copy go together: the SABnzbd
+	// history view suppresses the history copy only while the live completed
+	// queue row exists, so a half-applied delete resurrects the job as a fresh
+	// "Completed" slot pointing at a path the ARR already imported and deleted
+	// (issue #586). Deleting the queue row alone would also be unrecoverable —
+	// a retry can no longer find the item to clean up after.
+	return r.WithTransaction(ctx, func(tx *Repository) error {
+		result, err := tx.db.ExecContext(ctx, `DELETE FROM import_queue WHERE id = ?`, id)
+		if err != nil {
+			return fmt.Errorf("failed to remove from queue: %w", err)
+		}
 
-	result, err := r.db.ExecContext(ctx, query, id)
-	if err != nil {
-		return fmt.Errorf("failed to remove from queue: %w", err)
-	}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to get rows affected: %w", err)
+		}
 
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
-	}
+		if rowsAffected == 0 {
+			return sql.ErrNoRows
+		}
 
-	if rowsAffected == 0 {
-		return sql.ErrNoRows
-	}
+		if _, err := tx.db.ExecContext(ctx, `DELETE FROM import_history WHERE nzb_id = ?`, id); err != nil {
+			return fmt.Errorf("failed to remove import history for queue item %d: %w", id, err)
+		}
 
-	// Drop the import_history copy of the same job. The SABnzbd history view
-	// suppresses that copy only while the live completed queue row exists, so
-	// leaving it behind resurrects the job as a fresh "Completed" slot pointing
-	// at a path the ARR already imported and deleted (issue #586).
-	if _, err := r.db.ExecContext(ctx, `DELETE FROM import_history WHERE nzb_id = ?`, id); err != nil {
-		return fmt.Errorf("failed to remove import history for queue item %d: %w", id, err)
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // RemoveFromHistoryByDownloadID removes a record from import_history by its DownloadID

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -1037,14 +1037,27 @@ func (r *Repository) clearQueueItemsByStatus(ctx context.Context, statuses ...Qu
 	// deleted without its nzb_path ever reaching the caller for on-disk
 	// cleanup, and splitting the two deletes could leave history dropped with
 	// the queue rows still present (issue #586).
-	selectQuery := fmt.Sprintf(`SELECT nzb_path FROM import_queue WHERE status IN (%s)`, placeholders)
+	//
+	// The history delete goes FIRST so the transaction opens with a write.
+	// SQLite transactions are DEFERRED: leading with the SELECT would take a
+	// read snapshot and only then try to upgrade to a write, and under WAL an
+	// upgrade whose snapshot a concurrent commit has invalidated returns
+	// SQLITE_BUSY_SNAPSHOT — which busy_timeout does not retry. A "clear
+	// completed" fired while the importer commits would simply fail with
+	// "database is locked". Writing first takes the write lock up front, which
+	// busy_timeout does wait for.
 	historyQuery := fmt.Sprintf(
 		`DELETE FROM import_history WHERE nzb_id IN (SELECT id FROM import_queue WHERE status IN (%s))`, placeholders)
+	selectQuery := fmt.Sprintf(`SELECT nzb_path FROM import_queue WHERE status IN (%s)`, placeholders)
 	deleteQuery := fmt.Sprintf(`DELETE FROM import_queue WHERE status IN (%s)`, placeholders)
 
 	paths := []string{}
 	var rowsAffected int64
 	if err := r.WithTransaction(ctx, func(tx *Repository) error {
+		if _, err := tx.db.ExecContext(ctx, historyQuery, args...); err != nil {
+			return fmt.Errorf("failed to clear import history for queue items: %w", err)
+		}
+
 		rows, err := tx.db.QueryContext(ctx, selectQuery, args...)
 		if err != nil {
 			return fmt.Errorf("failed to list queue paths: %w", err)
@@ -1066,10 +1079,6 @@ func (r *Repository) clearQueueItemsByStatus(ctx context.Context, statuses ...Qu
 		}()
 		if err != nil {
 			return fmt.Errorf("failed to scan queue paths: %w", err)
-		}
-
-		if _, err := tx.db.ExecContext(ctx, historyQuery, args...); err != nil {
-			return fmt.Errorf("failed to clear import history for queue items: %w", err)
 		}
 
 		result, err := tx.db.ExecContext(ctx, deleteQuery, args...)

--- a/internal/health/library_sync.go
+++ b/internal/health/library_sync.go
@@ -103,6 +103,28 @@ func NewLibrarySyncWorker(
 
 const lastLibrarySyncResultKey = "last_library_sync_result"
 
+// recentSymlinkImportGuard is how long a freshly created symlink is protected
+// from orphan cleanup on the strength of its own age alone.
+//
+// Orphan cleanup also skips symlinks that still have an import_history row, but
+// that anchor is not permanent: deleting a queue item drops its history copy
+// (issue #586), and history is pruned wholesale at import.history_retention_days.
+// A user clearing the completed queue must not be able to strip the protection
+// off a symlink whose ARR import is still in flight, so the link's own mtime —
+// which no database cleanup can reach — backs the guard up.
+const recentSymlinkImportGuard = 24 * time.Hour
+
+// symlinkWithinImportGuard reports whether info describes a symlink young
+// enough that an ARR import may still be running for it. A mtime in the future
+// (clock skew, a restored backup) counts as recent: the guard fails safe
+// towards keeping the file.
+func symlinkWithinImportGuard(info os.FileInfo, now time.Time) bool {
+	if info == nil || info.Mode()&os.ModeSymlink == 0 {
+		return false
+	}
+	return info.ModTime().After(now.Add(-recentSymlinkImportGuard))
+}
+
 // LoadLastResult loads the last sync result from the database
 func (lsw *LibrarySyncWorker) LoadLastResult(ctx context.Context) error {
 	data, err := lsw.healthRepo.GetSystemState(ctx, lastLibrarySyncResultKey)
@@ -935,6 +957,14 @@ func (lsw *LibrarySyncWorker) SyncLibrary(ctx context.Context, dryRun bool) *Dry
 						// Only delete if it's actually a symlink
 						if info.Mode()&os.ModeSymlink == 0 {
 							slog.WarnContext(ctx, "Skipped orphaned file deletion: not a symlink", "path", file)
+							continue
+						}
+
+						// Protect symlinks young enough that an ARR import may
+						// still be in flight, whatever the database says.
+						if symlinkWithinImportGuard(info, time.Now()) {
+							slog.InfoContext(ctx, "Skipping orphaned symlink deletion: created too recently for an ARR import to have finished",
+								"path", file, "created", info.ModTime())
 							continue
 						}
 

--- a/internal/health/library_sync_symlink_guard_test.go
+++ b/internal/health/library_sync_symlink_guard_test.go
@@ -1,0 +1,64 @@
+package health
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// agedInfo restates a real Lstat result with a different mtime. Backdating a
+// symlink on disk needs lutimes, which the standard library does not expose
+// (os.Chtimes follows the link), and the guard only ever reads Mode and
+// ModTime.
+type agedInfo struct {
+	fs.FileInfo
+	mtime time.Time
+}
+
+func (a agedInfo) ModTime() time.Time { return a.mtime }
+
+// Orphan cleanup protects symlinks that AltMount imported, so an ARR still
+// mid-import does not lose the file underneath it. That protection used to rest
+// solely on an import_history row, but deleting a queue item now drops its
+// history copy (issue #586) — so a user tidying the completed queue could strip
+// the guard off a symlink whose import was still in flight. The symlink's own
+// age is an anchor no database cleanup can take away.
+func TestSymlinkWithinImportGuard(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+
+	link := filepath.Join(dir, "movie.mkv")
+	require.NoError(t, os.Symlink(filepath.Join(dir, "target.mkv"), link))
+	linkInfo, err := os.Lstat(link)
+	require.NoError(t, err)
+
+	plainFile := filepath.Join(dir, "plain.mkv")
+	require.NoError(t, os.WriteFile(plainFile, []byte("x"), 0o644))
+	fileInfo, err := os.Lstat(plainFile)
+	require.NoError(t, err)
+
+	assert.True(t, symlinkWithinImportGuard(linkInfo, now),
+		"a symlink created moments ago may still have an ARR import in flight")
+
+	stale := agedInfo{FileInfo: linkInfo, mtime: now.Add(-recentSymlinkImportGuard - time.Hour)}
+	assert.False(t, symlinkWithinImportGuard(stale, now),
+		"a symlink older than the guard window is a normal cleanup candidate")
+
+	// Right on the boundary the link is already outside the window.
+	edge := agedInfo{FileInfo: linkInfo, mtime: now.Add(-recentSymlinkImportGuard)}
+	assert.False(t, symlinkWithinImportGuard(edge, now))
+
+	// A future mtime (clock skew, a restored backup) must not read as ancient.
+	skewed := agedInfo{FileInfo: linkInfo, mtime: now.Add(2 * time.Hour)}
+	assert.True(t, symlinkWithinImportGuard(skewed, now),
+		"clock skew must fail safe towards keeping the file")
+
+	assert.False(t, symlinkWithinImportGuard(fileInfo, now),
+		"the guard covers symlinks only; regular files have their own safety checks")
+	assert.False(t, symlinkWithinImportGuard(nil, now))
+}


### PR DESCRIPTION
**Stack 2 of 4** · base `stack/1-arr-root-folder` (#928) · fixes #586

Only the last commits are new here; the diff against stack 1 is `internal/database/` plus two migrations.

## The bug

The SABnzbd history view is a UNION whose `import_history` arm is suppressed by an anti-join **only while the live completed queue row exists**:

```sql
LEFT JOIN import_queue q ON q.id = h.nzb_id AND q.status = 'completed' ...
WHERE q.id IS NULL
```

The SABnzbd-side delete already removed both rows — its comment literally says *"Also remove from history if it existed there (to prevent ghost items)"* — but the web UI's delete, bulk delete and clear-completed paths removed only the queue row. Deleting from the UI therefore resurrected the job as a fresh `Completed` slot pointing at a path Radarr had already imported and deleted, so Radarr re-ran `DownloadedMovieImportService` and failed with *"Import failed, path does not exist"*.

## Change

The history cleanup now lives in the repository so every caller is consistent, and all three paths are transactional — a half-applied delete is unrecoverable, since a retry can no longer find the item to clean up after.

Two types expose these methods and had to be fixed together: `database.Repository` (what the API handlers and Stremio cleanup hold) and `database.QueueRepository` (reachable as `DB.Repository`, what the importer uses). Fixing only the first left them silently divergent, so the next caller added to the importer's completion path would have reproduced this bug while looking correct.

`clearQueueItemsByStatus` also moved its `SELECT nzb_path` inside the transaction — reading it outside let a row that entered the target status in between be deleted without its path ever reaching the caller for on-disk cleanup.

Migration 040 adds `idx_import_history_nzb_id` (sqlite + postgres): every one of these deletes filters on that column, which had no index.

Also removed an `append(args, ...)` aliasing hazard between the count and delete queries in `RemoveFromQueueBulk`.

## Caller audit

The importer's rollback (no history row exists yet), the SABnzbd-fallback transfer and the Stremio cleanup all *want* the history row gone. `sql.ErrNoRows` still propagates unchanged (pinned by a test).

## Deliberate trade-off — please sanity-check

`/api/import/history` (the recent-imports list in the UI) reads the same `import_history` table, so deleting or clearing completed queue items now also drops those entries from that list. For a single delete this already happened via the SABnzbd path; the new exposure is bulk delete and clear-completed.

I think "delete the job → it's gone everywhere" is the coherent reading, but the alternative is a schema column marking a history row hidden-from-SAB rather than deleting it. Happy to switch if you'd rather keep the import history intact.

## Tests

- `internal/database/queue_delete_history_test.go` — single, bulk and clear-completed cleanup; unrelated (NULL `nzb_id`) history left alone; `ErrNoRows` contract; migration 040 creates the index.
- `internal/database/queue_repository_history_test.go` — the same guarantees on `QueueRepository`, including the processing-item refusal leaving history intact.

All confirmed failing against the old behaviour first. `make test`: 62/62 packages pass on this commit alone.
