### PR TITLE
fix(import): skip the per-file STAT sweep for declared NZB gaps; keep degraded-only hole data

### DIFF
--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -420,60 +420,72 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	acceptableMissingPercent := cfg.GetAcceptableMissingSegmentsPercentage()
+
+	var results []validation.FastFailFileResult
 	if !missing {
+		// The provider has everything the NZB lists. Gaps the NZB itself
+		// declares are mapped from their placeholders without a STAT; the
+		// per-file sweep would only re-learn what the probe just answered.
+		results = validation.PlaceholderResults(fastFailFiles)
+		if !anyBroken(results) {
+			if proc.log != nil {
+				proc.log.DebugContext(ctx, "Fast-fail release probe passed",
+					"files", len(fastFailFiles),
+					"duration", time.Since(probeStart))
+			}
+			return nil, nil, nil, nil
+		}
 		if proc.log != nil {
-			proc.log.DebugContext(ctx, "Fast-fail release probe passed",
+			proc.log.DebugContext(ctx, "Fast-fail release probe passed; mapping declared gaps without a per-file sweep",
 				"files", len(fastFailFiles),
 				"duration", time.Since(probeStart))
 		}
-		return nil, nil, nil, nil
-	}
+	} else {
+		isStremioImport := (category != nil && *category == "stremio") || (downloadID != nil && strings.HasPrefix(*downloadID, "stremio:"))
+		if isStremioImport && cfg.Stremio.EffectiveFastFailHeaderOnly() {
+			if proc.log != nil {
+				proc.log.InfoContext(ctx, "Fast-fail release probe failed for Stremio import; aborting immediately without per-file sweep",
+					"files", len(fastFailFiles),
+					"probe_duration", time.Since(probeStart))
+			}
+			return nil, nil, nil, multifile.ErrNoFilesProcessed
+		}
 
-	isStremioImport := (category != nil && *category == "stremio") || (downloadID != nil && strings.HasPrefix(*downloadID, "stremio:"))
-	if isStremioImport && cfg.Stremio.EffectiveFastFailHeaderOnly() {
+		// Phase 2 (escalation): the probe found an unreachable segment, so map
+		// exactly which files are broken. This sweeps a per-file sample of every
+		// file but only runs for releases that are already known to have missing
+		// segments — those imports skip Body work below, so the extra Stats are
+		// recovered.
 		if proc.log != nil {
-			proc.log.InfoContext(ctx, "Fast-fail release probe failed for Stremio import; aborting immediately without per-file sweep",
+			proc.log.DebugContext(ctx, "Fast-fail release probe found a missing segment, escalating to per-file sweep",
 				"files", len(fastFailFiles),
 				"probe_duration", time.Since(probeStart))
 		}
-		return nil, nil, nil, multifile.ErrNoFilesProcessed
-	}
 
-	// Phase 2 (escalation): the probe found an unreachable segment, so map
-	// exactly which files are broken. This sweeps a per-file sample of every
-	// file but only runs for releases that are already known to have missing
-	// segments — those imports skip Body work below, so the extra Stats are
-	// recovered.
-	if proc.log != nil {
-		proc.log.DebugContext(ctx, "Fast-fail release probe found a missing segment, escalating to per-file sweep",
-			"files", len(fastFailFiles),
-			"probe_duration", time.Since(probeStart))
-	}
+		// Report progress within the 0–10% band so the queue item doesn't appear
+		// frozen during the network sweep. NOT gated on HasSubscribers(): the
+		// tracker also persists the latest percentage for clients that connect
+		// mid-import, and this sweep can outlast the moment it starts.
+		var fastFailTracker *progress.Tracker
+		if proc.broadcaster != nil {
+			fastFailTracker = proc.broadcaster.CreateTracker(queueID, 0, 10).WithStage("Mapping missing segments")
+		}
 
-	// Report progress within the 0–10% band so the queue item doesn't appear
-	// frozen during the network sweep. NOT gated on HasSubscribers(): the
-	// tracker also persists the latest percentage for clients that connect
-	// mid-import, and this sweep can outlast the moment it starts.
-	var fastFailTracker *progress.Tracker
-	if proc.broadcaster != nil {
-		fastFailTracker = proc.broadcaster.CreateTracker(queueID, 0, 10).WithStage("Mapping missing segments")
-	}
-
-	acceptableMissingPercent := cfg.GetAcceptableMissingSegmentsPercentage()
-
-	results, err := validation.FastFailCheckFiles(
-		ctx,
-		fastFailFiles,
-		proc.poolManager,
-		cfg.Import.SegmentSamplePercentage,
-		concurrency,
-		proc.validationTimeout,
-		fastFailTracker,
-		proc.patchIndex,
-		acceptableMissingPercent == 0,
-	)
-	if err != nil {
-		return nil, nil, nil, err
+		results, err = validation.FastFailCheckFiles(
+			ctx,
+			fastFailFiles,
+			proc.poolManager,
+			cfg.Import.SegmentSamplePercentage,
+			concurrency,
+			proc.validationTimeout,
+			fastFailTracker,
+			proc.patchIndex,
+			acceptableMissingPercent == 0,
+		)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 	}
 
 	brokenIdx := make(map[int]struct{})
@@ -671,8 +683,13 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 		return nil, nil, nil, multifile.ErrNoFilesProcessed
 	}
 
-	if len(brokenIdx) == 0 {
+	if len(brokenIdx) == 0 && len(missingIDs) == 0 && len(degradedFiles) == 0 {
 		return nil, nil, nil, nil
+	}
+	if len(brokenIdx) == 0 {
+		// Degraded only: nothing to exclude, but the caller still needs the
+		// misses and degraded files to persist known holes and queue repair.
+		return nil, missingIDs, degradedFiles, nil
 	}
 
 	if proc.log != nil {
@@ -737,6 +754,16 @@ type gappedSet struct {
 	members    []int // members with declared gaps
 	totalBytes int64 // whole set, gap-free volumes included
 	totalSegs  int
+}
+
+// anyBroken reports whether any fast-fail result marks its file broken.
+func anyBroken(results []validation.FastFailFileResult) bool {
+	for _, r := range results {
+		if r.Broken {
+			return true
+		}
+	}
+	return false
 }
 
 // fastFailDamageIsDegraded judges a file's confirmed damage against the hole

--- a/internal/importer/processor_test.go
+++ b/internal/importer/processor_test.go
@@ -830,3 +830,95 @@ func TestClassifyDeclaredGaps(t *testing.T) {
 		t.Fatalf("20 gaps in a 500-segment file (4%%) = %v, want failed (ratio cap)", got)
 	}
 }
+
+// buildGappedRarSetNzb builds a stored RAR set of volumeCount volumes with
+// segsPerVolume segments each, all reachable on the client, and replaces the
+// given 1-based segment numbers of gapVolume with declared-gap placeholders.
+func buildGappedRarSetNzb(volumeCount, segsPerVolume, gapVolume int, gapNumbers ...int) (*nzbparser.Nzb, []string) {
+	gaps := make(map[int]struct{}, len(gapNumbers))
+	for _, g := range gapNumbers {
+		gaps[g] = struct{}{}
+	}
+	var placeholders []string
+	files := make(nzbparser.NzbFiles, volumeCount)
+	for v := range files {
+		name := fmt.Sprintf("release.part%03d.rar", v+1)
+		segs := make(nzbparser.NzbSegments, segsPerVolume)
+		for j := range segs {
+			id := fmt.Sprintf("%s-seg-%d", name, j+1)
+			if _, gap := gaps[j+1]; gap && v+1 == gapVolume {
+				id = holes.PlaceholderID(j+1, name)
+				placeholders = append(placeholders, id)
+			}
+			segs[j] = nzbparser.NzbSegment{Bytes: 100, Number: j + 1, ID: id}
+		}
+		files[v] = nzbparser.NzbFile{Filename: name, Subject: name, Segments: segs}
+	}
+	return &nzbparser.Nzb{Files: files}, placeholders
+}
+
+// TestPreParseFastFailDeclaredGapsOnHealthyReleaseSkipsPerFileSweep pins that
+// gaps declared by the NZB itself do not buy a per-file STAT sweep: the
+// release-wide probe still runs against the provider, and when it passes the
+// gap mapping comes from the placeholders alone.
+func TestPreParseFastFailDeclaredGapsOnHealthyReleaseSkipsPerFileSweep(t *testing.T) {
+	client := fakepool.New() // every real segment reachable
+	proc := &Processor{
+		poolManager:       processorTestPoolManager{client: client},
+		validationTimeout: 100 * time.Millisecond,
+	}
+	const volumes = 100
+	n, placeholders := buildGappedRarSetNzb(volumes, 10, 50, 4, 5)
+	cfg := config.DefaultConfig() // 2% acceptable missing; 2 gaps of 1000 segments qualify
+
+	brokenIdx, missingIDs, degraded, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
+	if err != nil {
+		t.Fatalf("preParseFastFail returned error: %v", err)
+	}
+	if len(brokenIdx) != 0 {
+		t.Errorf("brokenIdx = %v, want empty (declared gaps within the hole caps import degraded)", brokenIdx)
+	}
+	for _, id := range placeholders {
+		if _, ok := missingIDs[id]; !ok {
+			t.Errorf("missingIDs lacks placeholder %s", id)
+		}
+	}
+	if _, ok := degraded["release.part050.rar"]; !ok {
+		t.Errorf("degradedFiles = %v, want the gapped volume", degraded)
+	}
+	// The per-file sweep round-robins at least one STAT per volume, so any
+	// count at or above the volume count means it ran.
+	if got := client.StatCalls(); got == 0 || got >= volumes {
+		t.Errorf("StatCalls = %d, want 0 < n < %d (release probe only, no per-file sweep)", got, volumes)
+	}
+}
+
+// TestPreParseFastFailDegradedVideoReturnsHolesForPersistence pins that a
+// release with degraded-but-importable damage and nothing broken still hands
+// its missing segments and degraded files back, so the caller can persist the
+// known holes and queue repair; an empty brokenIdx must not blank them.
+func TestPreParseFastFailDegradedVideoReturnsHolesForPersistence(t *testing.T) {
+	client := fakepool.New()
+	proc := &Processor{
+		poolManager:       processorTestPoolManager{client: client},
+		validationTimeout: 100 * time.Millisecond,
+	}
+	n := buildMultiSegmentNzb(client, "Movie.2024.mkv", 50, 25)
+	cfg := config.DefaultConfig()
+	cfg.Import.SegmentSamplePercentage = 100
+	cfg.Health.AcceptableMissingSegmentsPercentage = 5
+
+	brokenIdx, missingIDs, degraded, err := proc.preParseFastFail(context.Background(), n, cfg, 1, nil, nil)
+	if err != nil {
+		t.Fatalf("preParseFastFail returned error: %v", err)
+	}
+	if len(brokenIdx) != 0 {
+		t.Fatalf("brokenIdx = %v, want empty", brokenIdx)
+	}
+	if _, ok := missingIDs["Movie.2024.mkv-seg-25"]; !ok {
+		t.Errorf("missingIDs = %v, want the sampled miss", missingIDs)
+	}
+	if _, ok := degraded["Movie.2024.mkv"]; !ok {
+		t.Errorf("degradedFiles = %v, want the degraded video", degraded)
+	}
+}

--- a/internal/importer/validation/fast_fail.go
+++ b/internal/importer/validation/fast_fail.go
@@ -172,6 +172,28 @@ func releaseLooksDead(missing, reported int) bool {
 	return missing >= deadReleaseMinMisses && float64(missing) >= deadReleaseMissFraction*float64(reported)
 }
 
+// PlaceholderResults maps the damage an NZB declares itself: every file whose
+// segments include gap placeholders (articles the NZB never listed) is reported
+// Broken with those ids as known misses, without a single STAT. Index-aligned
+// with files; gap-free files get the zero result. The group is not condemned
+// here: an exactly-known gap is judged against the hole caps by the caller,
+// which can keep a lightly holed archive set importable.
+func PlaceholderResults(files []FastFailFile) []FastFailFileResult {
+	results := make([]FastFailFileResult, len(files))
+	for fileIdx, file := range files {
+		_, placeholders := splitPlaceholders(file.Segments)
+		if len(placeholders) == 0 {
+			continue
+		}
+		results[fileIdx].Broken = true
+		results[fileIdx].KnownGapCount = len(placeholders)
+		for _, ph := range placeholders {
+			results[fileIdx].MissingSegmentIDs = append(results[fileIdx].MissingSegmentIDs, ph.Id)
+		}
+	}
+	return results
+}
+
 // splitPlaceholders separates a file's real segments from gap placeholders.
 func splitPlaceholders(segments []*metapb.SegmentData) (real, placeholders []*metapb.SegmentData) {
 	for _, seg := range segments {
@@ -308,9 +330,10 @@ func FastFailReleaseProbe(
 				continue
 			}
 			if holes.IsPlaceholderID(segment.Id) {
-				// The NZB itself omits this article: damage known without a
-				// single STAT, so the per-file sweep can map it right away.
-				return true, nil
+				// A gap the NZB itself declares is not a provider miss: it is
+				// mapped without a STAT (PlaceholderResults), and the probe's
+				// job is still to answer for the articles the NZB does list.
+				continue
 			}
 			segments = append(segments, segment)
 		}
@@ -418,7 +441,7 @@ func FastFailCheckFiles(
 		maxConnections = 1
 	}
 
-	results := make([]FastFailFileResult, len(files))
+	results := PlaceholderResults(files)
 
 	// brokenGroups records group keys with at least one unreachable segment, so
 	// remaining Stats for those groups can be skipped in later chunks.
@@ -446,19 +469,7 @@ func FastFailCheckFiles(
 		if len(file.Segments) == 0 {
 			continue
 		}
-		real, placeholders := splitPlaceholders(file.Segments)
-		if len(placeholders) > 0 {
-			// Articles the NZB never listed are misses known before the
-			// sweep starts; they need no STAT and are reported as observed.
-			// The group is not condemned here: an exactly-known gap is
-			// judged against the hole caps by the caller, which can keep a
-			// lightly holed archive set importable.
-			results[fileIdx].Broken = true
-			results[fileIdx].KnownGapCount = len(placeholders)
-			for _, ph := range placeholders {
-				results[fileIdx].MissingSegmentIDs = append(results[fileIdx].MissingSegmentIDs, ph.Id)
-			}
-		}
+		real, _ := splitPlaceholders(file.Segments)
 		if len(real) == 0 {
 			continue
 		}

--- a/internal/importer/validation/fast_fail_test.go
+++ b/internal/importer/validation/fast_fail_test.go
@@ -963,24 +963,6 @@ func TestFastFailCheckFilesPlaceholdersAreKnownMissesWithoutStat(t *testing.T) {
 	}
 }
 
-func TestFastFailReleaseProbePlaceholderIsDamageWithoutStat(t *testing.T) {
-	client := fakepool.New()
-	segs := makeTestSegments("f", 3)
-	segs[2] = &metapb.SegmentData{Id: holes.PlaceholderID(3, "f-0")}
-	missing, err := FastFailReleaseProbe(
-		context.Background(),
-		[]FastFailFile{{Filename: "movie.mkv", Segments: segs}},
-		fastFailPoolManager{client: client},
-		100, 1, 100*time.Millisecond, nil,
-	)
-	if err != nil || !missing {
-		t.Fatalf("probe = (%v, %v), want (true, nil)", missing, err)
-	}
-	if client.StatCalls() != 0 {
-		t.Fatalf("StatCalls = %d, want 0", client.StatCalls())
-	}
-}
-
 func TestCapReleaseProbeSampleKeepsEdgesAndBounds(t *testing.T) {
 	segs := makeTestSegments("big", 400)
 	selected := usenet.SelectSegmentsForValidation(segs, 100)
@@ -1172,5 +1154,66 @@ func TestFastFailCheckFilesStopFileOnFirstMissCondemnsGroup(t *testing.T) {
 	}
 	if got := client.StatCalls(); got != 1 {
 		t.Errorf("StatCalls = %d, want 1 (the whole set is condemned by the first miss)", got)
+	}
+}
+
+// TestFastFailReleaseProbeIgnoresPlaceholders pins that a gap the NZB itself
+// declares is not a reason to skip the probe: the placeholder is never STATed
+// and the probe still answers for the provider's copy of the real segments.
+func TestFastFailReleaseProbeIgnoresPlaceholders(t *testing.T) {
+	client := fakepool.New()
+	placeholder := holes.PlaceholderID(2, "salt")
+	files := []FastFailFile{{
+		Filename: "release.part01.rar",
+		GroupKey: "release",
+		Segments: []*metapb.SegmentData{
+			{Id: "rar-1"},
+			{Id: placeholder},
+			{Id: "rar-3"},
+		},
+	}}
+
+	missing, err := FastFailReleaseProbe(context.Background(), files, fastFailPoolManager{client: client}, 100, 1, 100*time.Millisecond, nil)
+	if err != nil {
+		t.Fatalf("FastFailReleaseProbe error = %v", err)
+	}
+	if missing {
+		t.Fatal("missing = true, want false: every real segment is reachable and a declared gap is not a provider miss")
+	}
+	if got := client.PerMessageCalls(placeholder); got != 0 {
+		t.Errorf("placeholder STATed %d times, want 0", got)
+	}
+	if got := client.StatCalls(); got == 0 {
+		t.Error("StatCalls = 0, want the real segments probed")
+	}
+}
+
+// TestPlaceholderResultsMapsDeclaredGapsWithoutStats pins the STAT-free result
+// shape for a release whose only damage is declared in the NZB.
+func TestPlaceholderResultsMapsDeclaredGapsWithoutStats(t *testing.T) {
+	p1, p2 := holes.PlaceholderID(2, "s"), holes.PlaceholderID(3, "s")
+	files := []FastFailFile{
+		{Filename: "release.part01.rar", GroupKey: "release", Segments: []*metapb.SegmentData{{Id: "a-1"}, {Id: "a-2"}}},
+		{Filename: "release.part02.rar", GroupKey: "release", Segments: []*metapb.SegmentData{{Id: "b-1"}, {Id: p1}, {Id: p2}}},
+		{Filename: "release.par2"},
+	}
+
+	results := PlaceholderResults(files)
+
+	if len(results) != len(files) {
+		t.Fatalf("len(results) = %d, want %d (index-aligned)", len(results), len(files))
+	}
+	if results[0].Broken || results[0].KnownGapCount != 0 || len(results[0].MissingSegmentIDs) != 0 || results[0].SampledCount != 0 {
+		t.Errorf("gap-free file result = %+v, want zero value", results[0])
+	}
+	got := results[1]
+	if !got.Broken || got.KnownGapCount != 2 || got.SampledCount != 0 {
+		t.Errorf("gapped file result = %+v, want Broken with KnownGapCount 2 and no sample", got)
+	}
+	if len(got.MissingSegmentIDs) != 2 || got.MissingSegmentIDs[0] != p1 || got.MissingSegmentIDs[1] != p2 {
+		t.Errorf("MissingSegmentIDs = %v, want [%s %s]", got.MissingSegmentIDs, p1, p2)
+	}
+	if results[2].Broken {
+		t.Errorf("segment-less sidecar result = %+v, want zero value", results[2])
 	}
 }


### PR DESCRIPTION
## Summary
- `FastFailReleaseProbe` returned "damaged" the instant it saw a gap placeholder (an article the NZB itself omits), before a single STAT. Every such release then escalated to the per-file sweep — ~250 STATs and ~1.5 s on a 125-file RAR set — even when the provider had every article the NZB lists. The sweep added no information there: the placeholder mapping is computed locally, and the release-wide probe already answers for the provider's copy.
- The probe now skips placeholders and probes the real segments. When it passes, results come from a new `validation.PlaceholderResults` (also used by `FastFailCheckFiles`, so there is one source of truth) and the sweep runs only on a confirmed provider miss. Degraded-set verdict, hole caps and PAR2 deferral are unchanged.
- **Also fixes a latent bug:** `preParseFastFail` returned `nil` for `missingIDs` and `degradedFiles` whenever nothing was *broken*, so degraded-only imports never reached `persistKnownHoles` / `queueImportRepairs` — their holes were rediscovered at play time and no PAR2 repair was queued.

## What this does and doesn't change
- Import wall time on gappy multi-volume sets is **unchanged** (measured on the local nzb-streaming-benchmarks corpus, `rar4-rNN`): once the sweep is gone, the first-segment warm-up of all volumes is the critical path (~2 s for 113 volumes, bounded by the import connection budget). That is a separate change.
- The win is ~190 fewer STATs competing with active streams per gappy import, and the persistence fix above.
- Releases that are both gappy *and* provider-damaged pay probe + sweep instead of sweep only (≤300 ms; the probe cancels on the first definitive miss).

## Test plan
- [x] `TestFastFailReleaseProbeIgnoresPlaceholders` — placeholder never STATed, probe answers for real segments
- [x] `TestPlaceholderResultsMapsDeclaredGapsWithoutStats`
- [x] `TestPreParseFastFailDeclaredGapsOnHealthyReleaseSkipsPerFileSweep` — STAT count stays below the volume count
- [x] `TestPreParseFastFailDegradedVideoReturnsHolesForPersistence` — the latent-bug regression test
- [x] Removed `TestFastFailReleaseProbePlaceholderIsDamageWithoutStat`, which pinned the replaced behaviour
- [x] `go test -race ./internal/importer/...` green; `go build ./...` ok; `go vet` clean on touched packages
- [x] Harness rerun (`rar4-rNN`, `damaged-partial`, `7z-split-tardes`) all served; debug import log confirms the probe-only path
- [ ] `golangci-lint` not run locally: installed binary cannot read Go 1.27 export data (toolchain mismatch); relying on CI