### PR TITLE
feat(streaming): hedge slow demand-position article fetches on a second connection

### DIFF
--- a/internal/usenet/flight.go
+++ b/internal/usenet/flight.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"hash/fnv"
 	"sync"
+	"sync/atomic"
 )
 
 // articleBuf is one article's decoded bytes as they arrive. buf holds what
@@ -20,6 +21,7 @@ type articleBuf struct {
 	done    bool
 	err     error
 	attempt int
+	hedged  int // an earlier attempt still allowed to publish while a hedge runs alongside it
 	leading bool
 	lead    int // bumped on every claimLead; identifies the current leader
 	refs    int
@@ -43,9 +45,10 @@ func (a *articleBuf) wakeLocked() {
 
 // articleWriter is one fetch attempt's sink.
 type articleWriter struct {
-	a       *articleBuf
-	attempt int
-	buf     []byte
+	a        *articleBuf
+	attempt  int
+	buf      []byte
+	received atomic.Int64 // bytes written so far, readable off the writing goroutine
 }
 
 // attemptWriter starts a new fetch attempt. Only the newest attempt can
@@ -54,11 +57,29 @@ func (a *articleBuf) attemptWriter() *articleWriter {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.attempt++
+	a.hedged = 0
 	return &articleWriter{a: a, attempt: a.attempt, buf: make([]byte, 0, max(a.size, 0))}
+}
+
+// hedgeWriter starts a second attempt racing primary for the same article.
+// Both stay live: they decode the same bytes, so whichever is further ahead
+// publishes and whichever completes first finishes the article.
+func (a *articleBuf) hedgeWriter(primary *articleWriter) *articleWriter {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.attempt++
+	a.hedged = primary.attempt
+	return &articleWriter{a: a, attempt: a.attempt, buf: make([]byte, 0, max(a.size, 0))}
+}
+
+// liveLocked reports whether w may still publish. Caller holds mu.
+func (a *articleBuf) liveLocked(w *articleWriter) bool {
+	return w.attempt == a.attempt || (a.hedged != 0 && w.attempt == a.hedged)
 }
 
 func (w *articleWriter) Write(p []byte) (int, error) {
 	w.buf = append(w.buf, p...)
+	w.received.Store(int64(len(w.buf)))
 	w.a.publish(w)
 	return len(p), nil
 }
@@ -68,7 +89,7 @@ func (w *articleWriter) bytes() []byte { return w.buf }
 
 func (a *articleBuf) publish(w *articleWriter) {
 	a.mu.Lock()
-	if a.done || w.attempt != a.attempt || int64(len(w.buf)) <= a.ready {
+	if a.done || !a.liveLocked(w) || int64(len(w.buf)) <= a.ready {
 		a.mu.Unlock()
 		return
 	}
@@ -81,7 +102,7 @@ func (a *articleBuf) publish(w *articleWriter) {
 // finish marks the article complete with the bytes w received.
 func (a *articleBuf) finish(w *articleWriter) {
 	a.mu.Lock()
-	if a.done || w.attempt != a.attempt {
+	if a.done || !a.liveLocked(w) {
 		a.mu.Unlock()
 		return
 	}

--- a/internal/usenet/hedge.go
+++ b/internal/usenet/hedge.go
@@ -1,0 +1,190 @@
+package usenet
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/javi11/nntppool/v4"
+	"github.com/kipsilabs/altmount/internal/pool"
+)
+
+// Hedged demand fetches. Delivery to the caller is in order, so one article
+// with an abnormally slow fetch at the read position stalls the stream while
+// the read-ahead window sits complete behind it; measured on a real provider
+// the tail (p90 300-870 ms, occasional 2-4 s against a 120-240 ms median)
+// repeatedly cut consumer throughput by three quarters. Widening the window
+// does not help. Instead, once a demand-position fetch has run well past the
+// recent median, the same article is requested a second time and the first
+// result wins; the other request is cancelled so its connection drains.
+const (
+	// hedgeFloor is the least a fetch must have run before it is hedged,
+	// whatever the median says: below it a second request is pure cost.
+	hedgeFloor = 400 * time.Millisecond
+	// hedgeFactor times the rolling median is the threshold once enough
+	// fetches have been observed to know what normal looks like.
+	hedgeFactor = 2
+	// hedgeWindow is how many recent successful fetch durations the median
+	// is taken over; hedgeMinSamples is how many are needed before the median
+	// replaces the floor.
+	hedgeWindow     = 16
+	hedgeMinSamples = 4
+	// maxHedgesInFlight caps concurrent hedges per reader: one per demand
+	// window slot, so a struggling provider is never asked for more than the
+	// reader is actually waiting on. The pool exposes no free-request
+	// capacity, so this constant is the only guard on the extra load.
+	maxHedgesInFlight = demandDepth
+	// hedgePollInterval is how often a slow speculative fetch re-checks
+	// whether the reader has caught up to it and it now qualifies.
+	hedgePollInterval = 100 * time.Millisecond
+)
+
+// hedgePolicy decides when a running fetch is slow enough to hedge and bounds
+// how many hedges a reader has out at once. The zero value is ready to use.
+type hedgePolicy struct {
+	mu       sync.Mutex
+	samples  [hedgeWindow]time.Duration
+	count    int
+	next     int
+	inFlight atomic.Int32
+}
+
+// record adds a successful fetch's duration to the rolling window.
+func (h *hedgePolicy) record(d time.Duration) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.samples[h.next] = d
+	h.next = (h.next + 1) % hedgeWindow
+	if h.count < hedgeWindow {
+		h.count++
+	}
+}
+
+// threshold is how long a fetch may run before it is hedged.
+func (h *hedgePolicy) threshold() time.Duration {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.count < hedgeMinSamples {
+		return hedgeFloor
+	}
+	sorted := slices.Clone(h.samples[:h.count])
+	slices.Sort(sorted)
+	return max(hedgeFloor, hedgeFactor*sorted[len(sorted)/2])
+}
+
+// tryAcquire takes a hedge slot without blocking. release is idempotent.
+func (h *hedgePolicy) tryAcquire() (release func(), ok bool) {
+	if h.inFlight.Add(1) > maxHedgesInFlight {
+		h.inFlight.Add(-1)
+		return nil, false
+	}
+	var once sync.Once
+	return func() { once.Do(func() { h.inFlight.Add(-1) }) }, true
+}
+
+// isDemand reports whether the range-local segment is at the read position or
+// within demandDepth of it, so the caller is (about to be) waiting on it.
+func (b *UsenetReader) isDemand(segIdx int) bool {
+	b.mu.Lock()
+	rg := b.rg
+	b.mu.Unlock()
+	if rg == nil {
+		return false
+	}
+	ahead := segIdx - rg.GetCurrentIndex()
+	return ahead >= 0 && ahead < demandDepth
+}
+
+type streamResult struct {
+	w    *articleWriter
+	body *nntppool.ArticleBody
+	err  error
+	dur  time.Duration
+}
+
+// streamArticle runs one priority-lane fetch of seg into art, hedging it with
+// a second request once it has run past the policy threshold at a demand
+// position without receiving a byte. The returned writer is the one whose bytes stand: the
+// winner's on success, the last failure's otherwise. ErrArticleNotFound from
+// either request ends the fetch at once — a 430 is never retried, and the
+// caller's miss re-check owns what happens next.
+func (b *UsenetReader) streamArticle(ctx context.Context, cp pool.NntpClient, seg *segment, segIdx int, art *articleBuf) (*articleWriter, *nntppool.ArticleBody, error) {
+	// Cancelling the parent on return is what stops the loser: nntppool
+	// switches its body to discard and drains or drops the connection.
+	ctx, cancelAll := context.WithCancel(ctx)
+	defer cancelAll()
+
+	results := make(chan streamResult, 2)
+	run := func(w *articleWriter) {
+		go func() {
+			start := time.Now()
+			body, err := cp.BodyStreamPriority(ctx, seg.Id, w)
+			results <- streamResult{w: w, body: body, err: err, dur: time.Since(start)}
+		}()
+	}
+
+	start := time.Now()
+	primary := art.attemptWriter()
+	run(primary)
+	pending := 1
+
+	hedged := false
+	wait := time.NewTimer(b.hedger.threshold())
+	defer wait.Stop()
+
+	var lastFailed streamResult
+	for pending > 0 {
+		select {
+		case r := <-results:
+			pending--
+			switch {
+			case r.err == nil:
+				b.hedger.record(r.dur)
+				if hedged {
+					winner := "hedge"
+					if r.w == primary {
+						winner = "original"
+					}
+					b.log.DebugContext(ctx, "hedged article fetch resolved",
+						"segment_id", seg.Id,
+						"winner", winner,
+						"winner_dur", r.dur,
+						"elapsed", time.Since(start))
+				}
+				return r.w, r.body, nil
+			case errors.Is(r.err, nntppool.ErrArticleNotFound):
+				return r.w, r.body, r.err
+			default:
+				lastFailed = r
+			}
+		case <-wait.C:
+			// Once bytes are flowing the fetch is slow, not stuck, and will
+			// finish in about its remaining time; the stragglers measured were
+			// requests queued behind another body with nothing received yet.
+			// Hedging a streaming 4 MiB article would only double its bytes.
+			if hedged || primary.received.Load() > 0 {
+				continue
+			}
+			if !b.isDemand(segIdx) {
+				wait.Reset(hedgePollInterval)
+				continue
+			}
+			release, ok := b.hedger.tryAcquire()
+			if !ok {
+				wait.Reset(hedgePollInterval)
+				continue
+			}
+			defer release()
+			hedged = true
+			b.log.DebugContext(ctx, "hedging slow demand article fetch",
+				"segment_id", seg.Id,
+				"elapsed", time.Since(start))
+			run(art.hedgeWriter(primary))
+			pending++
+		}
+	}
+	return lastFailed.w, lastFailed.body, lastFailed.err
+}

--- a/internal/usenet/hedge_test.go
+++ b/internal/usenet/hedge_test.go
@@ -1,0 +1,359 @@
+package usenet
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/javi11/nntppool/v4"
+	"github.com/kipsilabs/altmount/internal/pool"
+	"github.com/kipsilabs/altmount/internal/testsupport/fakepool"
+	"github.com/kipsilabs/altmount/internal/testsupport/segments"
+)
+
+// hedge_test.go pins the hedged demand fetch: a demand-position article whose
+// fetch runs abnormally long is requested a second time and the first result
+// wins. Measured on a real provider, one 2-3 s article at the read position
+// stalls playback while the whole read-ahead window sits complete behind it.
+
+// hedgeProbe wraps the fake so each call to a message-ID can be held for a
+// different extra delay before it reaches the fake. fakepool's Latency is
+// per-ID, so on its own it cannot make the second request for an article
+// faster than the first. Calls whose context ends inside the delay are
+// counted as cancelled and never reach the fake.
+type hedgeProbe struct {
+	*fakepool.Client
+	mu        sync.Mutex
+	delays    map[string][]time.Duration
+	calls     map[string]int
+	cancelled atomic.Int32
+}
+
+func newHedgeProbe(fp *fakepool.Client) *hedgeProbe {
+	return &hedgeProbe{Client: fp, delays: map[string][]time.Duration{}, calls: map[string]int{}}
+}
+
+// delayCalls holds the n-th call to id for delays[n]; calls past the list run
+// undelayed.
+func (p *hedgeProbe) delayCalls(id string, delays ...time.Duration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.delays[id] = delays
+}
+
+func (p *hedgeProbe) callsFor(id string) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls[id]
+}
+
+func (p *hedgeProbe) BodyStreamPriority(ctx context.Context, id string, w io.Writer, onMeta ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
+	p.mu.Lock()
+	n := p.calls[id]
+	p.calls[id]++
+	var d time.Duration
+	if ds := p.delays[id]; n < len(ds) {
+		d = ds[n]
+	}
+	p.mu.Unlock()
+	if d > 0 {
+		t := time.NewTimer(d)
+		defer t.Stop()
+		select {
+		case <-ctx.Done():
+			p.cancelled.Add(1)
+			return nil, ctx.Err()
+		case <-t.C:
+		}
+	}
+	return p.Client.BodyStreamPriority(ctx, id, w, onMeta...)
+}
+
+type countingMetrics struct{ downloaded atomic.Int64 }
+
+func (m *countingMetrics) IncArticlesDownloaded()                   { m.downloaded.Add(1) }
+func (m *countingMetrics) IncArticlesPosted()                       {}
+func (m *countingMetrics) UpdateDownloadProgress(_ string, _ int64) {}
+
+func newHedgeReader(t *testing.T, ctx context.Context, cp pool.NntpClient, rg *segmentRange, maxPrefetch int, metrics MetricsTracker) *UsenetReader {
+	t.Helper()
+	getter := func() (pool.NntpClient, error) { return cp, nil }
+	ur, err := NewUsenetReader(ctx, getter, rg, maxPrefetch, metrics, "hedge-test", nil, withFlightMap(newFlightMap()))
+	if err != nil {
+		t.Fatalf("NewUsenetReader: %v", err)
+	}
+	t.Cleanup(func() { _ = ur.Close() })
+	return ur
+}
+
+func fastSegments(fp *fakepool.Client, n, segSize int) []byte {
+	var want []byte
+	for i := range n {
+		fp.SetBehavior(segments.MessageID(i), fakepool.SegmentBehavior{Bytes: segments.Payload(i, segSize)})
+		want = append(want, segments.Payload(i, segSize)...)
+	}
+	return want
+}
+
+func waitFor(t *testing.T, d time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return cond()
+}
+
+// A slow demand article is hedged once the floor elapses and the read
+// completes in about the hedge's time, not the straggler's. The straggler's
+// context is cancelled so its connection can drain.
+func TestHedge_SlowDemandArticleIsHedgedAndLoserCancelled(t *testing.T) {
+	t.Parallel()
+	const nSegs, segSize = 4, 64
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	fp := fakepool.New()
+	want := fastSegments(fp, nSegs, segSize)
+	probe := newHedgeProbe(fp)
+	probe.delayCalls(segments.MessageID(1), 3*time.Second)
+
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+	ur := newHedgeReader(t, ctx, probe, rg, nSegs, noopMetrics{})
+
+	start := time.Now()
+	got, err := io.ReadAll(ur)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("payload mismatch: got %d bytes, want %d", len(got), len(want))
+	}
+	if elapsed < hedgeFloor || elapsed > 1500*time.Millisecond {
+		t.Errorf("read took %v, want about the hedge floor (%v) rather than the 3s straggler", elapsed, hedgeFloor)
+	}
+	if n := probe.callsFor(segments.MessageID(1)); n != 2 {
+		t.Errorf("slow article issued %d body calls, want 2 (original + one hedge)", n)
+	}
+	if !waitFor(t, time.Second, func() bool { return probe.cancelled.Load() == 1 }) {
+		t.Errorf("straggler context cancelled %d times, want 1", probe.cancelled.Load())
+	}
+}
+
+// Speculative articles are never hedged, however slow: only the read position
+// and the segment after it qualify.
+func TestHedge_SpeculativeArticlesAreNeverHedged(t *testing.T) {
+	t.Parallel()
+	const nSegs, segSize = 12, 64
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	fp := fakepool.New()
+	fastSegments(fp, nSegs, segSize)
+	probe := newHedgeProbe(fp)
+	slow := segments.MessageID(demandDepth + 3)
+	probe.delayCalls(slow, 3*time.Second)
+
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+	ur := newHedgeReader(t, ctx, probe, rg, nSegs, noopMetrics{})
+	ur.Start() // schedule the window without consuming: the read position stays at 0
+
+	time.Sleep(hedgeFloor + 4*hedgePollInterval)
+	if n := probe.callsFor(slow); n != 1 {
+		t.Errorf("speculative article issued %d body calls, want 1 (no hedge)", n)
+	}
+}
+
+// A demand article whose bytes are already arriving is slow, not stuck: it is
+// left to finish rather than fetched twice, however long it takes.
+func TestHedge_StreamingArticleIsNotHedged(t *testing.T) {
+	t.Parallel()
+	const nSegs, segSize = 3, 64
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	fp := fakepool.New()
+	want := fastSegments(fp, nSegs, segSize)
+	tail := make(chan struct{})
+	fp.SetBehavior(segments.MessageID(1), fakepool.SegmentBehavior{
+		Bytes: segments.Payload(1, segSize), ChunkSize: segSize / 2, TailGate: tail,
+	})
+	probe := newHedgeProbe(fp)
+
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+	ur := newHedgeReader(t, ctx, probe, rg, nSegs, noopMetrics{})
+
+	go func() {
+		time.Sleep(hedgeFloor + 4*hedgePollInterval)
+		close(tail)
+	}()
+	got, err := io.ReadAll(ur)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("payload mismatch: got %d bytes, want %d", len(got), len(want))
+	}
+	if n := probe.callsFor(segments.MessageID(1)); n != 1 {
+		t.Errorf("streaming article issued %d body calls, want 1 (no hedge once bytes flow)", n)
+	}
+}
+
+// An article is hedged at most once: a hedge that is itself slow is waited
+// for, never hedged again.
+func TestHedge_AtMostOneHedgePerArticle(t *testing.T) {
+	t.Parallel()
+	const nSegs, segSize = 3, 64
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	fp := fakepool.New()
+	fastSegments(fp, nSegs, segSize)
+	probe := newHedgeProbe(fp)
+	probe.delayCalls(segments.MessageID(1), 4*time.Second, 800*time.Millisecond)
+
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+	ur := newHedgeReader(t, ctx, probe, rg, nSegs, noopMetrics{})
+
+	start := time.Now()
+	if _, err := io.ReadAll(ur); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < hedgeFloor+800*time.Millisecond || elapsed > 3*time.Second {
+		t.Errorf("read took %v, want the hedge's own time (~%v)", elapsed, hedgeFloor+800*time.Millisecond)
+	}
+	time.Sleep(3 * hedgePollInterval)
+	if n := probe.callsFor(segments.MessageID(1)); n != 2 {
+		t.Errorf("article issued %d body calls, want exactly 2", n)
+	}
+}
+
+// A 430 from the hedge is authoritative: the straggler is cancelled and the
+// existing miss path (one re-check, then a named DataCorruptionError) runs
+// unchanged.
+func TestHedge_NotFoundFromEitherSideKeepsMissSemantics(t *testing.T) {
+	t.Parallel()
+	const nSegs, segSize = 3, 64
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	fp := fakepool.New()
+	fastSegments(fp, nSegs, segSize)
+	fp.SetBehavior(segments.MessageID(1), fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+	probe := newHedgeProbe(fp)
+	probe.delayCalls(segments.MessageID(1), 3*time.Second)
+
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+	ur := newHedgeReader(t, ctx, probe, rg, nSegs, noopMetrics{})
+
+	start := time.Now()
+	_, err := io.ReadAll(ur)
+	elapsed := time.Since(start)
+	var dce *DataCorruptionError
+	if !errors.As(err, &dce) {
+		t.Fatalf("want DataCorruptionError, got %v", err)
+	}
+	if dce.SegmentID != segments.MessageID(1) || dce.MissVerdict != MissConfirmed {
+		t.Errorf("miss reported as segment %q verdict %v, want %q / MissConfirmed", dce.SegmentID, dce.MissVerdict, segments.MessageID(1))
+	}
+	if elapsed > 1500*time.Millisecond {
+		t.Errorf("miss surfaced after %v, want about the hedge floor", elapsed)
+	}
+	if n := probe.callsFor(segments.MessageID(1)); n != 2 {
+		t.Errorf("missing article issued %d body calls, want 2 (no retry of a 430)", n)
+	}
+	if n := fp.StatPriorityCalls(); n != 1 {
+		t.Errorf("re-check issued %d priority STATs, want 1", n)
+	}
+	if !waitFor(t, time.Second, func() bool { return probe.cancelled.Load() == 1 }) {
+		t.Errorf("straggler cancelled %d times, want 1", probe.cancelled.Load())
+	}
+}
+
+// The articles-downloaded metric counts a hedged article once.
+func TestHedge_MetricsCountArticleOnce(t *testing.T) {
+	t.Parallel()
+	const nSegs, segSize = 4, 64
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	fp := fakepool.New()
+	fastSegments(fp, nSegs, segSize)
+	probe := newHedgeProbe(fp)
+	probe.delayCalls(segments.MessageID(1), 3*time.Second)
+
+	metrics := &countingMetrics{}
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+	ur := newHedgeReader(t, ctx, probe, rg, nSegs, metrics)
+
+	if _, err := io.ReadAll(ur); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !waitFor(t, time.Second, func() bool { return metrics.downloaded.Load() >= nSegs }) {
+		t.Fatalf("articles downloaded = %d, want %d", metrics.downloaded.Load(), nSegs)
+	}
+	time.Sleep(200 * time.Millisecond)
+	if n := metrics.downloaded.Load(); n != nSegs {
+		t.Errorf("articles downloaded = %d, want exactly %d (hedged article counted once)", n, nSegs)
+	}
+}
+
+// The threshold is the floor until enough fetches have been seen, then a
+// multiple of the rolling median, which one outlier does not move.
+func TestHedgePolicy_Threshold(t *testing.T) {
+	t.Parallel()
+	var h hedgePolicy
+	if got := h.threshold(); got != hedgeFloor {
+		t.Fatalf("empty threshold = %v, want floor %v", got, hedgeFloor)
+	}
+	for range hedgeMinSamples {
+		h.record(100 * time.Millisecond)
+	}
+	if got := h.threshold(); got != hedgeFloor {
+		t.Fatalf("fast-provider threshold = %v, want floor %v", got, hedgeFloor)
+	}
+	for range hedgeWindow {
+		h.record(500 * time.Millisecond)
+	}
+	if got := h.threshold(); got != hedgeFactor*500*time.Millisecond {
+		t.Fatalf("slow-provider threshold = %v, want %v", got, hedgeFactor*500*time.Millisecond)
+	}
+	h.record(10 * time.Second)
+	if got := h.threshold(); got != hedgeFactor*500*time.Millisecond {
+		t.Fatalf("one straggler moved the threshold to %v", got)
+	}
+}
+
+// Hedges in flight per reader are capped; a released slot can be reused.
+func TestHedgePolicy_InFlightCap(t *testing.T) {
+	t.Parallel()
+	var h hedgePolicy
+	var releases []func()
+	for range maxHedgesInFlight {
+		release, ok := h.tryAcquire()
+		if !ok {
+			t.Fatal("slot refused below the cap")
+		}
+		releases = append(releases, release)
+	}
+	if _, ok := h.tryAcquire(); ok {
+		t.Fatal("slot granted above the cap")
+	}
+	releases[0]()
+	releases[0]() // idempotent
+	if _, ok := h.tryAcquire(); !ok {
+		t.Fatal("released slot not reusable")
+	}
+	if _, ok := h.tryAcquire(); ok {
+		t.Fatal("double release freed two slots")
+	}
+}

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -290,6 +290,9 @@ type UsenetReader struct {
 	// budget holds under concurrent prefetch without a lock.
 	missRechecks atomic.Int32
 
+	// hedger decides when a slow demand-position fetch gets a second request.
+	hedger hedgePolicy
+
 	mu sync.Mutex
 }
 
@@ -611,8 +614,9 @@ func (b *UsenetReader) fetchContext(ctx context.Context, art *articleBuf, keepOn
 
 // downloadSegmentWithRetry attempts to download a segment with retry logic for
 // pool unavailability. keepOnClose lets a started streaming fetch finish after
-// ctx is cancelled; see fetchContext.
-func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segment, keepOnClose bool) ([]byte, error) {
+// ctx is cancelled; see fetchContext. segIdx is the segment's range-local
+// index, which decides whether a slow fetch is at a demand position.
+func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segment, segIdx int, keepOnClose bool) ([]byte, error) {
 	// Cache HIT: skip NNTP entirely
 	if b.segmentStore != nil {
 		if data, ok := b.segmentStore.Get(seg.Id); ok {
@@ -660,7 +664,7 @@ func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segmen
 	}
 
 	if !b.priority {
-		data, err := b.fetchWithRetry(ctx, cp, seg, nil)
+		data, err := b.fetchWithRetry(ctx, cp, seg, segIdx, nil)
 		if b.segmentStore != nil && data != nil && err == nil {
 			_ = b.segmentStore.Put(seg.Id, data)
 		}
@@ -696,7 +700,7 @@ func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segmen
 					b.flights.release(seg.Id, kept)
 				}
 			}
-			data, err := b.fetchWithRetry(fetchCtx, cp, seg, art)
+			data, err := b.fetchWithRetry(fetchCtx, cp, seg, segIdx, art)
 			cancelFetch()
 			switch {
 			case err == nil:
@@ -746,8 +750,8 @@ const maxMissRechecks = 1
 // A miss is re-checked once before it is allowed to stand: providers answer
 // 430 transiently, and giving up on that answer is what condemned a healthy
 // file in issue #749.
-func (b *UsenetReader) fetchWithRetry(ctx context.Context, cp pool.NntpClient, seg *segment, art *articleBuf) ([]byte, error) {
-	data, err := b.fetchAttempts(ctx, cp, seg, art)
+func (b *UsenetReader) fetchWithRetry(ctx context.Context, cp pool.NntpClient, seg *segment, segIdx int, art *articleBuf) ([]byte, error) {
+	data, err := b.fetchAttempts(ctx, cp, seg, segIdx, art)
 	if !errors.Is(err, nntppool.ErrArticleNotFound) {
 		return data, err
 	}
@@ -759,7 +763,7 @@ func (b *UsenetReader) fetchWithRetry(ctx context.Context, cp pool.NntpClient, s
 
 	b.log.InfoContext(ctx, "article present on re-check, retrying transient miss",
 		"segment_id", seg.Id)
-	retryData, retryErr := b.fetchAttempts(ctx, cp, seg, art)
+	retryData, retryErr := b.fetchAttempts(ctx, cp, seg, segIdx, art)
 	if retryErr == nil {
 		return retryData, nil
 	}
@@ -797,7 +801,7 @@ func (b *UsenetReader) recheckMiss(ctx context.Context, cp pool.NntpClient, seg 
 }
 
 // fetchAttempts runs the retry loop for one wire fetch of a segment.
-func (b *UsenetReader) fetchAttempts(ctx context.Context, cp pool.NntpClient, seg *segment, art *articleBuf) ([]byte, error) {
+func (b *UsenetReader) fetchAttempts(ctx context.Context, cp pool.NntpClient, seg *segment, segIdx int, art *articleBuf) ([]byte, error) {
 	segStart := time.Now()
 	var resultBytes []byte
 	err := retry.Do(
@@ -814,9 +818,9 @@ func (b *UsenetReader) fetchAttempts(ctx context.Context, cp pool.NntpClient, se
 				// Streaming: priority lane, decoded bytes published to readers as
 				// each wire read lands. A failed attempt leaves its bytes visible;
 				// the next attempt starts a fresh buffer and only publishes once
-				// it has passed what readers already saw.
-				w = art.attemptWriter()
-				result, err = cp.BodyStreamPriority(attemptCtx, seg.Id, w)
+				// it has passed what readers already saw. A slow demand-position
+				// fetch is hedged with a second request; see streamArticle.
+				w, result, err = b.streamArticle(attemptCtx, cp, seg, segIdx, art)
 			} else {
 				// Import: normal lane, buffered — always yields to streaming reads.
 				result, err = cp.Body(attemptCtx, seg.Id)
@@ -1063,7 +1067,7 @@ func (b *UsenetReader) downloadManager(ctx context.Context) {
 				return
 			}
 
-			data, err := b.downloadSegmentWithRetry(taskCtx, s, keepOnClose)
+			data, err := b.downloadSegmentWithRetry(taskCtx, s, segIdx, keepOnClose)
 
 			if err != nil {
 				if errors.Is(err, nntppool.ErrArticleNotFound) {


### PR DESCRIPTION
## Summary
- Cherry-pick of the hedge-fetch feature merged as #938, targeting `main` directly (previously merged into `docs/update-nzb-streaming-bench-results`, so it currently rides along in #933; this gives it its own PR against `main`).
- Once a demand-position article fetch runs past max(400ms, 2x rolling median) without a byte, races a second BodyStreamPriority fetch on another connection and takes whichever completes first, cancelling the loser.

## Test plan
- [x] Cherry-picked cleanly from merged commit fc3b42a0
- [x] Existing hedge_test.go covers hedging behavior
- [ ] CI green