### PR TITLE
docs(streaming): correct the documented max_prefetch default to 60

### DIFF
--- a/docs/docs/3. Configuration/streaming.md
+++ b/docs/docs/3. Configuration/streaming.md
@@ -19,12 +19,12 @@ _Streaming settings in the system configuration_
 
 | Parameter              | Description                                           | Default |
 | ---------------------- | ----------------------------------------------------- | ------- |
-| `max_prefetch`         | Number of segments to prefetch ahead during streaming | `30`    |
+| `max_prefetch`         | Number of segments to prefetch ahead during streaming | `60`    |
 | `read_timeout_seconds` | Maximum duration of a single read before it fails     | `120`   |
 
 ```yaml
 streaming:
-  max_prefetch: 30 # Number of segments prefetched ahead (default: 30)
+  max_prefetch: 60 # Number of segments prefetched ahead (default: 60; also capped at 96 MB)
   read_timeout_seconds: 120 # Fail a read that stalls this long (0 = default, -1 = disabled)
   failure_masking:
     enabled: true # Automatically hide files from mounts after repeated failures

--- a/docs/docs/5. Troubleshooting/common-issues.md
+++ b/docs/docs/5. Troubleshooting/common-issues.md
@@ -359,7 +359,7 @@ _[Screenshot placeholder: WebDAV client successfully connecting after authentica
 
    ```yaml
    streaming:
-     max_prefetch: 45 # Increase prefetch for better throughput
+     max_prefetch: 80 # Increase prefetch for better throughput
    ```
 
 2. **Provider Optimization**:

--- a/docs/docs/5. Troubleshooting/performance.md
+++ b/docs/docs/5. Troubleshooting/performance.md
@@ -27,7 +27,7 @@ The streaming system has a single tuning parameter: `max_prefetch`, which contro
 
 ```yaml
 streaming:
-  max_prefetch: 60 # More prefetch for high-bandwidth setups
+  max_prefetch: 90 # More prefetch for high-bandwidth setups
 
 import:
   max_processor_workers: 4 # Multiple NZB processors
@@ -38,7 +38,7 @@ import:
 
 ```yaml
 streaming:
-  max_prefetch: 30 # Default — good balance
+  max_prefetch: 60 # Default — good balance
 
 import:
   max_processor_workers: 2 # Standard processing
@@ -119,7 +119,7 @@ If media playback freezes or buffers frequently:
 
    ```yaml
    streaming:
-     max_prefetch: 45 # Increase from default 30
+     max_prefetch: 80 # Increase from default 60
    ```
 
 3. **Tune rclone VFS settings** (if using rclone mount): Playback freezing is often caused by rclone VFS settings rather than AltMount itself. See the [Streaming Configuration rclone section](../3.%20Configuration/streaming.md#rclone-vfs-recommended-settings) for recommended settings. Key parameters:


### PR DESCRIPTION
**Stack 4 of 4** · base `stack/3-streaming-recheck` (#930) · fixes #676

Docs only.

The code has defaulted `max_prefetch` to 60 since #424 (`perf(fuse): … prefetch increase`), and `config.sample.yaml` already said 60 — but the configuration table and the performance/troubleshooting guides still described the default as 30, and told users to "increase" it to 45, *below* the value they were actually running.

## Verified, not assumed

| Path | Result |
|---|---|
| `DefaultConfig()` | 60 |
| `LoadConfig()` on a fresh install | 60, and the generated `config.yaml` writes `max_prefetch: 60` |
| Existing config that omits the key | 60 |
| Explicit `max_prefetch: 0` | coerced to 60 |

There is a commit `5c688255 perf: reduce default max_prefetch from 60 to 30 segments`, but it lives only on the unmerged branch `feat/fuse-async-read-buffer` — it never reached `main`. So the docs were not describing a deliberate 30; they were simply never updated after #424.

## Changes

- `docs/docs/3. Configuration/streaming.md` — table and sample say 60, and note the 96 MB read-ahead cap (`readAheadBytesCap`), which is what actually bounds the effective window for large articles.
- `docs/docs/5. Troubleshooting/performance.md` — "Default — good balance" is 60; the high-bandwidth example moved 60 → 90 so it stays above the default; "increase from default 30" → 80.
- `docs/docs/5. Troubleshooting/common-issues.md` — "increase prefetch for better throughput" 45 → 80, which was below the default.

`cd docs && bun run build` passes.

## Note on the linked issue

#676 also reported playback errors at 60 that went away at 30. That is a separate symptom from the docs mismatch and I have not tried to fix it here — both commenters were on stale AltMount/aiostreams combinations, and 60 segments is already byte-capped at 96 MB. Worth its own issue rather than changing the default on that evidence.
