### PR TITLE
fix(streaming): recover from a transient article miss instead of condemning the file

### DIFF
--- a/internal/nzbfilesystem/issue749_transient_miss_test.go
+++ b/internal/nzbfilesystem/issue749_transient_miss_test.go
@@ -1,0 +1,161 @@
+package nzbfilesystem
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javi11/nntppool/v4"
+	"github.com/kipsilabs/altmount/internal/config"
+	"github.com/kipsilabs/altmount/internal/database"
+	"github.com/kipsilabs/altmount/internal/metadata"
+	metapb "github.com/kipsilabs/altmount/internal/metadata/proto"
+	"github.com/kipsilabs/altmount/internal/testsupport/fakepool"
+	"github.com/kipsilabs/altmount/internal/testsupport/segments"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// issue749_transient_miss_test.go reproduces the report end to end, through
+// the real FUSE read path rather than by calling the health handler:
+//
+//	"I have a file that altmount complained corrupted when playing half way.
+//	 But then when the file is re-added, the file can be added and in healthy
+//	 condition. I am also able to continue the playback."
+//
+// A provider answers 430 for a segment that is still there. Before the fix the
+// read failed, the metadata moved to the corrupted safety folder, and the ARR
+// was asked to redownload a healthy release.
+
+// writeMetaForTestFile persists metadata matching what newTestMVF builds in
+// memory, so the "was it moved to the corrupted folder?" assertions below have
+// a real file to check.
+func writeMetaForTestFile(t *testing.T, ms *metadata.MetadataService, filePath string, n, segSize int) {
+	t.Helper()
+	meta := ms.CreateFileMetadata(
+		int64(n*segSize), "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		buildSegmentData(t, n, segSize), metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	require.NoError(t, ms.WriteFileMetadata(filePath, meta))
+}
+
+// TestIssue749_TransientMissDoesNotBreakPlaybackOrCondemnTheFile: playback
+// must survive and the file must be left alone.
+func TestIssue749_TransientMissDoesNotBreakPlaybackOrCondemnTheFile(t *testing.T) {
+	const (
+		segCount = 4
+		segSize  = 1024
+	)
+
+	repo, db, ms := setupStreamHealthEnv(t)
+	ctx := context.Background()
+
+	filePath := "series/transient.s01e03.mkv"
+	_, err := db.Exec(
+		`INSERT INTO file_health (file_path, library_path, status, scheduled_check_at, streaming_failure_count)
+		 VALUES (?, ?, 'healthy', datetime('now'), 0)`,
+		filePath, "/media/library/transient.s01e03.mkv",
+	)
+	require.NoError(t, err)
+	writeMetaForTestFile(t, ms, filePath, segCount, segSize)
+
+	fp := fakepool.New()
+	configurePoolForFile(fp, segCount, segSize, fakepool.SegmentBehavior{})
+	// Segment 2 answers 430 once — a desynced backend — then serves normally,
+	// like the release that verified clean on re-import.
+	fp.SetBehavior(segments.MessageID(2), fakepool.SegmentBehavior{
+		Bytes:     segments.Payload(2, segSize),
+		FailFirst: 1,
+		FailErr:   nntppool.ErrArticleNotFound,
+	})
+
+	healthEnabled := true
+	maskingEnabled := true
+	cfg := config.DefaultConfig()
+	cfg.Health.Enabled = &healthEnabled
+	cfg.Streaming.FailureMasking.Enabled = &maskingEnabled
+	cfg.Streaming.FailureMasking.Threshold = 3
+	cfg.MountPath = ""
+
+	mvf := withConfig(newTestMVF(t, ctx, fp, segCount, segSize, 2), cfg)
+	mvf.name = filePath
+	mvf.healthRepository = repo
+	mvf.metadataService = ms
+	// Clip boundaries keep the file ineligible for hole padding, so a miss
+	// fails the read instead of being zero-filled.
+	mvf.meta.ClipBoundaries = []*metapb.ClipBoundary{{}}
+
+	buf := make([]byte, segCount*segSize)
+	n, readErr := mvf.ReadAtContext(ctx, buf, 0)
+
+	require.NoError(t, readErr, "playback must survive a transient 430")
+	require.Equal(t, len(buf), n, "the whole range must be served")
+
+	var want []byte
+	for i := range segCount {
+		want = append(want, segments.Payload(i, segSize)...)
+	}
+	assert.Equal(t, want, buf, "the recovered segment must carry its real bytes, not zeros")
+
+	fh, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	assert.Equal(t, database.HealthStatusHealthy, fh.Status,
+		"a transient miss must leave the file healthy")
+	assert.Zero(t, fh.StreamingFailureCount,
+		"a transient miss must not count toward masking, which never resets itself")
+
+	meta, readMetaErr := ms.ReadFileMetadata(filePath)
+	require.NoError(t, readMetaErr)
+	assert.NotNil(t, meta, "metadata must not be moved to the corrupted safety folder")
+}
+
+// TestIssue749_PermanentMissStillCondemns is the other half: the fix must not
+// buy transient-miss tolerance by making real corruption invisible.
+func TestIssue749_PermanentMissStillCondemns(t *testing.T) {
+	const (
+		segCount = 4
+		segSize  = 1024
+	)
+
+	repo, db, ms := setupStreamHealthEnv(t)
+	ctx := context.Background()
+
+	filePath := "series/permanent.s01e04.mkv"
+	_, err := db.Exec(
+		`INSERT INTO file_health (file_path, library_path, status, scheduled_check_at, streaming_failure_count)
+		 VALUES (?, ?, 'healthy', datetime('now'), 0)`,
+		filePath, "/media/library/permanent.s01e04.mkv",
+	)
+	require.NoError(t, err)
+	writeMetaForTestFile(t, ms, filePath, segCount, segSize)
+
+	fp := fakepool.New()
+	configurePoolForFile(fp, segCount, segSize, fakepool.SegmentBehavior{})
+	fp.SetBehavior(segments.MessageID(2), fakepool.SegmentBehavior{
+		Err: nntppool.ErrArticleNotFound,
+	})
+
+	healthEnabled := true
+	maskingEnabled := true
+	cfg := config.DefaultConfig()
+	cfg.Health.Enabled = &healthEnabled
+	cfg.Streaming.FailureMasking.Enabled = &maskingEnabled
+	cfg.Streaming.FailureMasking.Threshold = 3
+	cfg.MountPath = ""
+
+	mvf := withConfig(newTestMVF(t, ctx, fp, segCount, segSize, 2), cfg)
+	mvf.name = filePath
+	mvf.healthRepository = repo
+	mvf.metadataService = ms
+	mvf.meta.ClipBoundaries = []*metapb.ClipBoundary{{}}
+
+	buf := make([]byte, segCount*segSize)
+	_, readErr := mvf.ReadAtContext(ctx, buf, 0)
+	require.Error(t, readErr, "a genuinely missing article must still fail the read")
+
+	fh, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	assert.Equal(t, 1, fh.StreamingFailureCount,
+		"a confirmed miss must still count toward masking")
+}

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -2378,28 +2378,6 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 	cfg := mvf.configGetter()
 	healthEnabled := cfg.GetHealthEnabled()
 
-	// A 430 mid-stream is not proof the article is gone. The reader never
-	// retries ErrArticleNotFound, so one provider answering 430 transiently
-	// (backend desync) was enough to move a healthy file's metadata into the
-	// corrupted folder and make the ARR redownload it, while re-importing the
-	// same NZB minutes later verified clean (issue #749). Re-STAT the segment
-	// once and bail out when it turns out to be reachable.
-	//
-	// Only a proven-present article stops the repair. An unresolved re-check
-	// (transport error, no pool) falls through to the previous behaviour, so a
-	// briefly unhealthy pool cannot silently suppress repairs — the same
-	// direction validation.go takes for sweep results (#861).
-	//
-	// The debounce token taken above stays spent: a genuine failure on this
-	// path can be delayed by at most one debounce window, and the read itself
-	// has already failed, so the next attempt re-triggers.
-	if !mvf.confirmSegmentMissing(ctx, dataCorruptionErr) {
-		slog.WarnContext(ctx, "Streaming failure not confirmed on re-check, skipping repair",
-			"file", mvf.name,
-			"segment_id", dataCorruptionErr.SegmentID)
-		return
-	}
-
 	// Classify playback impact via the hole model — the verdict decides
 	// whether this failure triggers a repair at all. Note that with hole
 	// hooks wired, within-caps misses are zero-filled and never reach this
@@ -2407,6 +2385,49 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 	classification := mvf.classifyStreamingFailure(dataCorruptionErr)
 	isDegraded := healthEnabled && classification != nil &&
 		classification.Verdict == holes.VerdictDegraded
+
+	// A 430 mid-stream is not proof the article is gone. The reader never
+	// retries ErrArticleNotFound, so one provider answering 430 transiently
+	// (backend desync) was enough to hide a healthy file behind
+	// FILE_STATUS_CORRUPTED and make the ARR redownload it, while re-importing
+	// the same NZB minutes later verified clean (issue #749). Re-STAT the
+	// segment once and stop here when it turns out to be reachable.
+	//
+	// This runs while the caller holds mvf.mu, so it must not be paid on reads
+	// that would not act on it anyway: a degraded verdict is zero-filled and
+	// still playable, and takes no destructive action below. Everything past
+	// this point does — even with the health system disabled the file is marked
+	// corrupted, which hides it from listings and blocks opens.
+	//
+	// Only a proven-present article stops the repair. An unresolved re-check
+	// (transport error, no pool) falls through to the previous behaviour, so a
+	// briefly unhealthy pool cannot silently suppress repairs — the same
+	// direction validation.go takes for sweep results (#861).
+	//
+	// The failure is still recorded as pending rather than dropped, so a
+	// segment that is only intermittently reachable is re-checked properly by
+	// the health worker instead of stalling playback forever with no repair.
+	// The debounce token taken above stays spent: a genuine failure here can be
+	// delayed by at most one debounce window, and the read has already failed,
+	// so the next attempt re-triggers.
+	if !isDegraded && !mvf.confirmSegmentMissing(ctx, dataCorruptionErr) {
+		slog.WarnContext(ctx, "Streaming failure not confirmed on re-check, deferring to the health worker",
+			"file", mvf.name,
+			"segment_id", dataCorruptionErr.SegmentID)
+
+		errMsg := dataCorruptionErr.Error()
+		sourceNzb := &mvf.meta.SourceNzbPath
+		if *sourceNzb == "" {
+			sourceNzb = nil
+		}
+		if err := mvf.healthRepository.UpdateFileHealthScheduled(ctx,
+			mvf.name, database.HealthStatusPending, &errMsg, sourceNzb, nil, true, time.Now().UTC(),
+		); err != nil {
+			slog.WarnContext(ctx, "Failed to schedule health re-check after an unconfirmed streaming failure",
+				"file", mvf.name, "error", err)
+		}
+		return
+	}
 
 	// A missing article is PAR2-repairable regardless of eligibility for
 	// zero-fill (RAR/AES streams fail here instead of padding). Queue a
@@ -2574,9 +2595,10 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 }
 
 // missRecheckTimeout bounds the single re-STAT that confirms a mid-stream
-// article miss. A 430 answer can take about a second on some providers, so this
-// is generous enough to get a verdict without eating the caller's 5 s budget.
-const missRecheckTimeout = 3 * time.Second
+// article miss. A 430 answer takes about a second on some providers, so this
+// leaves headroom for one while capping how long the caller's mvf.mu is held
+// against a provider that never answers.
+const missRecheckTimeout = 1500 * time.Millisecond
 
 // confirmSegmentMissing re-checks a segment that a stream read reported as
 // missing, returning false only when the article is provably still there.

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -2378,6 +2378,28 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 	cfg := mvf.configGetter()
 	healthEnabled := cfg.GetHealthEnabled()
 
+	// A 430 mid-stream is not proof the article is gone. The reader never
+	// retries ErrArticleNotFound, so one provider answering 430 transiently
+	// (backend desync) was enough to move a healthy file's metadata into the
+	// corrupted folder and make the ARR redownload it, while re-importing the
+	// same NZB minutes later verified clean (issue #749). Re-STAT the segment
+	// once and bail out when it turns out to be reachable.
+	//
+	// Only a proven-present article stops the repair. An unresolved re-check
+	// (transport error, no pool) falls through to the previous behaviour, so a
+	// briefly unhealthy pool cannot silently suppress repairs — the same
+	// direction validation.go takes for sweep results (#861).
+	//
+	// The debounce token taken above stays spent: a genuine failure on this
+	// path can be delayed by at most one debounce window, and the read itself
+	// has already failed, so the next attempt re-triggers.
+	if !mvf.confirmSegmentMissing(ctx, dataCorruptionErr) {
+		slog.WarnContext(ctx, "Streaming failure not confirmed on re-check, skipping repair",
+			"file", mvf.name,
+			"segment_id", dataCorruptionErr.SegmentID)
+		return
+	}
+
 	// Classify playback impact via the hole model — the verdict decides
 	// whether this failure triggers a repair at all. Note that with hole
 	// hooks wired, within-caps misses are zero-filled and never reach this
@@ -2549,6 +2571,37 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 	); err != nil {
 		slog.WarnContext(ctx, "Failed to update health database for streaming failure", "file", mvf.name, "error", err)
 	}
+}
+
+// missRecheckTimeout bounds the single re-STAT that confirms a mid-stream
+// article miss. A 430 answer can take about a second on some providers, so this
+// is generous enough to get a verdict without eating the caller's 5 s budget.
+const missRecheckTimeout = 3 * time.Second
+
+// confirmSegmentMissing re-checks a segment that a stream read reported as
+// missing, returning false only when the article is provably still there.
+//
+// Anything else — a confirmed 430, a transport error, no pool, no segment id,
+// or a failure that was never an article-not-found in the first place — returns
+// true so the caller proceeds exactly as it did before. See the call site for
+// why "unresolved" must not stop a repair.
+func (mvf *MetadataVirtualFile) confirmSegmentMissing(ctx context.Context, dcErr *usenet.DataCorruptionError) bool {
+	if !usenet.IsArticleNotFound(dcErr.UnderlyingErr) || dcErr.SegmentID == "" || mvf.poolManager == nil {
+		return true
+	}
+
+	usenetPool, err := mvf.poolManager.GetPool()
+	if err != nil || usenetPool == nil {
+		return true
+	}
+
+	statCtx, cancel := context.WithTimeout(ctx, missRecheckTimeout)
+	defer cancel()
+
+	if _, err := usenetPool.Stat(statCtx, dcErr.SegmentID); err != nil {
+		return true
+	}
+	return false
 }
 
 // readFullContext reads exactly len(buf) bytes from r, but returns early

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -2386,34 +2386,31 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 	isDegraded := healthEnabled && classification != nil &&
 		classification.Verdict == holes.VerdictDegraded
 
-	// A 430 mid-stream is not proof the article is gone. The reader never
-	// retries ErrArticleNotFound, so one provider answering 430 transiently
-	// (backend desync) was enough to hide a healthy file behind
-	// FILE_STATUS_CORRUPTED and make the ARR redownload it, while re-importing
-	// the same NZB minutes later verified clean (issue #749). Re-STAT the
-	// segment once and stop here when it turns out to be reachable.
+	// A 430 mid-stream is not proof the article is gone: one transient answer
+	// was enough to hide a healthy file behind FILE_STATUS_CORRUPTED and have
+	// the ARR redownload it (issue #749). The reader settles that before the
+	// read fails, so this is only the backstop for failures arriving without a
+	// verdict — and only a proven-present article stops the repair, since a
+	// briefly unhealthy pool must not be able to suppress one.
 	//
-	// This runs while the caller holds mvf.mu, so it must not be paid on reads
-	// that would not act on it anyway: a degraded verdict is zero-filled and
-	// still playable, and takes no destructive action below. Everything past
-	// this point does — even with the health system disabled the file is marked
-	// corrupted, which hides it from listings and blocks opens.
+	// Gated on !isDegraded because it can cost a round trip while the caller
+	// holds mvf.mu: a degraded verdict is zero-filled and still playable and
+	// takes no destructive action, while everything past this point does —
+	// even with health disabled the file is marked corrupted, which hides it
+	// from listings and blocks opens.
 	//
-	// Only a proven-present article stops the repair. An unresolved re-check
-	// (transport error, no pool) falls through to the previous behaviour, so a
-	// briefly unhealthy pool cannot silently suppress repairs — the same
-	// direction validation.go takes for sweep results (#861).
-	//
-	// The failure is still recorded as pending rather than dropped, so a
-	// segment that is only intermittently reachable is re-checked properly by
-	// the health worker instead of stalling playback forever with no repair.
-	// The debounce token taken above stays spent: a genuine failure here can be
-	// delayed by at most one debounce window, and the read has already failed,
-	// so the next attempt re-triggers.
+	// Recording pending rather than dropping the failure hands an
+	// intermittently reachable segment to the health worker instead of
+	// stalling playback forever with no repair. The debounce token stays
+	// spent; the read has already failed, so the next attempt re-triggers.
 	if !isDegraded && !mvf.confirmSegmentMissing(ctx, dataCorruptionErr) {
-		slog.WarnContext(ctx, "Streaming failure not confirmed on re-check, deferring to the health worker",
+		// With health checking off nothing consumes the pending row. Still the
+		// right call — the article is provably there — but say so rather than
+		// promise a follow-up that will not happen.
+		slog.WarnContext(ctx, "Streaming failure not confirmed on re-check, not condemning the file",
 			"file", mvf.name,
-			"segment_id", dataCorruptionErr.SegmentID)
+			"segment_id", dataCorruptionErr.SegmentID,
+			"deferred_to_health_worker", healthEnabled)
 
 		errMsg := dataCorruptionErr.Error()
 		sourceNzb := &mvf.meta.SourceNzbPath
@@ -2594,21 +2591,23 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 	}
 }
 
-// missRecheckTimeout bounds the single re-STAT that confirms a mid-stream
-// article miss. A 430 answer takes about a second on some providers, so this
-// leaves headroom for one while capping how long the caller's mvf.mu is held
-// against a provider that never answers.
-const missRecheckTimeout = 1500 * time.Millisecond
-
-// confirmSegmentMissing re-checks a segment that a stream read reported as
-// missing, returning false only when the article is provably still there.
-//
-// Anything else — a confirmed 430, a transport error, no pool, no segment id,
-// or a failure that was never an article-not-found in the first place — returns
-// true so the caller proceeds exactly as it did before. See the call site for
-// why "unresolved" must not stop a repair.
+// confirmSegmentMissing re-checks a segment a stream read reported as missing,
+// returning false only when the article is provably still there. Anything else
+// returns true so the caller proceeds exactly as it did before.
 func (mvf *MetadataVirtualFile) confirmSegmentMissing(ctx context.Context, dcErr *usenet.DataCorruptionError) bool {
-	if !usenet.IsArticleNotFound(dcErr.UnderlyingErr) || dcErr.SegmentID == "" || mvf.poolManager == nil {
+	if !usenet.IsArticleNotFound(dcErr.UnderlyingErr) {
+		return true
+	}
+
+	// The reader already asked; asking again costs a round trip under mvf.mu
+	// for an answer we have. Every settled verdict means the miss stands,
+	// including present-but-unfetchable — re-checking that one forever would
+	// leave the file unplayable and unrepaired.
+	if dcErr.MissVerdict != usenet.MissUnverified {
+		return true
+	}
+
+	if dcErr.SegmentID == "" || mvf.poolManager == nil {
 		return true
 	}
 
@@ -2617,10 +2616,12 @@ func (mvf *MetadataVirtualFile) confirmSegmentMissing(ctx context.Context, dcErr
 		return true
 	}
 
-	statCtx, cancel := context.WithTimeout(ctx, missRecheckTimeout)
+	statCtx, cancel := context.WithTimeout(ctx, usenet.MissRecheckTimeout)
 	defer cancel()
 
-	if _, err := usenetPool.Stat(statCtx, dcErr.SegmentID); err != nil {
+	// Priority lane: a playback read is blocked behind this, so it must not
+	// spend its budget queued behind a large BODY on a busy connection.
+	if _, err := usenetPool.StatPriority(statCtx, dcErr.SegmentID); err != nil {
 		return true
 	}
 	return false

--- a/internal/nzbfilesystem/streaming_miss_reverify_test.go
+++ b/internal/nzbfilesystem/streaming_miss_reverify_test.go
@@ -1,0 +1,173 @@
+package nzbfilesystem
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/javi11/nntppool/v4"
+	"github.com/kipsilabs/altmount/internal/config"
+	"github.com/kipsilabs/altmount/internal/database"
+	"github.com/kipsilabs/altmount/internal/metadata"
+	metapb "github.com/kipsilabs/altmount/internal/metadata/proto"
+	"github.com/kipsilabs/altmount/internal/testsupport/fakepool"
+	"github.com/kipsilabs/altmount/internal/usenet"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const reverifySegmentID = "a@b.example.com"
+
+// newImportedStreamFile wires an mvf whose file is already imported (health row
+// carries a library_path), so the repair branch would move its metadata to the
+// corrupted safety folder.
+func newImportedStreamFile(
+	t *testing.T, ctx context.Context, filePath string,
+	repo *database.HealthRepository, db *sql.DB, ms *metadata.MetadataService,
+	seg []*metapb.SegmentData, fp *fakepool.Client,
+) *MetadataVirtualFile {
+	t.Helper()
+
+	_, err := db.Exec(
+		`INSERT INTO file_health (file_path, library_path, status, scheduled_check_at) VALUES (?, ?, 'healthy', datetime('now'))`,
+		filePath, "/media/library/"+filePath,
+	)
+	require.NoError(t, err)
+
+	enabled := true
+	cfg := config.DefaultConfig()
+	cfg.Health.Enabled = &enabled
+	cfg.MountPath = ""
+
+	mvf := newStreamFailureMVF(ctx, filePath, repo, ms, seg, cfg)
+	if fp != nil {
+		mvf.poolManager = newFakePoolManager(fp)
+	}
+	return mvf
+}
+
+// A single 430 mid-stream is not proof the article is gone: providers return it
+// transiently (backend desync), and the reader never retries an
+// ErrArticleNotFound. Condemning on that evidence moved a healthy file's
+// metadata into the corrupted folder and made the ARR redownload it, while
+// re-importing the very same NZB minutes later verified clean (issue #749).
+func TestUpdateFileHealthOnError_TransientMissIsNotCondemned(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	repo, db, ms := setupStreamHealthEnv(t)
+	ctx := context.Background()
+
+	filePath := "series/stream.s01e10.mkv"
+	seg := writeStreamMeta(t, ms, filePath)
+
+	// The re-check finds the article present: the 430 was transient.
+	fp := fakepool.New()
+	fp.SetBehavior(reverifySegmentID, fakepool.SegmentBehavior{Bytes: []byte("present")})
+
+	mvf := newImportedStreamFile(t, ctx, filePath, repo, db, ms, seg, fp)
+	mvf.updateFileHealthOnError(&usenet.DataCorruptionError{
+		UnderlyingErr: nntppool.ErrArticleNotFound,
+		SegmentID:     reverifySegmentID,
+		NoRetry:       true,
+		FileOffset:    -1,
+	}, true)
+
+	fh, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	if fh != nil {
+		assert.NotEqual(t, database.HealthStatusRepairTriggered, fh.Status,
+			"a re-check that finds the article present must not trigger a repair")
+	}
+
+	original, readErr := ms.ReadFileMetadata(filePath)
+	require.NoError(t, readErr)
+	assert.NotNil(t, original, "metadata must stay put when the miss is not confirmed")
+	assert.False(t, mvf.metadataGone.Load(), "handle must not latch closed on an unconfirmed miss")
+}
+
+// A re-check that confirms the 430 keeps the existing repair behavior.
+func TestUpdateFileHealthOnError_ConfirmedMissStillTriggersRepair(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	repo, db, ms := setupStreamHealthEnv(t)
+	ctx := context.Background()
+
+	filePath := "series/stream.s01e11.mkv"
+	seg := writeStreamMeta(t, ms, filePath)
+
+	fp := fakepool.New()
+	fp.SetBehavior(reverifySegmentID, fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+	mvf := newImportedStreamFile(t, ctx, filePath, repo, db, ms, seg, fp)
+	mvf.updateFileHealthOnError(&usenet.DataCorruptionError{
+		UnderlyingErr: nntppool.ErrArticleNotFound,
+		SegmentID:     reverifySegmentID,
+		NoRetry:       true,
+		FileOffset:    -1,
+	}, true)
+
+	fh, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	assert.Equal(t, database.HealthStatusRepairTriggered, fh.Status,
+		"a confirmed miss must still trigger the repair")
+
+	original, readErr := ms.ReadFileMetadata(filePath)
+	require.NoError(t, readErr)
+	assert.Nil(t, original, "a confirmed miss must still move the metadata away")
+}
+
+// When the re-check cannot resolve the question — transport error, no pool —
+// behaviour is unchanged: the failure is treated as before rather than newly
+// suppressing repairs whenever the pool is briefly unhealthy.
+func TestUpdateFileHealthOnError_UnresolvedRecheckKeepsPreviousBehaviour(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+
+	tests := []struct {
+		name string
+		pool func() *fakepool.Client
+	}{
+		{
+			name: "transport error during re-check",
+			pool: func() *fakepool.Client {
+				fp := fakepool.New()
+				fp.SetBehavior(reverifySegmentID, fakepool.SegmentBehavior{Err: errors.New("connection reset")})
+				return fp
+			},
+		},
+		{
+			name: "no pool configured",
+			pool: func() *fakepool.Client { return nil },
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, db, ms := setupStreamHealthEnv(t)
+			ctx := context.Background()
+
+			filePath := "series/stream.s01e2" + string(rune('0'+i)) + ".mkv"
+			seg := writeStreamMeta(t, ms, filePath)
+
+			mvf := newImportedStreamFile(t, ctx, filePath, repo, db, ms, seg, tt.pool())
+			mvf.updateFileHealthOnError(&usenet.DataCorruptionError{
+				UnderlyingErr: nntppool.ErrArticleNotFound,
+				SegmentID:     reverifySegmentID,
+				NoRetry:       true,
+				FileOffset:    -1,
+			}, true)
+
+			fh, err := repo.GetFileHealth(ctx, filePath)
+			require.NoError(t, err)
+			require.NotNil(t, fh)
+			assert.Equal(t, database.HealthStatusRepairTriggered, fh.Status)
+		})
+	}
+}

--- a/internal/nzbfilesystem/streaming_miss_reverify_test.go
+++ b/internal/nzbfilesystem/streaming_miss_reverify_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"runtime"
 	"testing"
 
@@ -20,6 +21,36 @@ import (
 )
 
 const reverifySegmentID = "a@b.example.com"
+
+// writeStreamMetaN writes metadata for a file of n equally sized segments, the
+// first of which carries reverifySegmentID. A single missing segment out of n
+// stays under every hole threshold, so it classifies as degraded rather than
+// failed — which writeStreamMeta's single-segment file cannot do.
+func writeStreamMetaN(t *testing.T, ms *metadata.MetadataService, filePath string, n int) []*metapb.SegmentData {
+	t.Helper()
+
+	const segSize = 1024
+	segs := make([]*metapb.SegmentData, n)
+	for i := range segs {
+		id := fmt.Sprintf("seg%d@example.com", i)
+		if i == 0 {
+			id = reverifySegmentID
+		}
+		segs[i] = &metapb.SegmentData{
+			Id:          id,
+			SegmentSize: segSize,
+			StartOffset: 0,
+			EndOffset:   segSize - 1,
+		}
+	}
+
+	meta := ms.CreateFileMetadata(
+		int64(n)*segSize, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		segs, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	require.NoError(t, ms.WriteFileMetadata(filePath, meta))
+	return meta.SegmentData
+}
 
 // newImportedStreamFile wires an mvf whose file is already imported (health row
 // carries a library_path), so the repair branch would move its metadata to the
@@ -78,15 +109,50 @@ func TestUpdateFileHealthOnError_TransientMissIsNotCondemned(t *testing.T) {
 
 	fh, err := repo.GetFileHealth(ctx, filePath)
 	require.NoError(t, err)
-	if fh != nil {
-		assert.NotEqual(t, database.HealthStatusRepairTriggered, fh.Status,
-			"a re-check that finds the article present must not trigger a repair")
-	}
+	require.NotNil(t, fh)
+	assert.Equal(t, database.HealthStatusPending, fh.Status,
+		"an unconfirmed miss must be handed to the health worker, not repaired and not forgotten")
 
 	original, readErr := ms.ReadFileMetadata(filePath)
 	require.NoError(t, readErr)
 	assert.NotNil(t, original, "metadata must stay put when the miss is not confirmed")
 	assert.False(t, mvf.metadataGone.Load(), "handle must not latch closed on an unconfirmed miss")
+}
+
+// The re-check costs a network round-trip while the caller holds mvf.mu, which
+// a concurrent foreground read on the same handle would block on. It must
+// therefore only run when something destructive would otherwise follow: a
+// degraded verdict is zero-filled and still playable, so it must not pay for a
+// STAT at all.
+func TestUpdateFileHealthOnError_DegradedMissSkipsTheRecheck(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	repo, db, ms := setupStreamHealthEnv(t)
+	ctx := context.Background()
+
+	filePath := "series/stream.s01e12.mkv"
+	seg := writeStreamMetaN(t, ms, filePath, 512)
+
+	fp := fakepool.New()
+	fp.SetBehavior(reverifySegmentID, fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+	mvf := newImportedStreamFile(t, ctx, filePath, repo, db, ms, seg, fp)
+	// A single missing segment in a large file classifies as degraded.
+	mvf.updateFileHealthOnError(&usenet.DataCorruptionError{
+		UnderlyingErr: nntppool.ErrArticleNotFound,
+		SegmentID:     reverifySegmentID,
+		NoRetry:       true,
+		FileOffset:    0,
+	}, true)
+
+	fh, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	require.Equal(t, database.HealthStatusDegraded, fh.Status,
+		"precondition: this failure must classify as degraded")
+	assert.Zero(t, fp.StatCalls(),
+		"a degraded (still playable) failure must not pay for a re-check on the read path")
 }
 
 // A re-check that confirms the 430 keeps the existing repair behavior.

--- a/internal/nzbfilesystem/streaming_miss_reverify_test.go
+++ b/internal/nzbfilesystem/streaming_miss_reverify_test.go
@@ -237,3 +237,88 @@ func TestUpdateFileHealthOnError_UnresolvedRecheckKeepsPreviousBehaviour(t *test
 		})
 	}
 }
+
+// The reader re-checks a miss before it reaches here (see
+// internal/usenet/transient_miss_test.go). When it has already answered, this
+// handler must reuse that answer rather than pay a second round trip under
+// mvf.mu — even though the article now STATs present, because the reader saw
+// the miss survive a full confirm-and-retry cycle.
+func TestUpdateFileHealthOnError_ReaderVerdictSkipsSecondCheck(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+
+	tests := []struct {
+		name    string
+		verdict usenet.MissVerdict
+	}{
+		{"confirmed gone by the reader", usenet.MissConfirmed},
+		{"present but unfetchable", usenet.MissUnfetchable},
+		{"reader could not resolve it", usenet.MissUnresolved},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, db, ms := setupStreamHealthEnv(t)
+			ctx := context.Background()
+
+			filePath := "series/stream.s01e3" + string(rune('0'+i)) + ".mkv"
+			seg := writeStreamMeta(t, ms, filePath)
+
+			// Deliberately present: a second check would say "transient" and
+			// wrongly defer a miss the reader already proved out.
+			fp := fakepool.New()
+			fp.SetBehavior(reverifySegmentID, fakepool.SegmentBehavior{Bytes: []byte("present")})
+
+			mvf := newImportedStreamFile(t, ctx, filePath, repo, db, ms, seg, fp)
+			mvf.updateFileHealthOnError(&usenet.DataCorruptionError{
+				UnderlyingErr: nntppool.ErrArticleNotFound,
+				SegmentID:     reverifySegmentID,
+				MissVerdict:   tt.verdict,
+				NoRetry:       true,
+				FileOffset:    -1,
+			}, true)
+
+			fh, err := repo.GetFileHealth(ctx, filePath)
+			require.NoError(t, err)
+			require.NotNil(t, fh)
+			assert.Equal(t, database.HealthStatusRepairTriggered, fh.Status,
+				"a miss the reader already settled must be repaired, not deferred")
+			assert.Zero(t, fp.StatCalls(),
+				"the reader's verdict must be reused, not re-asked under mvf.mu")
+		})
+	}
+}
+
+// Failures that reach here without a reader verdict (the crypt reader, older
+// call sites) still get their own check — on the priority lane, since a
+// normal-lane STAT can queue behind a large BODY for longer than its budget.
+func TestUpdateFileHealthOnError_FallbackRecheckUsesPriorityLane(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	repo, db, ms := setupStreamHealthEnv(t)
+	ctx := context.Background()
+
+	filePath := "series/stream.s01e40.mkv"
+	seg := writeStreamMeta(t, ms, filePath)
+
+	fp := fakepool.New()
+	fp.SetBehavior(reverifySegmentID, fakepool.SegmentBehavior{Bytes: []byte("present")})
+
+	mvf := newImportedStreamFile(t, ctx, filePath, repo, db, ms, seg, fp)
+	mvf.updateFileHealthOnError(&usenet.DataCorruptionError{
+		UnderlyingErr: nntppool.ErrArticleNotFound,
+		SegmentID:     reverifySegmentID,
+		MissVerdict:   usenet.MissUnverified,
+		NoRetry:       true,
+		FileOffset:    -1,
+	}, true)
+
+	fh, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	assert.Equal(t, database.HealthStatusPending, fh.Status)
+	assert.Equal(t, int64(1), fp.StatPriorityCalls(),
+		"the fallback re-check must not queue behind a body fetch")
+}

--- a/internal/pool/nntpclient.go
+++ b/internal/pool/nntpclient.go
@@ -50,6 +50,12 @@ type NntpClient interface {
 	// downloading the body. Used by health checks and validation.
 	Stat(ctx context.Context, messageID string) (*nntppool.StatResult, error)
 
+	// StatPriority is Stat on the priority lane, for an existence check with a
+	// playback read blocked on its result: on the normal lane it could spend
+	// its whole budget queued behind a large BODY rather than awaiting an
+	// answer. Used by the mid-stream miss re-check.
+	StatPriority(ctx context.Context, messageID string) (*nntppool.StatResult, error)
+
 	// StatMany checks the existence of many articles concurrently, streaming a
 	// result per message-id as each completes. Used by health checks and
 	// fast-fail import validation to batch existence sweeps instead of

--- a/internal/testsupport/fakepool/fakepool.go
+++ b/internal/testsupport/fakepool/fakepool.go
@@ -123,11 +123,16 @@ type Client struct {
 	bodyStreamPriCalls atomic.Int64
 	bodyAsyncCalls     atomic.Int64
 	statCalls          atomic.Int64
+	statPriCalls       atomic.Int64
 
 	// Per-message-ID call counts (string → *atomic.Int64). Tests that need
 	// to assert how often a specific segment was requested (e.g. to detect
 	// retry storms) read this map via PerMessageCalls.
 	perIDCalls sync.Map
+
+	// Per-message-ID body call counts, excluding existence checks, so a STAT
+	// alongside a fetch does not read as a retry.
+	perIDBodyCalls sync.Map
 }
 
 // New returns a fake client. Without further configuration it returns an
@@ -207,6 +212,10 @@ func (c *Client) BodyAsyncCalls() int64 { return c.bodyAsyncCalls.Load() }
 // StatCalls returns the count of Stat invocations.
 func (c *Client) StatCalls() int64 { return c.statCalls.Load() }
 
+// StatPriorityCalls reports existence checks made on the priority lane.
+// StatCalls counts those too, so "no STAT at all" assertions keep working.
+func (c *Client) StatPriorityCalls() int64 { return c.statPriCalls.Load() }
+
 // PerMessageCalls returns how many times the given message-ID was requested
 // across all method types (Body / BodyPriority / BodyAsync / Stat).
 //
@@ -214,7 +223,18 @@ func (c *Client) StatCalls() int64 { return c.statCalls.Load() }
 // re-issuing failed requests, the per-ID count climbs faster than the
 // number of distinct segments and the assertion fails.
 func (c *Client) PerMessageCalls(messageID string) int64 {
-	v, ok := c.perIDCalls.Load(messageID)
+	return loadCount(&c.perIDCalls, messageID)
+}
+
+// PerMessageBodyCalls returns how many times the message-ID was fetched,
+// ignoring existence checks. Use it to pin retry behaviour when the code under
+// test may also STAT the same article.
+func (c *Client) PerMessageBodyCalls(messageID string) int64 {
+	return loadCount(&c.perIDBodyCalls, messageID)
+}
+
+func loadCount(m *sync.Map, messageID string) int64 {
+	v, ok := m.Load(messageID)
 	if !ok {
 		return 0
 	}
@@ -232,22 +252,38 @@ func (c *Client) ResetCounters() {
 	c.bodyStreamPriCalls.Store(0)
 	c.bodyAsyncCalls.Store(0)
 	c.statCalls.Store(0)
-	c.perIDCalls.Range(func(k, _ any) bool {
-		c.perIDCalls.Delete(k)
-		return true
-	})
+	c.statPriCalls.Store(0)
+	for _, m := range []*sync.Map{&c.perIDCalls, &c.perIDBodyCalls} {
+		m.Range(func(k, _ any) bool {
+			m.Delete(k)
+			return true
+		})
+	}
 }
 
 // countMessage increments the per-ID counter atomically, lazily creating
 // the counter on first contact.
 func (c *Client) countMessage(messageID string) {
-	if v, ok := c.perIDCalls.Load(messageID); ok {
+	bumpCount(&c.perIDCalls, messageID)
+}
+
+// countBodyMessage records a fetch in both the all-methods and body-only
+// per-ID counters.
+func (c *Client) countBodyMessage(messageID string) {
+	bumpCount(&c.perIDCalls, messageID)
+	bumpCount(&c.perIDBodyCalls, messageID)
+}
+
+// bumpCount increments a per-ID counter atomically, lazily creating the
+// counter on first contact.
+func bumpCount(m *sync.Map, messageID string) {
+	if v, ok := m.Load(messageID); ok {
 		v.(*atomic.Int64).Add(1)
 		return
 	}
 	var fresh atomic.Int64
 	fresh.Add(1)
-	actual, loaded := c.perIDCalls.LoadOrStore(messageID, &fresh)
+	actual, loaded := m.LoadOrStore(messageID, &fresh)
 	if loaded {
 		actual.(*atomic.Int64).Add(1)
 	}
@@ -307,7 +343,7 @@ func waitOrCancel(ctx context.Context, d time.Duration) error {
 // ArticleBody filled with the configured Bytes after the configured latency.
 func (c *Client) Body(ctx context.Context, messageID string, onMeta ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
 	c.bodyCalls.Add(1)
-	c.countMessage(messageID)
+	c.countBodyMessage(messageID)
 	defer c.enter()()
 	return c.serveBody(ctx, messageID, nil, onMeta...)
 }
@@ -316,7 +352,7 @@ func (c *Client) Body(ctx context.Context, messageID string, onMeta ...func(nntp
 // distinguish streaming from importer traffic.
 func (c *Client) BodyPriority(ctx context.Context, messageID string, onMeta ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
 	c.bodyPriCalls.Add(1)
-	c.countMessage(messageID)
+	c.countBodyMessage(messageID)
 	defer c.enter()()
 	return c.serveBody(ctx, messageID, nil, onMeta...)
 }
@@ -325,7 +361,7 @@ func (c *Client) BodyPriority(ctx context.Context, messageID string, onMeta ...f
 // distinguish repair traffic from importer traffic.
 func (c *Client) BodyBackground(ctx context.Context, messageID string, onMeta ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
 	c.bodyBgCalls.Add(1)
-	c.countMessage(messageID)
+	c.countBodyMessage(messageID)
 	defer c.enter()()
 	return c.serveBody(ctx, messageID, nil, onMeta...)
 }
@@ -336,7 +372,7 @@ func (c *Client) BodyBackground(ctx context.Context, messageID string, onMeta ..
 // when FailAfterFirstChunk is set.
 func (c *Client) BodyStreamPriority(ctx context.Context, messageID string, w io.Writer, onMeta ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
 	c.bodyStreamPriCalls.Add(1)
-	c.countMessage(messageID)
+	c.countBodyMessage(messageID)
 	defer c.enter()()
 	return c.serveBody(ctx, messageID, w, onMeta...)
 }
@@ -345,7 +381,7 @@ func (c *Client) BodyStreamPriority(ctx context.Context, messageID string, w io.
 // BodyResult on the returned channel.
 func (c *Client) BodyAsync(ctx context.Context, messageID string, w io.Writer, onMeta ...func(nntppool.YEncMeta)) <-chan nntppool.BodyResult {
 	c.bodyAsyncCalls.Add(1)
-	c.countMessage(messageID)
+	c.countBodyMessage(messageID)
 	ch := make(chan nntppool.BodyResult, 1)
 	go func() {
 		defer c.enter()()
@@ -360,6 +396,18 @@ func (c *Client) BodyAsync(ctx context.Context, messageID string, w io.Writer, o
 // configured latency. If the behavior has Err set, it is returned.
 func (c *Client) Stat(ctx context.Context, messageID string) (*nntppool.StatResult, error) {
 	c.statCalls.Add(1)
+	return c.serveStat(ctx, messageID)
+}
+
+// StatPriority mirrors Stat on the priority lane, counting toward StatCalls
+// too so "no existence check happened" assertions hold for either lane.
+func (c *Client) StatPriority(ctx context.Context, messageID string) (*nntppool.StatResult, error) {
+	c.statCalls.Add(1)
+	c.statPriCalls.Add(1)
+	return c.serveStat(ctx, messageID)
+}
+
+func (c *Client) serveStat(ctx context.Context, messageID string) (*nntppool.StatResult, error) {
 	c.countMessage(messageID)
 	defer c.enter()()
 	b := c.behaviorFor(messageID)

--- a/internal/usenet/transient_miss_test.go
+++ b/internal/usenet/transient_miss_test.go
@@ -1,0 +1,163 @@
+package usenet
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/javi11/nntppool/v4"
+	"github.com/kipsilabs/altmount/internal/pool"
+	"github.com/kipsilabs/altmount/internal/testsupport/fakepool"
+	"github.com/kipsilabs/altmount/internal/testsupport/segments"
+)
+
+// transient_miss_test.go pins the contract for a mid-stream 430 that is not
+// actually a missing article (issue #749): providers desync and answer "no
+// such article" for a segment that is still there seconds later.
+
+// TestTransientMiss_ReadRecovers is the issue itself: one segment 430s once,
+// the article is present on a re-check, and playback must survive.
+func TestTransientMiss_ReadRecovers(t *testing.T) {
+	t.Parallel()
+	const (
+		segCount    = 4
+		segSize     = 16
+		maxPrefetch = 4
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	fp := fakepool.New()
+	for i := range segCount {
+		b := fakepool.SegmentBehavior{Bytes: segments.Payload(i, segSize)}
+		if i == 1 {
+			// One transient 430, then the article serves normally.
+			b.FailFirst = 1
+			b.FailErr = nntppool.ErrArticleNotFound
+		}
+		fp.SetBehavior(segments.MessageID(i), b)
+	}
+
+	rg := buildEagerRange(ctx, t, segCount, segSize)
+	ur := newReaderForTest(t, ctx, fp, rg, maxPrefetch)
+	ur.Start()
+
+	got, err := io.ReadAll(ur)
+	if err != nil {
+		t.Fatalf("read failed on a transient miss: %v", err)
+	}
+
+	var want []byte
+	for i := range segCount {
+		want = append(want, segments.Payload(i, segSize)...)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("payload mismatch after recovery: got %d bytes, want %d", len(got), len(want))
+	}
+	if n := fp.StatPriorityCalls(); n != 1 {
+		t.Errorf("re-check issued %d priority STATs, want exactly 1", n)
+	}
+}
+
+// TestTransientMiss_ConfirmedGoneNamesSegment pins what the health pipeline
+// needs from a genuine miss: the segment and the verdict. Without SegmentID
+// the downstream re-check in nzbfilesystem cannot run at all.
+func TestTransientMiss_ConfirmedGoneNamesSegment(t *testing.T) {
+	t.Parallel()
+	const (
+		segCount    = 3
+		segSize     = 16
+		maxPrefetch = 3
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	fp := fakepool.New()
+	fp.SetBehavior(segments.MessageID(0), fakepool.SegmentBehavior{Bytes: segments.Payload(0, segSize)})
+	// Permanently gone: both the body fetch and the re-check say 430.
+	fp.SetBehavior(segments.MessageID(1), fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+	fp.SetBehavior(segments.MessageID(2), fakepool.SegmentBehavior{Bytes: segments.Payload(2, segSize)})
+
+	rg := buildEagerRange(ctx, t, segCount, segSize)
+	ur := newReaderForTest(t, ctx, fp, rg, maxPrefetch)
+	ur.Start()
+
+	_, err := io.ReadAll(ur)
+	var dce *DataCorruptionError
+	if !errors.As(err, &dce) {
+		t.Fatalf("want DataCorruptionError, got %v", err)
+	}
+	if dce.SegmentID != segments.MessageID(1) {
+		t.Errorf("SegmentID = %q, want %q", dce.SegmentID, segments.MessageID(1))
+	}
+	if dce.MissVerdict != MissConfirmed {
+		t.Errorf("MissVerdict = %v, want MissConfirmed", dce.MissVerdict)
+	}
+	// One body attempt (never retried) plus exactly one confirming STAT.
+	if n := fp.PerMessageBodyCalls(segments.MessageID(1)); n != 1 {
+		t.Errorf("segment 1 issued %d body calls, want 1", n)
+	}
+	if n := fp.StatPriorityCalls(); n != 1 {
+		t.Errorf("issued %d priority STATs, want 1", n)
+	}
+}
+
+// TestTransientMiss_RecheckIsBudgeted keeps a dead release from paying a
+// ~1.2s existence check per hole: one round trip per reader, not per miss.
+func TestTransientMiss_RecheckIsBudgeted(t *testing.T) {
+	t.Parallel()
+	const (
+		segCount    = 8
+		segSize     = 16
+		maxPrefetch = 8
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	fp := fakepool.New()
+	fp.SetDefaultBehavior(fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+	rg := buildEagerRange(ctx, t, segCount, segSize)
+	ur := newReaderForTest(t, ctx, fp, rg, maxPrefetch)
+	ur.Start()
+	_, _ = io.ReadAll(ur)
+	time.Sleep(150 * time.Millisecond)
+
+	if n := fp.StatPriorityCalls(); n > 1 {
+		t.Errorf("issued %d priority STATs across %d missing segments, want at most 1", n, segCount)
+	}
+}
+
+// TestTransientMiss_ImportProfileDoesNotRecheck keeps the import path on its
+// own validation: it sweeps availability up front, so a re-check is pure cost.
+func TestTransientMiss_ImportProfileDoesNotRecheck(t *testing.T) {
+	t.Parallel()
+	const (
+		segCount    = 3
+		segSize     = 16
+		maxPrefetch = 3
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	fp := fakepool.New()
+	fp.SetDefaultBehavior(fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+
+	rg := buildEagerRange(ctx, t, segCount, segSize)
+	getter := func() (pool.NntpClient, error) { return fp, nil }
+	ur, err := NewUsenetReader(ctx, getter, rg, maxPrefetch, noopMetrics{}, "import-stream", nil,
+		withFlightMap(newFlightMap()), WithImportProfile(nil))
+	if err != nil {
+		t.Fatalf("NewUsenetReader: %v", err)
+	}
+	t.Cleanup(func() { _ = ur.Close() })
+	ur.Start()
+	_, _ = io.ReadAll(ur)
+	time.Sleep(150 * time.Millisecond)
+
+	if n := fp.StatCalls(); n != 0 {
+		t.Errorf("import profile issued %d existence checks, want 0", n)
+	}
+}

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -182,6 +182,8 @@ type DataCorruptionError struct {
 	FileOffset int64
 	// SegmentID is the message ID of the failing segment, when known.
 	SegmentID string
+	// MissVerdict says what a re-check of a missing article found.
+	MissVerdict MissVerdict
 }
 
 func (e *DataCorruptionError) Error() string {
@@ -190,6 +192,47 @@ func (e *DataCorruptionError) Error() string {
 
 func (e *DataCorruptionError) Unwrap() error {
 	return e.UnderlyingErr
+}
+
+// MissVerdict records what re-checking a missing article found. A 430 is not
+// proof the article is gone: backends desync and serve the same segment
+// moments later (issue #749). The reader re-checks once and reports what it
+// learned, so the health pipeline does not have to ask again.
+type MissVerdict uint8
+
+const (
+	// MissUnverified: no re-check ran (not a miss, no budget, no pool, import).
+	MissUnverified MissVerdict = iota
+	// MissConfirmed: a second existence check also said it is gone.
+	MissConfirmed
+	// MissUnresolved: the re-check could not answer. Callers must keep their
+	// pre-re-check behaviour — an unhealthy pool must not suppress repairs.
+	MissUnresolved
+	// MissUnfetchable: the article exists but a second fetch still failed, so
+	// it counts as a real miss rather than something to re-check forever.
+	MissUnfetchable
+)
+
+// missError annotates a miss with its segment and verdict without changing
+// what the error is: errors.Is(err, ErrArticleNotFound) still holds, so the
+// hole hooks and every existing miss branch behave as before.
+type missError struct {
+	segmentID string
+	verdict   MissVerdict
+	err       error
+}
+
+func (e *missError) Error() string { return e.err.Error() }
+func (e *missError) Unwrap() error { return e.err }
+
+// MissInfo reports the segment and verdict a miss was annotated with; ok is
+// false for errors that never went through the reader's miss path.
+func MissInfo(err error) (segmentID string, verdict MissVerdict, ok bool) {
+	var me *missError
+	if !errors.As(err, &me) {
+		return "", MissUnverified, false
+	}
+	return me.segmentID, me.verdict, true
 }
 
 // isCorruptionError reports whether err indicates the article body itself is
@@ -241,6 +284,10 @@ type UsenetReader struct {
 
 	// Tracing counters (atomic, no lock needed)
 	inFlight atomic.Int32 // goroutines actively downloading right now
+
+	// missRechecks counts re-checks attempted, refused ones included, so the
+	// budget holds under concurrent prefetch without a lock.
+	missRechecks atomic.Int32
 
 	mu sync.Mutex
 }
@@ -403,17 +450,9 @@ func (b *UsenetReader) Read(p []byte) (int, error) {
 
 		if b.isArticleNotFoundError(err) {
 			if totalRead > 0 {
-				return 0, &DataCorruptionError{
-					UnderlyingErr: err,
-					BytesRead:     totalRead,
-					FileOffset:    rg.start + totalRead,
-				}
+				return 0, corruptionFromMiss(err, totalRead, rg.start+totalRead)
 			} else {
-				return 0, &DataCorruptionError{
-					UnderlyingErr: err,
-					BytesRead:     0,
-					FileOffset:    rg.start,
-				}
+				return 0, corruptionFromMiss(err, 0, rg.start)
 			}
 		}
 		return 0, io.EOF
@@ -460,22 +499,14 @@ func (b *UsenetReader) Read(p []byte) (int, error) {
 
 					if b.isArticleNotFoundError(err) {
 						if totalRead > 0 {
-							return n, &DataCorruptionError{
-								UnderlyingErr: err,
-								BytesRead:     totalRead,
-								FileOffset:    rg.start + totalRead,
-							}
+							return n, corruptionFromMiss(err, totalRead, rg.start+totalRead)
 						}
 					}
 					return n, io.EOF
 				}
 			} else {
 				if b.isArticleNotFoundError(err) {
-					return n, &DataCorruptionError{
-						UnderlyingErr: err,
-						BytesRead:     totalRead,
-						FileOffset:    rg.start + totalRead,
-					}
+					return n, corruptionFromMiss(err, totalRead, rg.start+totalRead)
 				}
 				return n, err
 			}
@@ -483,6 +514,21 @@ func (b *UsenetReader) Read(p []byte) (int, error) {
 	}
 
 	return n, nil
+}
+
+// corruptionFromMiss builds the DataCorruptionError a missing article surfaces
+// as. Without the segment and verdict the download path recorded, the health
+// pipeline has no message-ID to re-check and cannot tell a transient 430 from
+// a real one (issue #749).
+func corruptionFromMiss(err error, bytesRead, fileOffset int64) *DataCorruptionError {
+	segmentID, verdict, _ := MissInfo(err)
+	return &DataCorruptionError{
+		UnderlyingErr: err,
+		BytesRead:     bytesRead,
+		FileOffset:    fileOffset,
+		SegmentID:     segmentID,
+		MissVerdict:   verdict,
+	}
 }
 
 // isArticleNotFoundError checks if the error indicates articles were not found in providers
@@ -683,10 +729,74 @@ func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segmen
 	}
 }
 
+// MissRecheckTimeout bounds the existence check that confirms a miss. A
+// present article STATs in tens of milliseconds; two seconds covers one
+// adaptive provider window without letting a silent provider hold a slot.
+const MissRecheckTimeout = 2 * time.Second
+
+// maxMissRechecks budgets re-checks per reader: one desynced segment needs
+// one, and a dead release must not pay ~1.2s per hole.
+const maxMissRechecks = 1
+
 // fetchWithRetry runs the wire fetch for one segment. With art set the
 // decoded bytes stream into art as they arrive (priority lane); with art nil
 // the article is buffered on the normal lane for import.
+//
+// A miss is re-checked once before it is allowed to stand: providers answer
+// 430 transiently, and giving up on that answer is what condemned a healthy
+// file in issue #749.
 func (b *UsenetReader) fetchWithRetry(ctx context.Context, cp pool.NntpClient, seg *segment, art *articleBuf) ([]byte, error) {
+	data, err := b.fetchAttempts(ctx, cp, seg, art)
+	if !errors.Is(err, nntppool.ErrArticleNotFound) {
+		return data, err
+	}
+
+	present, verdict := b.recheckMiss(ctx, cp, seg)
+	if !present {
+		return data, &missError{segmentID: seg.Id, verdict: verdict, err: err}
+	}
+
+	b.log.InfoContext(ctx, "article present on re-check, retrying transient miss",
+		"segment_id", seg.Id)
+	retryData, retryErr := b.fetchAttempts(ctx, cp, seg, art)
+	if retryErr == nil {
+		return retryData, nil
+	}
+
+	// Present but unfetchable: a real miss, or the file is re-checked forever
+	// and never repaired.
+	b.log.WarnContext(ctx, "article exists but a second fetch failed, treating the miss as real",
+		"segment_id", seg.Id, "error", retryErr)
+	return retryData, &missError{segmentID: seg.Id, verdict: MissUnfetchable, err: retryErr}
+}
+
+// recheckMiss asks the pool once whether a segment the fetch reported missing
+// is actually there. The verdict is meaningful only when present is false.
+//
+// Streaming only: the import path sweeps availability up front and fast-fails.
+func (b *UsenetReader) recheckMiss(ctx context.Context, cp pool.NntpClient, seg *segment) (present bool, verdict MissVerdict) {
+	if !b.priority || cp == nil || seg.Id == "" || holes.IsPlaceholderID(seg.Id) {
+		return false, MissUnverified
+	}
+	if b.missRechecks.Add(1) > maxMissRechecks {
+		return false, MissUnverified
+	}
+
+	statCtx, cancel := context.WithTimeout(ctx, MissRecheckTimeout)
+	defer cancel()
+
+	switch _, err := cp.StatPriority(statCtx, seg.Id); {
+	case err == nil:
+		return true, MissUnverified
+	case errors.Is(err, nntppool.ErrArticleNotFound):
+		return false, MissConfirmed
+	default:
+		return false, MissUnresolved
+	}
+}
+
+// fetchAttempts runs the retry loop for one wire fetch of a segment.
+func (b *UsenetReader) fetchAttempts(ctx context.Context, cp pool.NntpClient, seg *segment, art *articleBuf) ([]byte, error) {
 	segStart := time.Now()
 	var resultBytes []byte
 	err := retry.Do(

--- a/internal/usenet/usenet_reader_retry_test.go
+++ b/internal/usenet/usenet_reader_retry_test.go
@@ -19,17 +19,19 @@ import (
 // usenet_reader_retry_test.go pins the retry-policy invariants for the
 // segment download path.
 
-// TestRetry_ArticleNotFound_NoRetry pins the existing fast-fail policy:
-// nntppool.ErrArticleNotFound is a permanent failure and MUST NOT trigger
-// a retry. Retrying a missing article wastes provider connections for an
-// answer that will never change, and is a measurable contributor to
-// connection-storm conditions when whole batches of articles have expired.
+// TestRetry_ArticleNotFound_NoRetry pins the fast-fail policy for a body
+// fetch: nntppool.ErrArticleNotFound MUST NOT trigger a body retry. Re-pulling
+// a missing article wastes provider connections for an answer that will never
+// change, and is a measurable contributor to connection-storm conditions when
+// whole batches of articles have expired.
 //
-// The downloadSegmentWithRetry path uses retry.RetryIf to short-circuit
-// this error class; this test pins that exactly one BodyPriority call is
-// made even though retry.Attempts is 5.
+// The downloadSegmentWithRetry path uses retry.RetryIf to short-circuit this
+// error class; this test pins that exactly one BodyPriority call is made even
+// though retry.Attempts is 5.
 //
-// Should pass on current code.
+// The reader does spend one cheap existence check confirming the miss before
+// letting it stand (see transient_miss_test.go), which is why this asserts on
+// body calls rather than on every call to the message-ID.
 func TestRetry_ArticleNotFound_NoRetry(t *testing.T) {
 	t.Parallel()
 	const (
@@ -66,9 +68,9 @@ func TestRetry_ArticleNotFound_NoRetry(t *testing.T) {
 	// segments 1..N before segment 0's error short-circuited the reader).
 	time.Sleep(100 * time.Millisecond)
 
-	// segment 0 must have been requested exactly once: the retry policy
+	// segment 0 must have been fetched exactly once: the retry policy
 	// must NOT have re-issued the BodyPriority call.
-	if got := fp.PerMessageCalls(segments.MessageID(0)); got != 1 {
+	if got := fp.PerMessageBodyCalls(segments.MessageID(0)); got != 1 {
 		t.Errorf("segment 0 issued %d BodyPriority calls, want exactly 1 (no retry on ErrArticleNotFound)", got)
 	}
 }


### PR DESCRIPTION
**Stack 3 of 4** · base `stack/2-queue-history` (#929) · fixes #749

Diff against stack 2 is `internal/usenet/`, `internal/nzbfilesystem/`, plus the pool/fake surface the re-check needs.

## The bug

A mid-stream 430 is not proof the article is gone. Providers desync and serve the same segment normally moments later — which is why the reporter's file verified clean when the NZB was re-imported minutes after playback died. The reader never retried `ErrArticleNotFound`, and the failure handler treated one 430 as definitive: metadata moved to the corrupted safety folder, ARR asked to redownload a healthy release.

## Change

**The re-check happens in the reader, where it can recover.** On a confirmed miss the reader STATs the segment once on the priority lane; if the article is there, it retries the fetch. Playback continues and the health pipeline is never called. That is the half the report leads with — *"complained corrupted when playing half way"* — and no amount of after-the-fact bookkeeping fixes it.

**The outcome travels with the failure** as a `MissVerdict` on `DataCorruptionError`, so the handler reuses the reader's answer instead of paying a second round trip while it holds `mvf.mu`. An article that STATs present but stays unfetchable is recorded as `MissUnfetchable` and repaired, rather than re-checked forever into a file that never plays and never gets fixed.

**Only a proven-present article stops the repair.** An unresolved re-check falls through to the previous behaviour, so a briefly unhealthy pool cannot silently suppress repairs — the direction `validation.go` took for sweep results (#861) and the importer in #921.

Two things this had to fix in the first cut of the branch:

- `DataCorruptionError` carried no `SegmentID` for a missing article — only the CRC branch ever set one — so the re-check short-circuited on the empty id and never ran for the reported case at all.
- The handler's own STAT was on the normal lane, where it can spend its whole budget queued behind a large BODY instead of waiting for an answer. It is on the priority lane now, sharing one `usenet.MissRecheckTimeout`.

## Cost

The re-check is budgeted to **one per reader** and gated to the streaming profile: a dead release must not pay a ~1.2 s existence check per hole, and the import path sweeps availability up front already. A present article STATs in tens of milliseconds, so the case worth catching is cheap; the 2 s ceiling only bites on a provider that will not answer, and then it falls back. The handler's remaining backstop keeps the 30 s per-path repair debounce.

## Placement of the handler backstop

It runs after hole classification, gated on `!isDegraded`: a degraded verdict is zero-filled, still playable, and takes no destructive action, so it pays nothing. It is deliberately *not* gated on `healthEnabled` — that path still sets `FILE_STATUS_CORRUPTED`, which hides the file and blocks opens. It runs before `IncrementStreamingFailureCount`, whose UPDATE latches `is_masked` in the same statement; accumulating transient misses would hide a healthy file after 3 of them, and `is_masked` never resets itself. With health checking off nothing consumes the `pending` row, so the log says so instead of promising a follow-up.

## Two pre-existing issues found nearby (not touched here)

1. Nil-handling of `FailureMasking.Enabled` is inconsistent: the filter at `metadata_remote_file.go:598` treats nil as enabled, the increment gate as disabled.
2. `repairEnqueuer.Enqueue` fires before the masking decision, so a masked under-threshold file still queues PAR2 work.

Both look worth separate tickets.

## Tests

`internal/nzbfilesystem/issue749_transient_miss_test.go` is the regression test for the report, driven through the real `ReadAtContext` path rather than by calling the handler: one segment 430s once, and the read must return the true bytes with the file left healthy, unmasked, and its metadata in place. Verified red against the previous commit's behaviour (read fails), and against it with `SegmentID` blanked as it actually shipped. Its sibling pins that a permanent miss still fails the read and still counts toward masking.

`internal/usenet/transient_miss_test.go` — recovery, the verdict and segment id on a confirmed miss, the per-reader budget across 8 missing segments, and no re-check on the import profile.

`internal/nzbfilesystem/streaming_miss_reverify_test.go` — the reader's verdict is reused rather than re-asked, and the fallback check uses the priority lane.

`go test ./...` green; `go test -race` green on `usenet`, `nzbfilesystem`, `fuse`, `webdav`, `importer/...`, `health`, `pool`, `testsupport/...`. `make` stops in `golangci-lint` on a typecheck error that reproduces on a clean tree (its export-data reader predates the local Go 1.27 toolchain).
